### PR TITLE
Make runOracle.sh executable

### DIFF
--- a/OracleDatabase/dockerfiles/12.1.0.2/Dockerfile.ee
+++ b/OracleDatabase/dockerfiles/12.1.0.2/Dockerfile.ee
@@ -55,6 +55,7 @@ COPY $RUN_FILE $CONFIG_RSP $PWD_FILE $ORACLE_BASE/
 # ------------------------------------------------------------
 RUN mkdir -p $ORACLE_BASE/oradata && \
     chmod ug+x $ORACLE_BASE/$PWD_FILE && \
+    chmod ug+x $ORACLE_BASE/$RUN_FILE && \
     groupadd -g 500 dba && \
     groupadd -g 501 oinstall && \
     useradd -d /home/oracle -g dba -G oinstall,dba -m -s /bin/bash oracle && \

--- a/OracleDatabase/dockerfiles/12.1.0.2/Dockerfile.se2
+++ b/OracleDatabase/dockerfiles/12.1.0.2/Dockerfile.se2
@@ -57,6 +57,7 @@ RUN mkdir -p $ORACLE_BASE/oradata && \
     mv $INSTALL_DIR/$CONFIG_RSP $ORACLE_BASE/ && \
     mv $INSTALL_DIR/$PWD_FILE $ORACLE_BASE/ && \
     chmod ug+x $ORACLE_BASE/$PWD_FILE && \
+    chmod ug+x $ORACLE_BASE/$RUN_FILE && \    
     groupadd -g 500 dba && \
     groupadd -g 501 oinstall && \
     useradd -d /home/oracle -g dba -G oinstall,dba -m -s /bin/bash oracle && \


### PR DESCRIPTION
I get the following error when trying to run the container as is:

database_1 | /bin/sh: /opt/oracle/runOracle.sh: Permission denied

Making the script executable fixes the problem.