### PR TITLE
add SIGINT handler to close DB properly on control-c

### DIFF
--- a/OracleDatabase/dockerfiles/12.1.0.2/runOracle.sh
+++ b/OracleDatabase/dockerfiles/12.1.0.2/runOracle.sh
@@ -37,6 +37,16 @@ function symLinkFiles {
 
 }
 
+########### SIGINT handler ############
+function _int() {
+   echo "Stopping container."
+   echo "SIGINT received, shutting down database!"
+   sqlplus / as sysdba <<EOF
+   shutdown immediate;
+EOF
+   lsnrctl stop
+}
+
 ########### SIGTERM handler ############
 function _term() {
    echo "Stopping container."
@@ -133,6 +143,9 @@ if [ `cat /sys/fs/cgroup/memory/memory.limit_in_bytes` -lt 2147483648 ]; then
    echo "You currently only have $((`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`/1024/1024/1024)) GB allocated to the container."
    exit 1;
 fi;
+
+# Set SIGINT handler
+trap _int SIGINT
 
 # Set SIGTERM handler
 trap _term SIGTERM


### PR DESCRIPTION
While our Oracle docker images already address clean shutdown on docker stop signals, it does not address control-c yet, which is IMHO the easiest way to stop a container when experimenting in interactive mode.