### PR TITLE
Auto generated and user provided password for Glassfish 4.1.2-web 4.1.1 and 4.1.1-web image

### DIFF
--- a/GlassFish/4.1.1-web/Dockerfile
+++ b/GlassFish/4.1.1-web/Dockerfile
@@ -1,12 +1,12 @@
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 # 
-# Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015-2017 Oracle and/or its affiliates. All rights reserved.
 # 
 # GlassFish on Docker with Oracle Linux and OpenJDK
 FROM oraclelinux:latest
 
 # Maintainer
-MAINTAINER Bruno Borges <bruno.borges@oracle.com>
+MAINTAINER Arindam Bandyopadhyay<arindam.bandyopadhyay@oracle.com>
 
 # Set environment variables and default password for user 'admin'
 ENV GLASSFISH_PKG=glassfish-4.1.1-web.zip \
@@ -14,28 +14,20 @@ ENV GLASSFISH_PKG=glassfish-4.1.1-web.zip \
     GLASSFISH_HOME=/glassfish4 \
     MD5=44baeca38cf33bb655fd3dd09f7d2b78 \
     PATH=$PATH:/glassfish4/bin \
-    PASSWORD=glassfish \
     JAVA_HOME=/usr/lib/jvm/java-openjdk
 
 # Install packages, download and extract GlassFish
 # Setup password file
 # Enable DAS
-RUN yum -y install wget unzip java-1.8.0-openjdk-devel && \
+RUN yum -y install wget unzip java-1.7.0-openjdk-devel && \
     wget --quiet --no-check-certificate $GLASSFISH_URL && \
     echo "$MD5 *$GLASSFISH_PKG" | md5sum -c - && \
     unzip -o $GLASSFISH_PKG && \
     rm -f $GLASSFISH_PKG && \
