### PR TITLE
Use the rpm to install java into the container

### DIFF
--- a/OracleJava/Dockerfile
+++ b/OracleJava/Dockerfile
@@ -1,0 +1,19 @@
+# LICENSE CDDL 1.0 + GPL 2.0
+#
+# Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+#
+FROM oraclelinux:latest
+
+MAINTAINER Bruno Borges <bruno.borges@oracle.com>
+
+ARG JAVATYPE
+ARG JAVAVERSION
+ARG JAVASUBVERSION
+ARG JAVAPATCHVERSION
+
+ENV JAVA_HOME /usr/java/${JAVATYPE}1.${JAVAVERSION}.0_${JAVASUBVERSION}
+
+RUN curl -v -j -k -L --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/${JAVAVERSION}${JAVASUBVERSION}-${JAVAPATCHVERSION}/${JAVATYPE}-${JAVAVERSION}${JAVASUBVERSION}-linux-x64.rpm -o ${JAVATYPE}-linux-x64.rpm && rpm -i ${JAVATYPE}-linux-x64.rpm && rm ${JAVATYPE}-linux-x64.rpm
+
+
+

--- a/OracleJava/build.sh
+++ b/OracleJava/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -x
+
+export JAVATYPE=${1}
+export JAVAVERSION=${2}
+export JAVASUBVERSION=${3}
+export JAVAPATCHVERSION=${4}
+
+docker build \
+       --build-arg https_proxy \
+       --build-arg http_proxy \
+       --build-arg JAVATYPE=${JAVATYPE} \
+       --build-arg JAVAVERSION=${JAVAVERSION} \
+       --build-arg JAVASUBVERSION=${JAVASUBVERSION} \
+       --build-arg JAVAPATCHVERSION=${JAVAPATCHVERSION} \
+       -t oracle/${JAVATYPE}:${JAVAVERSION}${JAVASUBVERSION}-${JAVAPATCHVERSION} .
+
+docker tag oracle/${JAVATYPE}:${JAVAVERSION}${JAVASUBVERSION}-${JAVAPATCHVERSION} oracle/${JAVATYPE}:${JAVAVERSION}

--- a/OracleJava/buildall.sh
+++ b/OracleJava/buildall.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#http://download.oracle.com/otn-pub/java/jdk/8u101-b13/jre-8u101-linux-x64.tar.gz
+http://download.oracle.com/otn-pub/java/jdk/8u101-b13/jdk-8u101-linux-x64.rpm
+
+./build.sh jre 8 u101 b13
+./build.sh jdk 8 u101 b13
+
+


### PR DESCRIPTION
This is an automated way to install java into a docker container. 
This also names the containers with a higher granularity oracle/jdk:8u101-b13 so you can specify a specific version in your FROM section. 