### PR TITLE
Update Dockerfile.generic (fixing missing su)

### DIFF
--- a/OracleWebLogic/dockerfiles/12.1.3/Dockerfile.generic
+++ b/OracleWebLogic/dockerfiles/12.1.3/Dockerfile.generic
@@ -59,6 +59,7 @@ COPY $FMW_PKG install.file oraInst.loc /u01/
 RUN chmod a+xr /u01 && \
     useradd -b /u01 -m -s /bin/bash oracle && \
     echo oracle:oracle | chpasswd && \
+    yum -y install util-linux && yum clean all && \
     su -c "$JAVA_HOME/bin/java -jar /u01/$FMW_PKG -ignoreSysPrereqs -novalidation -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME ORACLE_HOME=$ORACLE_HOME" - oracle && \
     chown oracle:oracle -R /u01 && \
     rm /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file


### PR DESCRIPTION
Same change as in commit ed8015d14e09369ff1dfcefee43fe52ad9d49604 - fixes missing `su` issue when using `oraclelinux:7-slim` linux