### PR TITLE
fix package name in OracleJDK image

### DIFF
--- a/OracleJDK/java-7/Dockerfile
+++ b/OracleJDK/java-7/Dockerfile
@@ -6,7 +6,7 @@ FROM oraclelinux:latest
 
 MAINTAINER Bruno Borges <bruno.borges@oracle.com>
 
-ENV JAVA_PKG=server-jre-7u*-linux-x64.tar.gz \
+ENV JAVA_PKG=server-jre-7u*-linux-x64.tar.gz.download \
     JAVA_HOME=/usr/java/default \
     PATH=$PATH:/usr/java/default/bin
 

--- a/OracleJDK/java-8/Dockerfile
+++ b/OracleJDK/java-8/Dockerfile
@@ -6,7 +6,7 @@ FROM oraclelinux:latest
 
 MAINTAINER Bruno Borges <bruno.borges@oracle.com>
 
-ENV JAVA_PKG=server-jre-8u*-linux-x64.tar.gz \
+ENV JAVA_PKG=server-jre-8u*-linux-x64.tar.gz.download \
     JAVA_HOME=/usr/java/default \
     PATH=$PATH:/usr/java/default/bin
 


### PR DESCRIPTION
Instruction ADD fail during build because the search pattern for jre package is invalid. The jre package name ends with '.download'