### PR TITLE
Switch all FROM references to oraclelinux:latest

### DIFF
--- a/OpenJDK/java-6/Dockerfile
+++ b/OpenJDK/java-6/Dockerfile
@@ -4,7 +4,7 @@
 # 
 # Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
 # 
-FROM oracle/oraclelinux:latest
+FROM oraclelinux:latest
 
 MAINTAINER Bruno Borges <bruno.borges@oracle.com>
 

--- a/OpenJDK/java-7/Dockerfile
+++ b/OpenJDK/java-7/Dockerfile
@@ -4,7 +4,7 @@
 # 
 # Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
 # 
-FROM oracle/oraclelinux:latest
+FROM oraclelinux:latest
 
 MAINTAINER Bruno Borges <bruno.borges@oracle.com>
 

--- a/OpenJDK/java-8/Dockerfile
+++ b/OpenJDK/java-8/Dockerfile
@@ -4,7 +4,7 @@
 # 
 # Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
 # 
-FROM oracle/oraclelinux:latest
+FROM oraclelinux:latest
 
 MAINTAINER Bruno Borges <bruno.borges@oracle.com>
 

--- a/OracleJDK/java-7/Dockerfile
+++ b/OracleJDK/java-7/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
 #
-FROM oracle/oraclelinux:latest
+FROM oraclelinux:latest
 
 MAINTAINER Bruno Borges <bruno.borges@oracle.com>
 

--- a/OracleJDK/java-8/Dockerfile
+++ b/OracleJDK/java-8/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
 #
-FROM oracle/oraclelinux:latest
+FROM oraclelinux:latest
 
 MAINTAINER Bruno Borges <bruno.borges@oracle.com>
 


### PR DESCRIPTION
Use the official Oracle Linux (/_/oraclelinux) images which are updated more quickly.

Signed-off-by: Avi Miller <avi.miller@oracle.com>