### PR TITLE
Fix dockerfiles for weblogic

### DIFF
--- a/OracleWebLogic/dockerfiles/12.2.1/Dockerfile.developer
+++ b/OracleWebLogic/dockerfiles/12.2.1/Dockerfile.developer
@@ -34,7 +34,7 @@
 #
 # Pull base image
 # ---------------
-FROM oracle/jdk:8
+FROM oracle/openjdk:8
 
 # Maintainer
 # ----------

--- a/OracleWebLogic/dockerfiles/12.2.1/Dockerfile.generic
+++ b/OracleWebLogic/dockerfiles/12.2.1/Dockerfile.generic
@@ -36,7 +36,7 @@
 #
 # Pull base image
 # ---------------
-FROM oracle/jdk:8
+FROM oracle/openjdk:8
 
 # Maintainer
 # ----------

--- a/OracleWebLogic/dockerfiles/12.2.1/Dockerfile.infrastructure
+++ b/OracleWebLogic/dockerfiles/12.2.1/Dockerfile.infrastructure
@@ -36,7 +36,7 @@
 #
 # Pull base image
 # ---------------
-FROM oracle/jdk:8
+FROM oracle/openjdk:8
 
 # Maintainer
 # ----------


### PR DESCRIPTION
There are no images `oracle/jdk` on the docker hub, only `oracle/openjdk`.