### PR TITLE
Fix for issue #219

### DIFF
--- a/OracleDatabase/dockerfiles/12.1.0.2/runOracle.sh
+++ b/OracleDatabase/dockerfiles/12.1.0.2/runOracle.sh
@@ -79,11 +79,15 @@ EOF
 ############# MAIN ################
 
 # Check whether container has enough memory
-if [ `cat /sys/fs/cgroup/memory/memory.limit_in_bytes` -lt 2147483648 ]; then
-   echo "Error: The container doesn't have enough memory allocated."
-   echo "A database container needs at least 2 GB of memory."
-   echo "You currently only have $((`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`/1024/1024/1024)) GB allocated to the container."
-   exit 1;
+# Github issue #219: Prevent integer overflow,
+# only check if memory digits are less than 11 (single GB range and below) 
+if [ `cat /sys/fs/cgroup/memory/memory.limit_in_bytes | wc -c` -lt 11 ]; then
+   if [ `cat /sys/fs/cgroup/memory/memory.limit_in_bytes` -lt 2147483648 ]; then
+      echo "Error: The container doesn't have enough memory allocated."
+      echo "A database container needs at least 2 GB of memory."
+      echo "You currently only have $((`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`/1024/1024/1024)) GB allocated to the container."
+      exit 1;
+   fi;
 fi;
 
 # Set SIGINT handler


### PR DESCRIPTION
Bash test cannot handle the maximum integer value of
18446744073709551615 in a 64 bit system. Introduced another check to
don’t bother if the digits of memory available go over the single digit
GB range.