### PR TITLE
Add a link to Oracle Container Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ And Open Source projects:
 
 Oracle Linux images can be found in the [`OracleLinux-images`](https://github.com/oracle/docker/tree/OracleLinux-images) branch of this repository.
 
+For pre-built images containing Oracle software, please check the [Oracle Container Registry](https://container-registry.oracle.com).
+
 For support and certification information, please consult the documentation for each product.
 
 For community support, discussions and feedback about the provided Dockerfiles visit the [OTN Community Docker Space](https://community.oracle.com/community/docker/overview)


### PR DESCRIPTION
Update the README to include a link to the Oracle Container Registry.