### PR TITLE
Use "exec" where possible to avoid excess shell processes

### DIFF
--- a/NoSQL/sample-cluster/inner-scripts/Dockerfile
+++ b/NoSQL/sample-cluster/inner-scripts/Dockerfile
@@ -4,4 +4,4 @@ RUN mkdir sample-cluster
 
 COPY *.sh ./sample-cluster/
 
-CMD bash
+CMD ["bash"]

--- a/OracleDatabase/dockerfiles/11.2.0.2/Dockerfile.xe
+++ b/OracleDatabase/dockerfiles/11.2.0.2/Dockerfile.xe
@@ -73,4 +73,4 @@ RUN yum -y install unzip libaio bc initscripts net-tools openssl && \
 VOLUME ["$ORACLE_BASE/oradata"]
 EXPOSE 1521 8080
 
-CMD $ORACLE_BASE/$RUN_FILE
+CMD exec $ORACLE_BASE/$RUN_FILE

--- a/OracleDatabase/dockerfiles/12.1.0.2/Dockerfile.ee
+++ b/OracleDatabase/dockerfiles/12.1.0.2/Dockerfile.ee
@@ -76,4 +76,4 @@ VOLUME ["$ORACLE_BASE/oradata"]
 EXPOSE 1521 5500
     
 # Define default command to start Oracle Database. 
-CMD $ORACLE_BASE/$RUN_FILE
+CMD exec $ORACLE_BASE/$RUN_FILE

--- a/OracleDatabase/dockerfiles/12.1.0.2/Dockerfile.se2
+++ b/OracleDatabase/dockerfiles/12.1.0.2/Dockerfile.se2
@@ -76,4 +76,4 @@ VOLUME ["$ORACLE_BASE/oradata"]
 EXPOSE 1521 5500
     
 # Define default command to start Oracle Database. 
-CMD $ORACLE_BASE/$RUN_FILE
+CMD exec $ORACLE_BASE/$RUN_FILE

--- a/OracleDatabase/dockerfiles/12.2.0.1/Dockerfile.ee
+++ b/OracleDatabase/dockerfiles/12.2.0.1/Dockerfile.ee
@@ -74,4 +74,4 @@ VOLUME ["$ORACLE_BASE/oradata"]
 EXPOSE 1521 5500
     
 # Define default command to start Oracle Database. 
-CMD $ORACLE_BASE/$RUN_FILE
+CMD exec $ORACLE_BASE/$RUN_FILE

--- a/OracleDatabase/dockerfiles/12.2.0.1/Dockerfile.se2
+++ b/OracleDatabase/dockerfiles/12.2.0.1/Dockerfile.se2
@@ -74,4 +74,4 @@ VOLUME ["$ORACLE_BASE/oradata"]
 EXPOSE 1521 5500
     
 # Define default command to start Oracle Database. 
-CMD $ORACLE_BASE/$RUN_FILE
+CMD exec $ORACLE_BASE/$RUN_FILE


### PR DESCRIPTION
As written, this ends up keeping a `/bin/sh` process resident as PID 1, which can cause issues with signals being sent to the service, but mostly is unnecessary. :+1: :heart:

In case you aren't familiar with `exec`, here's the relevant docs from Bash: (https://www.gnu.org/software/bash/manual/bashref.html#index-exec)

> If command is supplied, it replaces the shell without creating a new process. ... If command cannot be executed for some reason, a non-interactive shell exits, unless the execfail shell option is enabled. In that case, it returns failure. ...

Happy to edit, rebase, adjust, etc as desired!