### PR TITLE
Pull request oracledb

### DIFF
--- a/OracleDatabase/dockerfiles/12.2.0.1/dbca.rsp.tmpl
+++ b/OracleDatabase/dockerfiles/12.2.0.1/dbca.rsp.tmpl
@@ -170,7 +170,7 @@ nationalCharacterSet=UTF8
 # Default value : None
 # Mandatory     : NO
 #-----------------------------------------------------------------------------
-initParams=db_recovery_file_dest=/opt/oracle/oradata/fast_recovery_area,audit_trail=none,audit_sys_operations=false
+initParams=db_recovery_file_dest=/opt/oracle/oradata/fast_recovery_area,audit_trail=none,audit_sys_operations=false,sga_target=3000M
 
 #-----------------------------------------------------------------------------
 # Name          : listeners

--- a/OracleDatabase/dockerfiles/12.2.0.1/setupLinuxEnv.sh
+++ b/OracleDatabase/dockerfiles/12.2.0.1/setupLinuxEnv.sh
@@ -22,6 +22,6 @@ groupadd -g 500 dba && \
 groupadd -g 501 oinstall && \
 useradd  -u 500 -d /home/oracle -g dba -G dba,oinstall -m -s /bin/bash oracle && \
 echo oracle:oracle | chpasswd && \
-yum -y install oracle-database-server-12cR2-preinstall unzip wget tar openssl && \
+yum -y install oracle-database-server-12cR2-preinstall unzip wget tar openssl vim && \
 yum clean all && \
 chown -R oracle:dba $ORACLE_BASE


### PR DESCRIPTION
I've been trying to create the Oracle 12.2.0.1 container with no success. I made some small changes to make it easier to debug. One I noticed that during db creation it was failing because it wanted an sga_target larger than ~2500M, so I just made it 3000M. I also added the vim package so I could modify files and make it easier to make changes within the container. 

A SIDE NOTE: I've been able to successfully install the Oracle Database XE container.

For my Oracle 12.2.0.1, my docker run looks like:

docker run --privileged --name oracle -p 9000:1521 -p 9001:5500 -e ORACLE_SID=ORCLCDB -e ORACLE_PID=ORCLPDB1 -e ORACLE_CHARACTERSET=AL32UTF8 -v /var/oracle:/opt/oracle/oradata oracle/database:12.2.0.1-ee


My /var/oracle is an ext4 filesystem, with permissions oracle as the user and dba as the group permission.

Permissions on the /var/oracle directory: 
drwxr-xr-x.  6 oracle dba  4096 Mar  7 11:04 oracle

The error I'm seeing is below. My guess is it has something to do with the LISTENER and its not liking that its not set? I tried changing the dbca template to say the name was LISTENER but it wasn't happy with that either. Any guidance would be appreciated. 

Thanks,

Roger

------
ERROR BELOW:

```
LSNRCTL for Linux: Version 12.2.0.1.0 - Production on 07-MAR-2017 16:03:58

Copyright (c) 1991, 2016, Oracle.  All rights reserved.

Starting /opt/oracle/product/12.2.0.1/dbhome_1/bin/tnslsnr: please wait...

TNSLSNR for Linux: Version 12.2.0.1.0 - Production
System parameter file is /opt/oracle/product/12.2.0.1/dbhome_1/network/admin/listener.ora
Log messages written to /opt/oracle/diag/tnslsnr/2b276472afdf/listener/alert/log.xml
Listening on: (DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1)))
Listening on: (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=0.0.0.0)(PORT=1521)))

Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=IPC)(KEY=EXTPROC1)))
STATUS of the LISTENER
------------------------
Alias                     LISTENER
Version                   TNSLSNR for Linux: Version 12.2.0.1.0 - Production
Start Date                07-MAR-2017 16:03:59
Uptime                    0 days 0 hr. 0 min. 0 sec
Trace Level               off
Security                  ON: Local OS Authentication
SNMP                      OFF
Listener Parameter File   /opt/oracle/product/12.2.0.1/dbhome_1/network/admin/listener.ora
Listener Log File         /opt/oracle/diag/tnslsnr/2b276472afdf/listener/alert/log.xml
Listening Endpoints Summary...
  (DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1)))
  (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=0.0.0.0)(PORT=1521)))
The listener supports no services
The command completed successfully
**[WARNING] [DBT-10102] The listener configuration is not selected for the database. EM DB Express URL will not be accessible.
   CAUSE: The database should be registered with a listener in order to access the EM DB Express URL.
   ACTION: Select a listener to be registered or created with the database.**
Copying database files
1% complete
2% complete
**DBCA Operation failed.**
Look at the log file "/opt/oracle/cfgtoollogs/dbca/ORCLCDB/ORCLCDB.log" for further details.
[ 2017-03-07 16:04:06.230 UTC ] Copying database files
DBCA_PROGRESS : 1%
[ 2017-03-07 16:04:08.027 UTC ] ORA-01078: failure in processing system parameters

DBCA_PROGRESS : 2%
[ 2017-03-07 16:04:08.028 UTC ] ORA-01034: ORACLE not available

[ 2017-03-07 16:04:08.029 UTC ] ORA-01034: ORACLE not available

[ 2017-03-07 16:04:13.185 UTC ] DBCA_PROGRESS : DBCA Operation failed.

SQL*Plus: Release 12.2.0.1.0 Production on Tue Mar 7 16:04:13 2017

Copyright (c) 1982, 2016, Oracle.  All rights reserved.

Connected to an idle instance.

SQL>    ALTER SYSTEM SET control_files='/opt/oracle/oradata/ORCLCDB/control01.ctl' scope=spfile
*
ERROR at line 1:
ORA-01034: ORACLE not available
Process ID: 0
Session ID: 0 Serial number: 0


SQL>    ALTER PLUGGABLE DATABASE ORCLPDB1 SAVE STATE
*
ERROR at line 1:
ORA-01034: ORACLE not available
Process ID: 0
Session ID: 0 Serial number: 0


SQL> Disconnected
mv: cannot stat '/opt/oracle/product/12.2.0.1/dbhome_1/dbs/spfileORCLCDB.ora': No such file or directory
mv: cannot stat '/opt/oracle/product/12.2.0.1/dbhome_1/dbs/orapwORCLCDB': No such file or directory
#########################
DATABASE IS READY TO USE!
#########################
tail: cannot open '/opt/oracle/diag/rdbms/*/*/trace/alert*.log' for reading: No such file or directory
tail: no files remaining

**cat /opt/oracle/cfgtoollogs/dbca/ORCLCDB/ORCLCDB.log**
[ 2017-03-07 16:04:06.230 UTC ] Copying database files
DBCA_PROGRESS : 1%
[ 2017-03-07 16:04:08.027 UTC ] ORA-01078: failure in processing system parameters

DBCA_PROGRESS : 2%
[ 2017-03-07 16:04:08.028 UTC ] ORA-01034: ORACLE not available

[ 2017-03-07 16:04:08.029 UTC ] ORA-01034: ORACLE not available

[ 2017-03-07 16:04:13.185 UTC ] DBCA_PROGRESS : DBCA Operation failed.
```

