### PR TITLE
Fix to not recreate domain on container restart

### DIFF
--- a/OracleWebLogic/samples/1221-medrec/startSample.sh
+++ b/OracleWebLogic/samples/1221-medrec/startSample.sh
@@ -3,10 +3,19 @@
 # Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
 #
 sample=$1
+WORK_DIR=/u01/oracle/wlserver/samples/server/medrec/
+FILE=/u01/oracle/user_projects/domains/medrec/config/jdbc/MedRec-jdbc.xml
 
-# Define default command to create medrec domain 
-ant $sample
+#check if medrec is already deployed
+if [ -f $FILE ]; then
+   echo "Start AdminServer"
+   cd $WORK_DIR/install/non-mt-single-server
+   ant start
+else
+   # Define default command to create medrec domain
+   ant $sample
+   mkdir -p /u01/oracle/user_projects/domains/medrec/servers/AdminServer/logs/
+   touch /u01/oracle/user_projects/domains/medrec/servers/AdminServer/logs/AdminServer.log
+fi
 
-mkdir -p /u01/oracle/user_projects/domains/medrec/servers/AdminServer/logs/
-touch /u01/oracle/user_projects/domains/medrec/servers/AdminServer/logs/AdminServer.log
 tail -f /u01/oracle/user_projects/domains/medrec/servers/AdminServer/logs/AdminServer.log


### PR DESCRIPTION
Added check to the start script to ensures that the domain is only created the first time the container is started. On subsequent restarts, only derby and the admin server is started. Thus retaining local changes.