### PR TITLE
Fix bug in createAndStartEmptyDomain.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.jar
 **/*.zip
 **/*.tar.gz
+.idea/

--- a/OracleWebLogic/dockerfiles/12.2.1.2/container-scripts/createAndStartEmptyDomain.sh
+++ b/OracleWebLogic/dockerfiles/12.2.1.2/container-scripts/createAndStartEmptyDomain.sh
@@ -38,7 +38,7 @@ fi
 # Create Domain only if 1st execution
 if [ $ADD_DOMAIN -eq 0 ]; then
 # Auto generate Oracle WebLogic Server admin password
-ADMIN_PASSWORD=$(cat date| md5sum | fold -w 8 | head -n 1) 
+ADMIN_PASSWORD=$(date| md5sum | fold -w 8 | head -n 1)
 
 echo ""
 echo "    Oracle WebLogic Server Auto Generated Empty Domain:"


### PR DESCRIPTION
On starting the 12.2.1.2 container, below error is logged:
`cat: date: No such file or directory`

Then the calculated admin password will always be `d41d8cd9`.