### PR TITLE
Database: Provide a env variable to set the character set during db creation

### DIFF
--- a/OracleDatabase/README.md
+++ b/OracleDatabase/README.md
@@ -39,6 +39,8 @@ Before you build the image make sure that you have provided the installation bin
 
 You may extend the image with your own Dockerfile and create the users and tablespaces that you may need.
 
+The character set for the database is set during creating of the database. 11g Express Edition supports only UTF-8. You can set the character set for the Standard Edition 2 and Enterprise Edition during the first run of your container and may keep separate folders containing different tablespaces with different character sets.
+
 ### Running Oracle Database in a Docker container
 
 #### Running Oracle Database Enterprise and Standard Edition in a Docker container
@@ -48,6 +50,7 @@ To run your Oracle Database Docker image use the **docker run** command as follo
 	-p <host port>:1521 -p <host port>:5500 \
 	-e ORACLE_SID=<your SID> \
 	-e ORACLE_PDB=<your PDB name> \
+	-e ORACLE_CHARACTERSET=<your character set> \
 	-v [<host mount point>:]/opt/oracle/oradata \
 	oracle/database:12.1.0.2-ee
 	
@@ -57,6 +60,8 @@ To run your Oracle Database Docker image use the **docker run** command as follo
 	                  Two ports are exposed: 1521 (Oracle Listener), 5500 (OEM Express)
 	   -e ORACLE_SID: The Oracle Database SID that should be used (default: ORCLCDB)
 	   -e ORACLE_PDB: The Oracle Database PDB name that should be used (default: ORCLPDB1)
+	   -e ORACLE_CHARACTERSET:
+	                  The character set to use when creating the database (default: AL32UTF8)
 	   -v             The data volume to use for the database.
 	                  Has to be owned by the Unix user "oracle" or set appropriately.
 	                  If omitted the database will not be persisted over container recreation.

--- a/OracleDatabase/dockerfiles/12.1.0.2/createDB.sh
+++ b/OracleDatabase/dockerfiles/12.1.0.2/createDB.sh
@@ -34,6 +34,7 @@ cp $ORACLE_BASE/$CONFIG_RSP $ORACLE_BASE/dbca.rsp
 sed -i -e "s|###ORACLE_SID###|$ORACLE_SID|g" $ORACLE_BASE/dbca.rsp
 sed -i -e "s|###ORACLE_PDB###|$ORACLE_PDB|g" $ORACLE_BASE/dbca.rsp
 sed -i -e "s|###ORACLE_PWD###|$ORACLE_PWD|g" $ORACLE_BASE/dbca.rsp
+sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" $ORACLE_BASE/dbca.rsp
 
 # Create network related config files (sqlnet.ora, tnsnames.ora, listener.ora)
 mkdir -p $ORACLE_HOME/network/admin

--- a/OracleDatabase/dockerfiles/12.1.0.2/dbca.rsp.tmpl
+++ b/OracleDatabase/dockerfiles/12.1.0.2/dbca.rsp.tmpl
@@ -227,7 +227,7 @@ DBSNMPPASSWORD = "###ORACLE_PWD###"
 # Default value : "US7ASCII"
 # Mandatory     : NO
 #-----------------------------------------------------------------------------
-CHARACTERSET = "AL32UTF8"
+CHARACTERSET = "###ORACLE_CHARACTERSET###"
 
 #-----------------------------------------------------------------------------
 # Name          : NATIONALCHARACTERSET

--- a/OracleDatabase/dockerfiles/12.1.0.2/runOracle.sh
+++ b/OracleDatabase/dockerfiles/12.1.0.2/runOracle.sh
@@ -128,8 +128,8 @@ if [ "$ORACLE_PDB" == "" ]; then
 fi;
 
 # Default for ORACLE CHARACTERSET
-if [ "$ORACLE_CHARACTERSET" == ""]; then
-	export ORACLE_CHARACTERSET=AL32UTF8
+if [ "$ORACLE_CHARACTERSET" == "" ]; then
+   export ORACLE_CHARACTERSET=AL32UTF8
 fi;
 
 # Check whether database already exists

--- a/OracleDatabase/dockerfiles/12.1.0.2/runOracle.sh
+++ b/OracleDatabase/dockerfiles/12.1.0.2/runOracle.sh
@@ -127,6 +127,11 @@ if [ "$ORACLE_PDB" == "" ]; then
    export ORACLE_PDB=ORCLPDB1
 fi;
 
+# Default for ORACLE CHARACTERSET
+if [ "$ORACLE_CHARACTERSET" == ""]; then
+	export ORACLE_CHARACTERSET=AL32UTF8
+fi;
+
 # Check whether database already exists
 if [ -d $ORACLE_BASE/oradata/$ORACLE_SID ]; then
    symLinkFiles;


### PR DESCRIPTION
I'd kindly propose the following change:

* Introduce `ORACLE_CHARACTERSET` defaulted to AL32UTF8
* Change the dbca template to have a place holder for CHARACTERSET instead of the fix value above
* Use an env variable to determine the characterset for the database

Thus, the character set can be passed to the container on the first run to create a database with a different characterset for Standard Edition 2 and Enterprise Edition.

I have updated the README accordingly and hope this is of use to you too.