### PR TITLE
Enhancement : OHS Docker Solution with Docker Data Volume

### DIFF
--- a/OracleHTTPServer/samples/1221-ohs-domain/README.md
+++ b/OracleHTTPServer/samples/1221-ohs-domain/README.md
@@ -1,28 +1,46 @@
 Example of Oracle HTTP Server with Weblogic Proxy Plugin
 ===============
-This Dockerfile extends the Oracle HTTP Install image by creating a sample OHSdomain and configures Oracle WebLogic Server Proxy Plug-In  in order to load balance a WebLogic cluster, from inside a container in the same network as the Weblogic Cluster.
+This Dockerfile extends the Oracle HTTP Install image by creating a sample OHSdomain .
+During OHS container creation Oracle WebLogic Server Proxy Plug-In can be configured in order to load balance applications deployed onto either the Weblogic Admin Server, the Managed Servers or the  WebLogic cluster running on docker containers within the same network.
 
 ## How to build image and run container
 First make sure you have the Oracle HTTP install image (oracle/ohs:12.2.1-sa) ready by running following command as root user
 $ docker images
 
-1.To build the domain image using this sample Dockerfile, run command:
+1.To build the OHS domain image using this sample Dockerfile, run command:
 
-    $ docker build --force-rm=true --no-cache=true --rm=true -t sampleohs:12.2.1 --build-arg NM_PASSWORD=welcome1 .
+      $ docker build --force-rm=true --no-cache=true --rm=true -t sampleohs:12.2.1 --build-arg NM_PASSWORD=welcome1 .
 
-2.To start the Container with above image , run command :
+2. Run the below command to create a docker data volume.
 
-    $ docker run -d --env-file ./env.list -p 7777:7777  sampleohs:12.2.1 configureWLSProxyPlugin.sh
+       Eg:$ docker volume create --name volume
 
