### PR TITLE
Java alternatives

### DIFF
--- a/OracleJDK/java-7/Dockerfile
+++ b/OracleJDK/java-7/Dockerfile
@@ -6,10 +6,14 @@ FROM oraclelinux:latest
 
 MAINTAINER Bruno Borges <bruno.borges@oracle.com>
 
-ENV JAVA_PKG=server-jre-7u*-linux-x64.tar.gz 
+ENV JAVA_PKG=server-jre-7u*-linux-x64.tar.gz \
+    JAVA_HOME=/usr/java/latest
 
 ADD $JAVA_PKG /usr/java/
 
-RUN alternatives --install /usr/bin/java java $(ls -1 -d /usr/java/*)/bin/java 20000 && \
-    alternatives --install /usr/bin/javac javac $(ls -1 -d /usr/java/*)/bin/javac 20000 && \
-    alternatives --install /usr/bin/jar jar $(ls -1 -d /usr/java/*)/bin/jar 20000
+RUN export JAVA_DIR=$(ls -1 -d /usr/java/*) && \
+    ln -s $JAVA_DIR /usr/java/latest && \
+    ln -s $JAVA_DIR /usr/java/default && \
+    alternatives --install /usr/bin/java java $JAVA_DIR/bin/java 20000 && \
+    alternatives --install /usr/bin/javac javac $JAVA_DIR/bin/javac 20000 && \
+    alternatives --install /usr/bin/jar jar $JAVA_DIR/bin/jar 20000

--- a/OracleJDK/java-7/Dockerfile
+++ b/OracleJDK/java-7/Dockerfile
@@ -6,10 +6,10 @@ FROM oraclelinux:latest
 
 MAINTAINER Bruno Borges <bruno.borges@oracle.com>
 
-ENV JAVA_PKG=server-jre-7u*-linux-x64.tar.gz \
-    JAVA_HOME=/usr/java/default \
-    PATH=$PATH:/usr/java/default/bin
+ENV JAVA_PKG=server-jre-7u*-linux-x64.tar.gz 
 
 ADD $JAVA_PKG /usr/java/
 
-RUN mv $(ls -1 -d /usr/java/*) $JAVA_HOME 
+RUN alternatives --install /usr/bin/java java $(ls -1 -d /usr/java/*)/bin/java 20000 && \
+    alternatives --install /usr/bin/javac javac $(ls -1 -d /usr/java/*)/bin/javac 20000 && \
+    alternatives --install /usr/bin/jar jar $(ls -1 -d /usr/java/*)/bin/jar 20000

--- a/OracleJDK/java-8/Dockerfile
+++ b/OracleJDK/java-8/Dockerfile
@@ -6,10 +6,14 @@ FROM oraclelinux:latest
 
 MAINTAINER Bruno Borges <bruno.borges@oracle.com>
 
-ENV JAVA_PKG=server-jre-8u*-linux-x64.tar.gz 
+ENV JAVA_PKG=server-jre-8u*-linux-x64.tar.gz \
+    JAVA_HOME=/usr/java/latest
 
 ADD $JAVA_PKG /usr/java/
 
-RUN alternatives --install /usr/bin/java java $(ls -1 -d /usr/java/*)/bin/java 20000 && \
-    alternatives --install /usr/bin/javac javac $(ls -1 -d /usr/java/*)/bin/javac 20000 && \
-    alternatives --install /usr/bin/jar jar $(ls -1 -d /usr/java/*)/bin/jar 20000
+RUN export JAVA_DIR=$(ls -1 -d /usr/java/*) && \
+    ln -s $JAVA_DIR /usr/java/latest && \
+    ln -s $JAVA_DIR /usr/java/default && \
+    alternatives --install /usr/bin/java java $JAVA_DIR/bin/java 20000 && \
+    alternatives --install /usr/bin/javac javac $JAVA_DIR/bin/javac 20000 && \
+    alternatives --install /usr/bin/jar jar $JAVA_DIR/bin/jar 20000 

--- a/OracleJDK/java-8/Dockerfile
+++ b/OracleJDK/java-8/Dockerfile
@@ -6,10 +6,10 @@ FROM oraclelinux:latest
 
 MAINTAINER Bruno Borges <bruno.borges@oracle.com>
 
-ENV JAVA_PKG=server-jre-8u*-linux-x64.tar.gz \
-    JAVA_HOME=/usr/java/default \
-    PATH=$PATH:/usr/java/default/bin
+ENV JAVA_PKG=server-jre-8u*-linux-x64.tar.gz 
 
 ADD $JAVA_PKG /usr/java/
 
-RUN mv $(ls -1 -d /usr/java/*) $JAVA_HOME 
+RUN alternatives --install /usr/bin/java java $(ls -1 -d /usr/java/*)/bin/java 20000 && \
+    alternatives --install /usr/bin/javac javac $(ls -1 -d /usr/java/*)/bin/javac 20000 && \
+    alternatives --install /usr/bin/jar jar $(ls -1 -d /usr/java/*)/bin/jar 20000

--- a/OracleWebLogic/dockerfiles/12.2.1/Dockerfile.developer
+++ b/OracleWebLogic/dockerfiles/12.2.1/Dockerfile.developer
@@ -48,7 +48,7 @@ ENV FMW_PKG=fmw_12.2.1.0.0_wls_quick_Disk1_1of1.zip \
     USER_MEM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
     DEBUG_FLAG=true\
     PRODUCTION_MODE=dev\
-    PATH=$PATH:/usr/java/default/bin:/u01/oracle/oracle_common/common/bin
+    PATH=$PATH:/u01/oracle/oracle_common/common/bin
 
 # Copy packages
 # -------------
@@ -61,8 +61,9 @@ COPY $FMW_PKG install.file oraInst.loc /u01/
 RUN chmod a+xr /u01 && \
     useradd -b /u01 -m -s /bin/bash oracle && \
     echo oracle:oracle | chpasswd && \
-    cd /u01 && $JAVA_HOME/bin/jar xf /u01/$FMW_PKG && cd - && \
-    su -c "$JAVA_HOME/bin/java -jar /u01/$FMW_JAR -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME" - oracle && \
+    cd /u01 && jar xf /u01/$FMW_PKG && cd - && \
+    export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::") && \
+    su -c "java -jar /u01/$FMW_JAR -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME" - oracle && \
     chown oracle:oracle -R /u01 && \
     rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file
 

--- a/OracleWebLogic/dockerfiles/12.2.1/Dockerfile.developer
+++ b/OracleWebLogic/dockerfiles/12.2.1/Dockerfile.developer
@@ -62,7 +62,6 @@ RUN chmod a+xr /u01 && \
     useradd -b /u01 -m -s /bin/bash oracle && \
     echo oracle:oracle | chpasswd && \
     cd /u01 && jar xf /u01/$FMW_PKG && cd - && \
-    export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::") && \
     su -c "java -jar /u01/$FMW_JAR -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME" - oracle && \
     chown oracle:oracle -R /u01 && \
     rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file


### PR DESCRIPTION
This updates the base java-7 and java-8 builds to match what would occur if the Oracle JDK RPM is installed. This also leverages the `alternatives` tool to create system-wide in-path java/javac/jar binaries.