### PR TITLE
Auto generated and user provided password for Glassfish 4.1.2 image

### DIFF
--- a/GlassFish/4.1.2/Dockerfile
+++ b/GlassFish/4.1.2/Dockerfile
@@ -13,7 +13,6 @@ ENV GLASSFISH_PKG=glassfish-4.1.2.zip \
     GLASSFISH_HOME=/glassfish4 \
     MD5=9a37928ea6e54334101b8a89e03a8d7d \
     PATH=$PATH:/glassfish4/bin \
-    PASSWORD=glassfish \
     JAVA_HOME=/usr/lib/jvm/java-openjdk
 
 # Install packages, download and extract GlassFish
@@ -24,17 +23,10 @@ RUN yum -y install wget unzip java-1.7.0-openjdk-devel && \
     echo "$MD5 *$GLASSFISH_PKG" | md5sum -c - && \
     unzip -o $GLASSFISH_PKG && \
     rm -f $GLASSFISH_PKG && \
-    yum -y remove wget unzip && rm -rf /var/cache/yum/* && \
-    echo "--- Setup the password file ---" && \
-    echo "AS_ADMIN_PASSWORD=" > /tmp/glassfishpwd && \
-    echo "AS_ADMIN_NEWPASSWORD=${PASSWORD}" >> /tmp/glassfishpwd  && \
-    echo "--- Enable DAS, change admin password, and secure admin access ---" && \
-    asadmin --user=admin --passwordfile=/tmp/glassfishpwd change-admin-password --domain_name domain1 && \
-    asadmin start-domain && \
-    echo "AS_ADMIN_PASSWORD=${PASSWORD}" > /tmp/glassfishpwd && \
-    asadmin --user=admin --passwordfile=/tmp/glassfishpwd enable-secure-admin && \
-    asadmin --user=admin stop-domain && \
-    rm /tmp/glassfishpwd
+    yum -y remove wget unzip && rm -rf /var/cache/yum/*
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 
 # Ports being exposed
 EXPOSE 4848 8080 8181

--- a/GlassFish/4.1.2/docker-entrypoint.sh
+++ b/GlassFish/4.1.2/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# 
+# Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+if [[ -z $ADMIN_PASSWORD ]]; then
+	ADMIN_PASSWORD=$(date| md5sum | fold -w 8 | head -n 1)
+	echo "##########GENERATED ADMIN PASSWORD: $ADMIN_PASSWORD  ##########"
+fi
+echo "AS_ADMIN_PASSWORD=" > /tmp/glassfishpwd
+echo "AS_ADMIN_NEWPASSWORD=${ADMIN_PASSWORD}" >> /tmp/glassfishpwd
+asadmin --user=admin --passwordfile=/tmp/glassfishpwd change-admin-password --domain_name domain1
+asadmin start-domain
+echo "AS_ADMIN_PASSWORD=${ADMIN_PASSWORD}" > /tmp/glassfishpwd
+asadmin --user=admin --passwordfile=/tmp/glassfishpwd enable-secure-admin
+asadmin --user=admin stop-domain
+rm /tmp/glassfishpwd
+exec "$@"


### PR DESCRIPTION
user provided password -
docker run -ti -e ADMIN_PASSWORD=<your-secret-password> -p 4848:4848 -p 8080:8080 -d oracle/glassfish:4.1.2

Auto Generated password -

docker run -ti -p 4848:4848 -p 8080:8080 -d oracle/glassfish:4.1.2

password = `docker logs <CONTAINER> | grep "GENERATED ADMIN PASSWORD"`