-    yum -y remove wget unzip && rm -rf /var/cache/yum/* && \
-    echo "--- Setup the password file ---" && \
-    echo "AS_ADMIN_PASSWORD=" > /tmp/glassfishpwd && \
-    echo "AS_ADMIN_NEWPASSWORD=${PASSWORD}" >> /tmp/glassfishpwd  && \
-    echo "--- Enable DAS, change admin password, and secure admin access ---" && \
-    asadmin --user=admin --passwordfile=/tmp/glassfishpwd change-admin-password --domain_name domain1 && \
-    asadmin start-domain && \
-    echo "AS_ADMIN_PASSWORD=${PASSWORD}" > /tmp/glassfishpwd && \
-    asadmin --user=admin --passwordfile=/tmp/glassfishpwd enable-secure-admin && \
-    asadmin --user=admin stop-domain && \
-    rm /tmp/glassfishpwd
+    yum -y remove wget unzip && rm -rf /var/cache/yum/*
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 
 # Ports being exposed
 EXPOSE 4848 8080 8181

--- a/GlassFish/4.1.1-web/docker-entrypoint.sh
+++ b/GlassFish/4.1.1-web/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# 
+# Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+if [[ -z $ADMIN_PASSWORD ]]; then
+	ADMIN_PASSWORD=$(date| md5sum | fold -w 8 | head -n 1)
+	echo "##########GENERATED ADMIN PASSWORD: $ADMIN_PASSWORD  ##########"
+fi
+echo "AS_ADMIN_PASSWORD=" > /tmp/glassfishpwd
+echo "AS_ADMIN_NEWPASSWORD=${ADMIN_PASSWORD}" >> /tmp/glassfishpwd
+asadmin --user=admin --passwordfile=/tmp/glassfishpwd change-admin-password --domain_name domain1
+asadmin start-domain
+echo "AS_ADMIN_PASSWORD=${ADMIN_PASSWORD}" > /tmp/glassfishpwd
+asadmin --user=admin --passwordfile=/tmp/glassfishpwd enable-secure-admin
+asadmin --user=admin stop-domain
+rm /tmp/glassfishpwd
+exec "$@"

--- a/GlassFish/4.1.1/Dockerfile
+++ b/GlassFish/4.1.1/Dockerfile
@@ -1,12 +1,12 @@
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 # 
-# Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015-2017 Oracle and/or its affiliates. All rights reserved.
 # 
 # GlassFish on Docker with Oracle Linux and OpenJDK
 FROM oraclelinux:latest
 
 # Maintainer
-MAINTAINER Bruno Borges <bruno.borges@oracle.com>
+MAINTAINER Arindam Bandyopadhyay<arindam.bandyopadhyay@oracle.com>
 
 # Set environment variables and default password for user 'admin'
 ENV GLASSFISH_PKG=glassfish-4.1.1.zip \
@@ -14,28 +14,20 @@ ENV GLASSFISH_PKG=glassfish-4.1.1.zip \
     GLASSFISH_HOME=/glassfish4 \
     MD5=4e7ce65489347960e9797d2161e0ada2 \
     PATH=$PATH:/glassfish4/bin \
-    PASSWORD=glassfish \
     JAVA_HOME=/usr/lib/jvm/java-openjdk
 
 # Install packages, download and extract GlassFish
 # Setup password file
 # Enable DAS
-RUN yum -y install wget unzip java-1.8.0-openjdk-devel && \
+RUN yum -y install wget unzip java-1.7.0-openjdk-devel && \
     wget --quiet --no-check-certificate $GLASSFISH_URL && \
     echo "$MD5 *$GLASSFISH_PKG" | md5sum -c - && \
     unzip -o $GLASSFISH_PKG && \
     rm -f $GLASSFISH_PKG && \
-    yum -y remove wget unzip && rm -rf /var/cache/yum/* && \
-    echo "--- Setup the password file ---" && \
-    echo "AS_ADMIN_PASSWORD=" > /tmp/glassfishpwd && \
-    echo "AS_ADMIN_NEWPASSWORD=${PASSWORD}" >> /tmp/glassfishpwd  && \
-    echo "--- Enable DAS, change admin password, and secure admin access ---" && \
-    asadmin --user=admin --passwordfile=/tmp/glassfishpwd change-admin-password --domain_name domain1 && \
-    asadmin start-domain && \
-    echo "AS_ADMIN_PASSWORD=${PASSWORD}" > /tmp/glassfishpwd && \
-    asadmin --user=admin --passwordfile=/tmp/glassfishpwd enable-secure-admin && \
-    asadmin --user=admin stop-domain && \
-    rm /tmp/glassfishpwd
+    yum -y remove wget unzip && rm -rf /var/cache/yum/*
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 
 # Ports being exposed
 EXPOSE 4848 8080 8181

--- a/GlassFish/4.1.1/docker-entrypoint.sh
+++ b/GlassFish/4.1.1/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# 
+# Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+if [[ -z $ADMIN_PASSWORD ]]; then
+	ADMIN_PASSWORD=$(date| md5sum | fold -w 8 | head -n 1)
+	echo "##########GENERATED ADMIN PASSWORD: $ADMIN_PASSWORD  ##########"
+fi
+echo "AS_ADMIN_PASSWORD=" > /tmp/glassfishpwd
+echo "AS_ADMIN_NEWPASSWORD=${ADMIN_PASSWORD}" >> /tmp/glassfishpwd
+asadmin --user=admin --passwordfile=/tmp/glassfishpwd change-admin-password --domain_name domain1
+asadmin start-domain
+echo "AS_ADMIN_PASSWORD=${ADMIN_PASSWORD}" > /tmp/glassfishpwd
+asadmin --user=admin --passwordfile=/tmp/glassfishpwd enable-secure-admin
+asadmin --user=admin stop-domain
+rm /tmp/glassfishpwd
+exec "$@"

--- a/GlassFish/4.1.2-web/Dockerfile
+++ b/GlassFish/4.1.2-web/Dockerfile
@@ -1,6 +1,6 @@
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 # 
-# Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
 # 
 # GlassFish on Docker with Oracle Linux and OpenJDK
 FROM oraclelinux:latest
@@ -14,28 +14,20 @@ ENV GLASSFISH_PKG=glassfish-4.1.2-web.zip \
     GLASSFISH_HOME=/glassfish4 \
     MD5=6d0e8d860c451938bd671b27c5e348f2 \
     PATH=$PATH:/glassfish4/bin \
-    PASSWORD=glassfish \
     JAVA_HOME=/usr/lib/jvm/java-openjdk
 
 # Install packages, download and extract GlassFish
 # Setup password file
 # Enable DAS
-RUN yum -y install wget unzip java-1.8.0-openjdk-devel && \
+RUN yum -y install wget unzip java-1.7.0-openjdk-devel && \
     wget --quiet --no-check-certificate $GLASSFISH_URL && \
     echo "$MD5 *$GLASSFISH_PKG" | md5sum -c - && \
     unzip -o $GLASSFISH_PKG && \
     rm -f $GLASSFISH_PKG && \
-    yum -y remove wget unzip && rm -rf /var/cache/yum/* && \
-    echo "--- Setup the password file ---" && \
-    echo "AS_ADMIN_PASSWORD=" > /tmp/glassfishpwd && \
-    echo "AS_ADMIN_NEWPASSWORD=${PASSWORD}" >> /tmp/glassfishpwd  && \
-    echo "--- Enable DAS, change admin password, and secure admin access ---" && \
-    asadmin --user=admin --passwordfile=/tmp/glassfishpwd change-admin-password --domain_name domain1 && \
-    asadmin start-domain && \
-    echo "AS_ADMIN_PASSWORD=${PASSWORD}" > /tmp/glassfishpwd && \
-    asadmin --user=admin --passwordfile=/tmp/glassfishpwd enable-secure-admin && \
-    asadmin --user=admin stop-domain && \
-    rm /tmp/glassfishpwd
+    yum -y remove wget unzip && rm -rf /var/cache/yum/*
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 
 # Ports being exposed
 EXPOSE 4848 8080 8181

--- a/GlassFish/4.1.2-web/docker-entrypoint.sh
+++ b/GlassFish/4.1.2-web/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# 
+# Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+if [[ -z $ADMIN_PASSWORD ]]; then
+	ADMIN_PASSWORD=$(date| md5sum | fold -w 8 | head -n 1)
+	echo "##########GENERATED ADMIN PASSWORD: $ADMIN_PASSWORD  ##########"
+fi
+echo "AS_ADMIN_PASSWORD=" > /tmp/glassfishpwd
+echo "AS_ADMIN_NEWPASSWORD=${ADMIN_PASSWORD}" >> /tmp/glassfishpwd
+asadmin --user=admin --passwordfile=/tmp/glassfishpwd change-admin-password --domain_name domain1
+asadmin start-domain
+echo "AS_ADMIN_PASSWORD=${ADMIN_PASSWORD}" > /tmp/glassfishpwd
+asadmin --user=admin --passwordfile=/tmp/glassfishpwd enable-secure-admin
+asadmin --user=admin stop-domain
+rm /tmp/glassfishpwd
+exec "$@"

--- a/GlassFish/4.1.2/Dockerfile
+++ b/GlassFish/4.1.2/Dockerfile
@@ -13,7 +13,6 @@ ENV GLASSFISH_PKG=glassfish-4.1.2.zip \
     GLASSFISH_HOME=/glassfish4 \
     MD5=9a37928ea6e54334101b8a89e03a8d7d \
     PATH=$PATH:/glassfish4/bin \
-    PASSWORD=glassfish \
     JAVA_HOME=/usr/lib/jvm/java-openjdk
 
 # Install packages, download and extract GlassFish
@@ -24,17 +23,10 @@ RUN yum -y install wget unzip java-1.7.0-openjdk-devel && \
     echo "$MD5 *$GLASSFISH_PKG" | md5sum -c - && \
     unzip -o $GLASSFISH_PKG && \
     rm -f $GLASSFISH_PKG && \
-    yum -y remove wget unzip && rm -rf /var/cache/yum/* && \
-    echo "--- Setup the password file ---" && \
-    echo "AS_ADMIN_PASSWORD=" > /tmp/glassfishpwd && \
-    echo "AS_ADMIN_NEWPASSWORD=${PASSWORD}" >> /tmp/glassfishpwd  && \
-    echo "--- Enable DAS, change admin password, and secure admin access ---" && \
-    asadmin --user=admin --passwordfile=/tmp/glassfishpwd change-admin-password --domain_name domain1 && \
-    asadmin start-domain && \
-    echo "AS_ADMIN_PASSWORD=${PASSWORD}" > /tmp/glassfishpwd && \
-    asadmin --user=admin --passwordfile=/tmp/glassfishpwd enable-secure-admin && \
-    asadmin --user=admin stop-domain && \
-    rm /tmp/glassfishpwd
+    yum -y remove wget unzip && rm -rf /var/cache/yum/*
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 
 # Ports being exposed
 EXPOSE 4848 8080 8181

--- a/GlassFish/4.1.2/Dockerfile
+++ b/GlassFish/4.1.2/Dockerfile
@@ -7,6 +7,7 @@ FROM oraclelinux:latest
 
 # Maintainer
 MAINTAINER Arindam Bandyopadhyay<arindam.bandyopadhyay@oracle.com>
+
 # Set environment variables and default password for user 'admin'
 ENV GLASSFISH_PKG=glassfish-4.1.2.zip \
     GLASSFISH_URL=http://download.oracle.com/glassfish/4.1.2/release/glassfish-4.1.2.zip \

--- a/GlassFish/4.1.2/docker-entrypoint.sh
+++ b/GlassFish/4.1.2/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# 
+# Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+if [[ -z $ADMIN_PASSWORD ]]; then
+	ADMIN_PASSWORD=$(date| md5sum | fold -w 8 | head -n 1)
+	echo "##########GENERATED ADMIN PASSWORD: $ADMIN_PASSWORD  ##########"
+fi
+echo "AS_ADMIN_PASSWORD=" > /tmp/glassfishpwd
+echo "AS_ADMIN_NEWPASSWORD=${ADMIN_PASSWORD}" >> /tmp/glassfishpwd
+asadmin --user=admin --passwordfile=/tmp/glassfishpwd change-admin-password --domain_name domain1
+asadmin start-domain
+echo "AS_ADMIN_PASSWORD=${ADMIN_PASSWORD}" > /tmp/glassfishpwd
+asadmin --user=admin --passwordfile=/tmp/glassfishpwd enable-secure-admin
+asadmin --user=admin stop-domain
+rm /tmp/glassfishpwd
+exec "$@"


### PR DESCRIPTION
1. Auto generated and user provided password for Glassfish 4.1.2-web 4.1.1 and 4.1.1-web image
2.Updated 4.1.1 m 4.1.1-web 4.1.2-web to use jdk 1.7 as recommended jdk for glassfish 4.*.* is 1.7 