### PR TITLE
Update NoSQL Dockerfile to use CE_4.3 #298

### DIFF
--- a/NoSQL/4.3.11/Dockerfile
+++ b/NoSQL/4.3.11/Dockerfile
@@ -1,0 +1,26 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# 
+# Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+# 
+FROM oracle/openjdk:latest
+
+MAINTAINER Mayuresh A Nirhali <mayuresh.nirhali@oracle.com>
+
+ENV VERSION="4.3.11" \
+    KVHOME=/kv-4.3.11 \
+    PACKAGE="kv-ce" \
+    EXTENSION="zip" \
+    BASE_URL="http://download.oracle.com/otn-pub/otn_software/nosql-database/" \
+    _JAVA_OPTIONS="-Djava.security.egd=file:/dev/./urandom"
+ 
+RUN yum -y install unzip && \
+    curl -OLs "${BASE_URL}/${PACKAGE}-${VERSION}.${EXTENSION}" && \
+    unzip "${PACKAGE}-${VERSION}.${EXTENSION}" && \
+    rm "${PACKAGE}-${VERSION}.${EXTENSION}" && \
+    yum -y remove unzip && rm -rf /var/cache/yum/*
+ 
+WORKDIR "/kv-${VERSION}"
+ 
+EXPOSE 5000 5001 5010-5020
+
+CMD ["java", "-jar", "lib/kvstore.jar", "kvlite", "-secure-config", "disable"]

--- a/NoSQL/README.md
+++ b/NoSQL/README.md
@@ -17,19 +17,20 @@ You can also use the Oracle NoSQL Command Line Interface (CLI). Start the follow
 
         kv-> ping 
         Pinging components of store kvstore based upon topology sequence #14
-        10 partitions and 1 storage nodes
-        Time: 2015-12-11 09:26:07 UTC   Version: 12.1.3.4.7
-        Shard Status: healthy:1 writable-degraded:0 read-only:0 offline:0
-        Admin Status: healthy
-        Zone [name=KVLite id=zn1 type=PRIMARY]   RN Status: online:1 offline:0
-        Storage Node [sn1] on e91227b8b450:5000    Zone: [name=KVLite id=zn1 type=PRIMARY]    
-        Status: RUNNING   Ver: 12cR1.3.4.7 2015-10-01 04:48:39 UTC  Build id: 44f8b0e7d93a
-        Admin [admin1]		Status: RUNNING,MASTER
-        Rep Node [rg1-rn1]	Status: RUNNING,MASTER sequenceNumber:39 haPort:5006
-
+	10 partitions and 1 storage nodes
+	Time: 2017-02-28 15:37:41 UTC   Version: 12.1.4.3.11
+	Shard Status: healthy:1 writable-degraded:0 read-only:0 offline:0
+	Admin Status: healthy
+	Zone [name=KVLite id=zn1 type=PRIMARY allowArbiters=false]   RN Status: online:1 offline:0
+	Storage Node [sn1] on 659dbf4fba07:5000    
+	Zone: [name=KVLite id=zn1 type=PRIMARY allowArbiters=false]    
+	Status: RUNNING   Ver: 12cR1.4.3.11 2017-02-17 06:52:09 UTC  Build id: 0e3ebe7568a0
+	Admin [admin1]		Status: RUNNING,MASTER
+	Rep Node [rg1-rn1]	Status: RUNNING,MASTER sequenceNumber:49 haPort:5006
+        
         kv-> put kv -key /SomeKey -value SomeValue
         Operation successful, record inserted.
-        kv-> kv-> get kv -key /SomeKey
+        kv-> get kv -key /SomeKey
         SomeValue
         kv->
 
@@ -41,7 +42,7 @@ For more information on Oracle NoSQL, visit the [homepage](http://www.oracle.com
 This image contains Oracle NoSQL Community Edition and OpenJDK.
 
 # Licenses
-Oracle NoSQL Community Edition is licensed under the [GNU AFFERO GENERAL PUBLIC LICENSE v3.0](http://www.oracle.com/technetwork/database/database-technologies/nosqldb/documentation/nosql-db-agpl-license-1432845.txt).
+Oracle NoSQL Community Edition is licensed under the [APACHE LICENSE v2.0](https://docs.oracle.com/cd/NOSQL/html/driver_table_c/doc/LICENSE.txt).
 
 OpenJDK is licensed under the [GNU General Public License v2.0 with the Classpath Exception](http://openjdk.java.net/legal/gplv2+ce.html)
 
@@ -51,4 +52,4 @@ Oracle NoSQL Enterprise Edition is **not** certified on Docker.
 Oracle NoSQL Community Edition has **no** commercial support.
 
 # Copyright
-Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.


### PR DESCRIPTION
Oracle NoSQL Database 4.3 (Community Edition) is now released. It would be useful to have the Dockerfile included in this repo for the latest version. Some of the key changes from docker perspective include -

    The community edition is now licensed under Apache License v2.0
    oracle nosql database is now secure by default. This affects how the kvlite instance can be started within the container.

I created a patch to add the Dockerfile with necessary changes to the Readme and added the Dockerfile. Please review and let me know your feedback.