### PR TITLE
Fixed :Oracle Database 12c EE -ORA-48122: error with opening the ADR block file

### DIFF
--- a/OracleDatabase/dockerfiles/12.1.0.2/Dockerfile.ee
+++ b/OracleDatabase/dockerfiles/12.1.0.2/Dockerfile.ee
@@ -70,7 +70,7 @@ RUN $ORACLE_BASE/oraInventory/orainstRoot.sh && \
 USER oracle
 WORKDIR /home/oracle
 
-VOLUME ["$ORACLE_BASE/oradata"]
+VOLUME ["$ORACLE_BASE/oradata","$ORACLE_BASE/diag"]
 EXPOSE 1521 5500
     
 # Define default command to start Oracle Database. 


### PR DESCRIPTION
Docker host using file system such as NFS and ZFS which does not support O_DIRECT can run database container without ADR error adding -v [volume:]/opt/oracle/diag. #241 