- ######Note : env.list file should have valid values of WEBLOGIC_HOST, WEBLOGIC_PORT and WEBLOGIC_CLUSTER from existing containers running WebLogic servers.
+_This data volume will be created in "/var/lib/docker" directory or the location where "/var/lib/docker" points to._
+
+3. Depending on your Weblogic environment , create a **custom_mod_wl_ohs.conf** file by referring to container-scripts/mod_wl_ohs.conf.sample and section 2.4 @ [OHS 12c Documentation](http://docs.oracle.com/middleware/1221/webtier/develop-plugin/oracle.htm#PLGWL553)
+
+4. Place the custom_mod_wl_ohs.conf file in docker data volume directory . e.g /var/lib/docker/volume
+
+4. To start the OHS Container with above sampleohs:12.2.1 image , run command  from data volume directory:
+
+       $ cd /var/lib/docker/volume
+       $ docker run -v `pwd`:/volume -w /volume -d --name ohs -p 7777:7777  sampleohs:12.2.1 configureWLSProxyPlugin.sh
+
+5. All applications will now be accessible via the OHS port 7777.
+
+######NOTE: If custom_mod_wl_ohs.conf is not provided, then configureWLSProxyPlugin.sh will just start OHS which will be accessible @ http://localhost:7777/index.html. Later you can login to running container and configure Weblogic Server proxy plugin file and run restartOHS script.
+
 
 ## Configuring the Oracle WebLogic Server Proxy Plug-In with Oracle HTTP Server
-Oracle WebLogic Server Proxy Plug-In (mod_wl_ohs)is used for proxying requests from Oracle HTTP Server to Oracle WebLogic Server.
-The Oracle WebLogic Server Proxy Plug-In is included in the Oracle HTTP Server 12c (12.2.1) installation.
-Refer https://docs.oracle.com/middleware/1221/webtier/develop-plugin/oracle.htm#PLGWL553
 
-To configure OHS server with WLS Proxy Plugin, a sample file mod_wl_ohs.conf.sample has been provided under **samples/1221-ohs-domain/container-scripts** folder.
-The values for WEBLOGIC_HOST, WEBLOGIC_PORT and WEBLOGIC_CLUSTER will be used from values provided by user during docker run via the env.list
+Oracle WebLogic Server Proxy Plug-In (mod_wl_ohs)is used for proxying requests from Oracle HTTP Server to Oracle WebLogic Server.
+The Oracle WebLogic Server Proxy Plug-In is included in the Oracle HTTP Server 12c (12.2.1) installation by default.
+
+A sample WebLogic Server Proxy Plug-In file has been provided @ **samples/1221-ohs-domain/container-scripts/mod_wl_ohs.conf.sample**
+Refer [OHS 12c Documentation](http://docs.oracle.com/middleware/1221/webtier/develop-plugin/oracle.htm#PLGWL553) for more details and examples
+
+Depending on the nature of your applications create your own "custom_mod_wl_ohs.conf" file.
+
 
 ### Example with WLS Docker Container
 
@@ -32,32 +50,58 @@ The values for WEBLOGIC_HOST, WEBLOGIC_PORT and WEBLOGIC_CLUSTER will be used fr
    - http://myhost:7001/console
 
 2. Two WLS Containers with Managed Servers running on 9001 and 9002 ports (inside same weblogic cluster).
-   Assume some sample application is deployed on the each managed server and are accessible via URLs
-   - http://myhost:9001/sample1
-   - http://myhost:9002/sample2
+   Assume some "sample" application is deployed on the weblogic cluster and are accessible via URLs
+   - http://myhost:9001/sample
+   - http://myhost:9002/sample
 
 ##### To configure Oracle WebLogic Server Proxy Plug-In inside OHS container
 
-1.Edit the env.list file and provide values
+1. Create the custom_mod_wl_ohs.conf file by referring to container-scripts/mod_wl_ohs.conf.sample
 
-        WEBLOGIC_HOST=myhost
-        WEBLOGIC_PORT=7001
-        WEBLOGIC_CLUSTER=myhost:9001,myhost:9002
+       For e.g
+       LoadModule weblogic_module   "/u01/oracle/ohssa/ohs/modules/mod_wl_ohs.so"
+       <IfModule mod_weblogic.c>
+       WebLogicHost myhost
+       WebLogicPort 7001
+       </IfModule>
+       #
+       # Directive for weblogic admin console deployed on Admin Server
+       <Location /console>
+       WLSRequest On
+       WebLogicHost myhost
+       WeblogicPort 7001
+       </Location>
+       #
+       # Directive for all application deployed on weblogic cluster with prepath /weblogic
+       <Location /weblogic>
+       WLSRequest On
+       WebLogicCluster myhost:9001,myhost:9002
+       PathTrim /weblogic
+       </Location>
 
-2. As part of docker run command provide the env.file
 
-        $ docker run -d --env-file ./env.list -p 7777:7777  sampleohs:12.2.1 configureWLSProxyPlugin.sh
+2. Place it in docker data volume directory say /var/lib/docker/volume
 
-   The **configureWLSProxyPlugin.sh** script will
+3. From docker data volume directory run following docker run command
+
+        For e.g
+        $ cd /var/lib/docker/volume
+        $ docker run -v `pwd`:/volume -w /volume -d --name ohs -p 7777:7777  sampleohs:12.2.1 configureWLSProxyPlugin.sh
+
+   The **configureWLSProxyPlugin.sh** script will be the first script to be run inside the OHS container .
+   This script will perform the following actions:
    - Start the Node Manager and OHS server
-   - Edit the mod_wl_ohs.conf.sample with right directives (based on values passed via env.list)
-   - Copy the mod_wl_ohs.conf file under INSTANCE home
+   - Fetch the custom_mod_wl_ohs.conf file from mounted shared data volume
+   - Place the custom_mod_wl_ohs.conf file under OHS INSTANCE home
    - Restart OHS server
 
-3. Now you will be able to access all the URLS via the OHS Listen Port 7777
-    - http://myhost:7777/console
-    - http://myhost:7777/sample1
-    - http://myhost:7777/sample2
+4. Now you will be able to access all the URLS via the OHS Listen Port 7777
+    - http://localhost:7777/console
+    - http://localhost:7777/weblogic/sample
+
+ _NOTE: If custom_mod_wl_ohs.conf is not provided or not found under mounted shared data volume, then configureWLSProxyPlugin.sh will still start OHS server which will be accessible @ http://localhost:7777/index.html._
+ _Later you can login to running container and configure Weblogic Server proxy plugin file and run restartOHS script._
+
 
 # Copyright
 Copyright (c) 2016-2017 Oracle and/or its affiliates. All rights reserved.

--- a/OracleHTTPServer/samples/1221-ohs-domain/container-scripts/configureWLSProxyPlugin-WLSMultihost.sh
+++ b/OracleHTTPServer/samples/1221-ohs-domain/container-scripts/configureWLSProxyPlugin-WLSMultihost.sh
@@ -6,18 +6,11 @@
 #*************************************************************************
 #This script will configure Oracle WebLogic Server Proxy Plug-In (mod_wl_ohs),
 #in order to enable the Oracle HTTP Server instances to route applications
-#deployed on the Admin Server, Single Managed Server or the Oracle WebLogic Server clusters
+#deployed on the Oracle WebLogic Server Multi Host
 #Refer to Section 2.4 @ http://docs.oracle.com/middleware/1221/webtier/develop-plugin/oracle.htm#PLGWL553
 #
-#Prerequisite:
-#1.Create docker volume e.g docker volume create --name volume
-#2.Create "custom_mod_wl_ohs.conf"  as per your environment by referring to mod_wl_ohs.conf sample file and OHS document above
-#3.Place the "custom_mod_wl_ohs.conf" inside the docker volume
-#4.During OHS container creation mount the docker volume which contains the "custom_mod_wl_ohs.conf"
-#
-# Note :
-# If custom_mod_wl_ohs.conf is not provided, WebLogic Server Proxy Plug-In will not be configured. But OHS server will be still running.
-# User may login to OHS container and manually configure the WebLogic Server Proxy Plug-In later
+#Prerequisite: Setup environment for Weblogic MultiHost by referring to samples in
+# https://github.com/oracle/docker-images/tree/master/OracleWebLogic/samples/1221-multihost
 #
 #MW_HOME    - The root directory of your OHS standalone install
 #DOMAIN_NAME - Env Value set by Dockerfile , default is "ohsDOmain"
@@ -27,6 +20,9 @@
 echo "MW_HOME=${MW_HOME:?"Please set MW_HOME"}"
 echo "DOMAIN_NAME=${DOMAIN_NAME:?"Please set DOMAIN_NAME"}"
 echo "OHS_COMPONENT_NAME=${OHS_COMPONENT_NAME:?"Please set OHS_COMPONENT_NAME"}"
+echo "WEBLOGIC_HOST=${WEBLOGIC_HOST:?"Please provide Weblogic Admin Server hostname"}"
+echo "WEBLOGIC_PORT=${WEBLOGIC_PORT:?"Please provide Weblogic Admin Server Port"}"
+echo "WEBLOGIC_CLUSTER=${WEBLOGIC_CLUSTER:?"Please provide the Weblogic Cluster details"}"
 
 DOMAIN_HOME=${MW_HOME}/user_projects/domains/${DOMAIN_NAME}
 INSTANCE_CONFIG_HOME=$DOMAIN_HOME/config/fmwconfig/components/OHS/${OHS_COMPONENT_NAME}
@@ -38,23 +34,20 @@ echo "Starting Node Manager and OHS server"
 /u01/oracle/container-scripts/startNMandOHS.sh
 
 
-#Search for the customized mod_wl_ohs.conf file
-modwlsconfigfile=`find / -name 'custom_mod_wl_ohs.conf' 2>&1 | grep -v 'Permission denied'`
-export modwlsconfigfile
+#Modify the variables in the mod_wl_ohs.conf.sample file with values provided in the env.file
+cp /u01/oracle/container-scripts/mod_wl_ohs.conf.sample /u01/oracle/container-scripts/mod_wl_ohs.conf.sample.WLSMultiHost
+sed -i -e "s/WEBLOGIC_HOST/$WEBLOGIC_HOST/g" -e "s/WEBLOGIC_PORT/$WEBLOGIC_PORT/g" -e "s/WEBLOGIC_CLUSTER/$WEBLOGIC_CLUSTER/g" mod_wl_ohs.conf.sample.WLSMultiHost
 
-# Check and copy custom_mod_wl_ohs.conf to OHS Instance Home
-if [[ -n "${modwlsconfigfile/[ ]*\n/}" ]]; then
+# Rename the original file and copy the sample file to instance config location
+echo "Configuring Oracle WebLogic Server Proxy Plug-In for WLS MultiHost sample"
 cd ${INSTANCE_CONFIG_HOME}
 mv mod_wl_ohs.conf mod_wl_ohs.conf.ORIGINAL
-echo "Copying ${modwlsconfigfile} to ${INSTANCE_CONFIG_HOME} and restarting OHS server"
-cp ${modwlsconfigfile} ${INSTANCE_CONFIG_HOME}/mod_wl_ohs.conf
-echo "Restarting OHS server after successful configuration of WebLogic Server Proxy Plug-In "
+echo "Copying plugin file to INSTANCE_CONFIG_DIR=${INSTANCE_CONFIG_HOME}"
+cp /u01/oracle/container-scripts/mod_wl_ohs.conf.sample.WLSMultiHost ${INSTANCE_CONFIG_HOME}/mod_wl_ohs.conf
+
+# Restart ohs server
+echo "Restarting OHS server "
 /u01/oracle/container-scripts/restartOHS.sh
-echo "You may now access the the application deployed to the DockerCluster @ http://myhost:7777/weblogic/application_end_url"
-else
-echo "Customized mod_wl_ohs.conf file not found in mounted volume!!! WebLogic Server Proxy Plug-In has not been configured, but OHS is running  "
-echo "You may now access OHS @ http://myhost:7777/index.html"
-fi
 
 #Tail all server logs
 tail -f ${DOMAIN_HOME}/nodemanager/nodemanager.log ${DOMAIN_HOME}/servers/*/logs/*.out

--- a/OracleHTTPServer/samples/1221-ohs-domain/container-scripts/mod_wl_ohs.conf.sample
+++ b/OracleHTTPServer/samples/1221-ohs-domain/container-scripts/mod_wl_ohs.conf.sample
@@ -3,6 +3,10 @@
 #***************************************************************
 # NOTE : This is a sample template to configure mod_weblogic.
 # Author: hemastuti.baruah@oracle.com
+#
+#
+#Refer to OHS documentation for more details and examples
+#Section 2.4 @ http://docs.oracle.com/middleware/1221/webtier/develop-plugin/oracle.htm#PLGWL553
 #*************************************************************************
 LoadModule weblogic_module   "/u01/oracle/ohssa/ohs/modules/mod_wl_ohs.so"
 
@@ -11,15 +15,24 @@ WebLogicHost WEBLOGIC_HOST
 WebLogicPort WEBLOGIC_PORT
 </IfModule>
 
-# Weblogic Admin Server
-<Location />
+# Directive for weblogic admin Console deployed on Weblogic Admin Server
+<Location /console>
 SetHandler weblogic-handler
 WebLogicHost WEBLOGIC_HOST
 WeblogicPort WEBLOGIC_PORT
 </Location>
 
-#All application deployed on weblogic cluster
-<Location />
-SetHandler weblogic-handler
+# Directive for all application deployed on weblogic cluster with /weblogic prepath
+#All application deployed on cluster can be accessed via http://myhost:7777/weblogic/application_end_url
+<Location /weblogic>
+WLSRequest On
 WebLogicCluster WEBLOGIC_CLUSTER
+PathTrim /weblogic
 </Location>
+
+#Directive for application deployed on single or set of Managed Servers (and NOT on weblogic cluster)
+#<Location /application_end_url>
+#SetHandler weblogic-handler
+#WebLogicHost ManagedServer_HOST
+#WeblogicPort ManagedServer_PORT
+#</Location>


### PR DESCRIPTION
Now user can provide custom Oracle Weblogic Proxy Plugin file containing directives as per their weblogic environments .
This file will need to be placed in docker data volume , which in turn will be mounted during OHS container creation.
In this way, the same OHS docker solution can be used to route applications running on either  Weblogic Admin Server or Weblogic cluster or set of individual Managed Servers .