### PR TITLE
Generic path for JDK

### DIFF
--- a/OracleWebLogic/dockerfiles/12.2.1/Dockerfile.infrastructure
+++ b/OracleWebLogic/dockerfiles/12.2.1/Dockerfile.infrastructure
@@ -64,7 +64,11 @@ ADD $JAVA_PKG /usr/java/
 RUN chmod a+xr /u01 && \
     useradd -b /u01 -m -s /bin/bash oracle && \
     echo oracle:oracle | chpasswd && \
-    ln -s $(ls -1 /usr/java) $JAVA_HOME && \
+    JDK_ORIGINAL_NAME=$(ls -1 /usr/java) && \
+    mv /usr/java/$JDK_ORIGINAL_NAME /usr/java/jdk && \
+    chown -R root.root /usr/java/jdk && \
+    ln -s jdk /usr/java/$JDK_ORIGINAL_NAME && \
+    ln -s jdk /usr/java/default && \
     cd /u01 && $JAVA_HOME/bin/jar xf /u01/$FMW_PKG && cd - && \
     su -c "$JAVA_HOME/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME INSTALL_TYPE=\"Fusion Middleware Infrastructure\"" - oracle && \
     chown oracle:oracle -R /u01 && \


### PR DESCRIPTION
Weblogic uses full path of JDK, not symbolic link, so to update the JDK is better to use a generic name, not one with the version.
Otherwise is necessary to update Weblogic script files to use the new JDK path (one with the new version)