### PR TITLE
fix wrong log path

### DIFF
--- a/OracleDatabase/dockerfiles/12.1.0.2/createDB.sh
+++ b/OracleDatabase/dockerfiles/12.1.0.2/createDB.sh
@@ -53,7 +53,7 @@ echo "LISTENER =
 # Start LISTENER and run DBCA
 lsnrctl start &&
 dbca -silent -responseFile $ORACLE_BASE/dbca.rsp ||
- cat /opt/oracle/cfgtoollogs/dbca/$ORACLE_SID/$ORACLE_SID.log
+ cat /opt/oracle/cfgtoollogs/dbca/$ORACLE_SID.log
 
 echo "$ORACLE_SID=localhost:1521/$ORACLE_SID" >> $ORACLE_HOME/network/admin/tnsnames.ora
 echo "$ORACLE_PDB= 

--- a/OracleDatabase/dockerfiles/12.1.0.2/createDB.sh
+++ b/OracleDatabase/dockerfiles/12.1.0.2/createDB.sh
@@ -53,6 +53,7 @@ echo "LISTENER =
 # Start LISTENER and run DBCA
 lsnrctl start &&
 dbca -silent -responseFile $ORACLE_BASE/dbca.rsp ||
+ cat /opt/oracle/cfgtoollogs/dbca/$ORACLE_SID/$ORACLE_SID.log ||
  cat /opt/oracle/cfgtoollogs/dbca/$ORACLE_SID.log
 
 echo "$ORACLE_SID=localhost:1521/$ORACLE_SID" >> $ORACLE_HOME/network/admin/tnsnames.ora


### PR DESCRIPTION
If dbca failed the dbca-log should be displayed, but the specified path is wrong. I triggered this error by using an SID with invalid character.