### PR TITLE
Added support for auto-deploying Java applications on boot of WebLogic

### DIFF
--- a/OracleWebLogic/dockerfiles/12.2.1.1/Dockerfile.developer
+++ b/OracleWebLogic/dockerfiles/12.2.1.1/Dockerfile.developer
@@ -51,7 +51,7 @@ RUN mkdir -p /u01 && \
    
 # Copy scripts
 #-------------
-COPY container-scripts/createAndStartEmptyDomain.sh container-scripts/create-wls-domain.py /u01/oracle/
+COPY container-scripts/createAndStartEmptyDomain.sh container-scripts/create-wls-domain.py container-scripts/deploy-app.py /u01/oracle/
 
 ENV SCRIPT_FILE=/u01/oracle/createAndStartEmptyDomain.sh \
     DOMAIN_NAME="${DOMAIN_NAME:-base_domain}" \

--- a/OracleWebLogic/dockerfiles/12.2.1.1/Dockerfile.generic
+++ b/OracleWebLogic/dockerfiles/12.2.1.1/Dockerfile.generic
@@ -49,7 +49,7 @@ RUN mkdir -p /u01 && \
 
 # Copy scripts
 #-------------
-COPY container-scripts/createAndStartEmptyDomain.sh container-scripts/create-wls-domain.py /u01/oracle/
+COPY container-scripts/createAndStartEmptyDomain.sh container-scripts/create-wls-domain.py container-scripts/deploy-app.py /u01/oracle/
     
 ENV SCRIPT_FILE=/u01/oracle/createAndStartEmptyDomain.sh \
     DOMAIN_NAME="${DOMAIN_NAME:-base_domain}" \

--- a/OracleWebLogic/dockerfiles/12.2.1.1/container-scripts/createAndStartEmptyDomain.sh
+++ b/OracleWebLogic/dockerfiles/12.2.1.1/container-scripts/createAndStartEmptyDomain.sh
@@ -50,6 +50,15 @@ echo "password=$ADMIN_PASSWORD" >> /u01/oracle/user_projects/domains/$DOMAIN_NAM
 ${DOMAIN_HOME}/bin/setDomainEnv.sh 
 fi
 
+# Deploying Applications
+for f in *;
+do
+   if [[ "${f: -4}" == ".war" || "${f: -4}" == ".ear" ]]
+   then
+     echo "Deploying $f"
+     wlst.sh deploy.py $f
+   fi
+done
 
 # Start Admin Server and tail the logs
 ${DOMAIN_HOME}/startWebLogic.sh

--- a/OracleWebLogic/dockerfiles/12.2.1.1/container-scripts/deploy-app.py
+++ b/OracleWebLogic/dockerfiles/12.2.1.1/container-scripts/deploy-app.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+domainhome = os.environ.get('DOMAIN_HOME', '/u01/oracle/user_projects/domains/base_domain')
+
+readDomain(domainhome)
+appFile = sys.argv[1]
+appName = os.path.splitext(appFile)[0]
+
+app = create(appName, 'AppDeployment')
+app.setSourcePath('/u01/oracle/'+appFile)
+app.setStagingMode('nostage')
+assign('AppDeployment', appName, 'Target', 'AdminServer')
+
+updateDomain()
+closeDomain()
+exit()

--- a/OracleWebLogic/dockerfiles/12.2.1.2/Dockerfile.developer
+++ b/OracleWebLogic/dockerfiles/12.2.1.2/Dockerfile.developer
@@ -49,7 +49,7 @@ RUN mkdir -p /u01 && \
     
 # Copy scripts
 #-------------
-COPY container-scripts/createAndStartEmptyDomain.sh container-scripts/create-wls-domain.py /u01/oracle/
+COPY container-scripts/createAndStartEmptyDomain.sh container-scripts/create-wls-domain.py container-scripts/deploy-app.py /u01/oracle/
 
 ENV SCRIPT_FILE=/u01/oracle/createAndStartEmptyDomain.sh \
     DOMAIN_NAME="${DOMAIN_NAME:-base_domain}" \

--- a/OracleWebLogic/dockerfiles/12.2.1.2/Dockerfile.generic
+++ b/OracleWebLogic/dockerfiles/12.2.1.2/Dockerfile.generic
@@ -49,7 +49,7 @@ RUN mkdir -p /u01 && \
    
 # Copy scripts
 #-------------
-COPY container-scripts/createAndStartEmptyDomain.sh container-scripts/create-wls-domain.py /u01/oracle/
+COPY container-scripts/createAndStartEmptyDomain.sh container-scripts/create-wls-domain.py container-scripts/deploy-app.py /u01/oracle/
 
 ENV SCRIPT_FILE=/u01/oracle/createAndStartEmptyDomain.sh \
     DOMAIN_NAME="${DOMAIN_NAME:-base_domain}" \

--- a/OracleWebLogic/dockerfiles/12.2.1.2/container-scripts/createAndStartEmptyDomain.sh
+++ b/OracleWebLogic/dockerfiles/12.2.1.2/container-scripts/createAndStartEmptyDomain.sh
@@ -50,6 +50,15 @@ echo "password=$ADMIN_PASSWORD" >> /u01/oracle/user_projects/domains/$DOMAIN_NAM
 ${DOMAIN_HOME}/bin/setDomainEnv.sh 
 fi
 
+# Deploying Applications
+for f in *;
+do
+   if [[ "${f: -4}" == ".war" || "${f: -4}" == ".ear" ]]
+   then
+     echo "Deploying $f"
+     wlst.sh deploy.py $f
+   fi
+done
 
 # Start Admin Server and tail the logs
 ${DOMAIN_HOME}/startWebLogic.sh

--- a/OracleWebLogic/dockerfiles/12.2.1.2/container-scripts/deploy-app.py
+++ b/OracleWebLogic/dockerfiles/12.2.1.2/container-scripts/deploy-app.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+domainhome = os.environ.get('DOMAIN_HOME', '/u01/oracle/user_projects/domains/base_domain')
+
+readDomain(domainhome)
+appFile = sys.argv[1]
+appName = os.path.splitext(appFile)[0]
+
+app = create(appName, 'AppDeployment')
+app.setSourcePath('/u01/oracle/'+appFile)
+app.setStagingMode('nostage')
+assign('AppDeployment', appName, 'Target', 'AdminServer')
+
+updateDomain()
+closeDomain()
+exit()


### PR DESCRIPTION
Prior to this PR, there was no way to easily build custom WebLogic images based off the official Docker images. This PR allows a user to do the following:

Given a Dockerfile of
```
FROM container-registry.oracle.com/middleware/weblogic:12.2.1.1
COPY sample.war .
```
And a `sample.war` file in the build context folder `.`
When the user runs `docker build -t sample .`
And then user runs `docker run -ti -p 7001:7001 sample`
Then they will have a running WebLogic domain with the sample app pre-deployed

On boot, it works by scanning `/u01/oracle` directory for `*.war` and `*.ear` files and deploying each one via WLST offline after the domain is created but before it is booted. Obviously, if no applications exist it will just boot a vanilla WebLogic domain as per usual.

As the 12.2.1.1 and 12.2.1.2 Docker images are the only ones that create a working WebLogic domain, they are the only ones where this approach will work. If 12.1.3 image is updated in future to create a WebLogic domain on boot, this same solution would work.