### PR TITLE
Fixed to set ADMIN_PASSWORD to an environmental valuable

### DIFF
--- a/OracleWebLogic/samples/1221-domain/Dockerfile
+++ b/OracleWebLogic/samples/1221-domain/Dockerfile
@@ -29,6 +29,7 @@ ARG ADMIN_PASSWORD
 ENV DOMAIN_NAME="base_domain" \
     ADMIN_PORT="8001" \
     ADMIN_HOST="wlsadmin" \
+    ADMIN_PASSWORD="$ADMIN_PASSWORD" \
     NM_PORT="5556" \
     MS_PORT="7001" \
     CLUSTER_NAME="DockerCluster" \


### PR DESCRIPTION
Fixed the Dockerfile to set ADMIN_PASSWORD to an environmental valuable, or else it fails to run "createServer.sh" and so on.
Because Managed Servers can't acquire ADMIN_PASSWORD and WLST call fails.