### PR TITLE
Issue oracle/docker-images#137. Test if pwmake is present

### DIFF
--- a/OracleDatabase/dockerfiles/buildDockerImage.sh
+++ b/OracleDatabase/dockerfiles/buildDockerImage.sh
@@ -106,6 +106,10 @@ fi
 # Is password omitted?
 if [ "$GENERATED_PWD" -eq 1 ]; then
    ORACLE_PWD="`pwmake 64`";
+   if [ -z "$ORACLE_PWD" ]; then
+     echo "Your OS does not have 'pwmake'. Use -p <password> parameter explicitly"
+     exit 1
+   fi
 fi
 
 # Oracle Database Image Name


### PR DESCRIPTION
Issue #137 was caused by missing passwords. Not all operating systems, where `buildDockerImage.sh` is executed, have `pwmake` utility. Test its result before continuing 