### PR TITLE
Fix container cloud stacks

### DIFF
--- a/ContainerCloud/stacks/haproxy-lb-to-apache/Makefile
+++ b/ContainerCloud/stacks/haproxy-lb-to-apache/Makefile
@@ -1,4 +1,4 @@
-IMAGES=apache-backend haproxy
+IMAGES=runit confd apache-backend haproxy
 
 # Include the common makefile which provides the following targets:
 # stack (default):    runs images, publish, and generate-stack-yml targets

--- a/ContainerCloud/stacks/haproxy-lb-to-nginx/Makefile
+++ b/ContainerCloud/stacks/haproxy-lb-to-nginx/Makefile
@@ -1,4 +1,4 @@
-IMAGES=nginx-backend haproxy
+IMAGES=runit confd nginx-backend haproxy
 
 # Include the common makefile which provides the following targets:
 # stack (default):    runs images, publish, and generate-stack-yml targets

--- a/ContainerCloud/stacks/nginx-lb-to-apache/Makefile
+++ b/ContainerCloud/stacks/nginx-lb-to-apache/Makefile
@@ -1,4 +1,4 @@
-IMAGES=apache-backend nginx-lb
+IMAGES=runit confd apache-backend nginx-lb
 
 # Include the common makefile which provides the following targets:
 # stack (default):    runs images, publish, and generate-stack-yml targets

--- a/ContainerCloud/stacks/nginx-lb-to-nginx/Makefile
+++ b/ContainerCloud/stacks/nginx-lb-to-nginx/Makefile
@@ -1,4 +1,4 @@
-IMAGES=nginx-backend nginx-lb
+IMAGES=runit confd nginx-backend nginx-lb
 
 # Include the common makefile which provides the following targets:
 # stack (default):    runs images, publish, and generate-stack-yml targets


### PR DESCRIPTION
The make files in for the load balancer stacks are missing their base container images. This PR fixes that specific issue so that all container cloud stacks are buildable.