### PR TITLE
Allow for user defined passwords while still generating by default

### DIFF
--- a/OracleDatabase/README.md
+++ b/OracleDatabase/README.md
@@ -4,8 +4,8 @@ Sample Docker build files to facilitate installation, configuration, and environ
 
 ## How to build and run
 This project offers sample Dockerfiles for:
- * Oracle Database 12c Release 2 (12.2.0.1) Enterprise Edition and Standard Edition
- * Oracle Database 12c Release 1 (12.1.0.2) Enterprise Edition and Standard Edition
+ * Oracle Database 12c Release 2 (12.2.0.1) Enterprise Edition and Standard Edition 2
+ * Oracle Database 12c Release 1 (12.1.0.2) Enterprise Edition and Standard Edition 2
  * Oracle Database 11g Release 2 (11.2.0.2) Express Edition.
 
 To assist in building the images, you can use the [buildDockerImage.sh](dockerfiles/buildDockerImage.sh) script. See below for instructions and usage.
@@ -48,7 +48,7 @@ The character set for the database is set during creating of the database. 11g E
 
 ### Running Oracle Database in a Docker container
 
-#### Running Oracle Database Enterprise and Standard Edition in a Docker container
+#### Running Oracle Database Enterprise and Standard Edition 2 in a Docker container
 To run your Oracle Database Docker image use the **docker run** command as follows:
 
 	docker run --name <container name> \
@@ -87,9 +87,9 @@ The Oracle Database inside the container also has Oracle Enterprise Manager Expr
 
 #### Changing the admin accounts passwords
 
-On the first startup of the container a random password will be generated for the database. You can find this password in the output line:  
+On the first startup of the container a random password will be generated for the database if not provided. You can find this password in the output line:  
 	
-	ORACLE AUTO GENERATED PASSWORD FOR SYS, SYSTEM AND PDBAMIN:
+	ORACLE PASSWORD FOR SYS, SYSTEM AND PDBADMIN:
 
 The password for those accounts can be changed via the **docker exec** command. **Note**, the container has to be running:
 
@@ -101,24 +101,27 @@ To run your Oracle Database Express Edition Docker image use the **docker run** 
 	docker run --name <container name> \
 	--shm-size=1g \
 	-p 1521:1521 -p 8080:8080 \
+	-e ORACLE_PWD=<your database passwords> \
 	-v [<host mount point>:]/u01/app/oracle/oradata \
 	oracle/database:11.2.0.2-xe
 	
 	Parameters:
-	   --name:     The name of the container (default: auto generated)
-	   --shm-size: Amount of Linux shared memory
-	   -p:         The port mapping of the host port to the container port.
-	               Two ports are exposed: 1521 (Oracle Listener), 8080 (APEX)
-	   -v          The data volume to use for the database.
-	               Has to be owned by the Unix user "oracle" or set appropriately.
-	               If omitted the database will not be persisted over container recreation.
+	   --name:        The name of the container (default: auto generated)
+	   --shm-size:    Amount of Linux shared memory
+	   -p:            The port mapping of the host port to the container port.
+	                  Two ports are exposed: 1521 (Oracle Listener), 8080 (APEX)
+	   -e ORACLE_PWD: The Oracle Database SYS, SYSTEM and PDB_ADMIN password (default: auto generated)
+
+	   -v             The data volume to use for the database.
+	                  Has to be owned by the Unix user "oracle" or set appropriately.
+	                  If omitted the database will not be persisted over container recreation.
 
 There are two ports that are exposed in this image:
 * 1521 which is the port to connect to the Oracle Database.
 * 8080 which is the port of Oracle Application Express (APEX).
 
-On the first startup of the container a random password will be generated for the database. You can find this password in the output line:
-	ORACLE AUTO GENERATED PASSWORD FOR SYS AND SYSTEM:
+On the first startup of the container a random password will be generated for the database if not provided. You can find this password in the output line:
+	ORACLE PASSWORD FOR SYS AND SYSTEM:
 
 The password for those accounts can be changed via the **docker exec** command. **Note**, the container has to be running:
 	docker exec oraclexe /u01/app/oracle/setPassword.sh <your password>

--- a/OracleDatabase/README.md
+++ b/OracleDatabase/README.md
@@ -55,6 +55,7 @@ To run your Oracle Database Docker image use the **docker run** command as follo
 	-p <host port>:1521 -p <host port>:5500 \
 	-e ORACLE_SID=<your SID> \
 	-e ORACLE_PDB=<your PDB name> \
+	-e ORACLE_PWD=<your database passwords> \
 	-e ORACLE_CHARACTERSET=<your character set> \
 	-v [<host mount point>:]/opt/oracle/oradata \
 	oracle/database:12.2.0.1-ee
@@ -65,6 +66,7 @@ To run your Oracle Database Docker image use the **docker run** command as follo
 	                  Two ports are exposed: 1521 (Oracle Listener), 5500 (OEM Express)
 	   -e ORACLE_SID: The Oracle Database SID that should be used (default: ORCLCDB)
 	   -e ORACLE_PDB: The Oracle Database PDB name that should be used (default: ORCLPDB1)
+	   -e ORACLE_PWD: The Oracle Database SYS, SYSTEM and PDB_ADMIN password (default: auto generated)
 	   -e ORACLE_CHARACTERSET:
 	                  The character set to use when creating the database (default: AL32UTF8)
 	   -v             The data volume to use for the database.

--- a/OracleDatabase/dockerfiles/11.2.0.2/runOracle.sh
+++ b/OracleDatabase/dockerfiles/11.2.0.2/runOracle.sh
@@ -54,9 +54,9 @@ function _kill() {
 
 ############# Create DB ################
 function createDB {
-   # Auto generate ORACLE PWD
-   ORACLE_PWD=`openssl rand -hex 8`
-   echo "ORACLE AUTO GENERATED PASSWORD FOR SYS AND SYSTEM: $ORACLE_PWD";
+   # Auto generate ORACLE PWD if not passed on
+   export ORACLE_PWD=${ORACLE_PWD:-"`openssl rand -hex 8`"}
+   echo "ORACLE PASSWORD FOR SYS AND SYSTEM: $ORACLE_PWD";
 
    sed -i -e "s|###ORACLE_PWD###|$ORACLE_PWD|g" $ORACLE_BASE/$CONFIG_RSP && \
    /etc/init.d/oracle-xe configure responseFile=$ORACLE_BASE/$CONFIG_RSP

--- a/OracleDatabase/dockerfiles/11.2.0.2/runOracle.sh
+++ b/OracleDatabase/dockerfiles/11.2.0.2/runOracle.sh
@@ -97,14 +97,6 @@ EOF"
 
 ############# MAIN ################
 
-# Check whether container has enough memory
-if [ `df -k /dev/shm | tail -n 1 | awk '{print $2}'` -lt 1048576 ]; then
-   echo "Error: The container doesn't have enough memory allocated."
-   echo "A database XE container needs at least 1 GB of shared memory (/dev/shm)."
-   echo "You currently only have $((`df -k /dev/shm | tail -n 1 | awk '{print $2}'`/1024)) MB allocated to the container."
-   exit 1;
-fi;
-
 # Set SIGTERM handler
 trap _term SIGTERM
 
@@ -122,6 +114,15 @@ fi;
 
 /etc/init.d/oracle-xe start | grep -qc "Oracle Database 11g Express Edition is not configured"
 if [ "$?" == "0" ]; then
+   # Check whether container has enough memory
+   if [ `df -k /dev/shm | tail -n 1 | awk '{print $2}'` -lt 1048576 ]; then
+      echo "Error: The container doesn't have enough memory allocated."
+      echo "A database XE container needs at least 1 GB of shared memory (/dev/shm)."
+      echo "You currently only have $((`df -k /dev/shm | tail -n 1 | awk '{print $2}'`/1024)) MB allocated to the container."
+      exit 1;
+   fi;
+   
+   # Create database
    createDB;
 fi;
 

--- a/OracleDatabase/dockerfiles/12.1.0.2/createDB.sh
+++ b/OracleDatabase/dockerfiles/12.1.0.2/createDB.sh
@@ -22,7 +22,7 @@ export ORACLE_PDB=${2:-ORCLPDB1}
 
 # Auto generate ORACLE PWD if not passed on
 export ORACLE_PWD=${3:-"`openssl rand -base64 8`1"}
-echo "ORACLE PASSWORD FOR SYS, SYSTEM AND PDBAMIN: $ORACLE_PWD";
+echo "ORACLE PASSWORD FOR SYS, SYSTEM AND PDBADMIN: $ORACLE_PWD";
 
 # Replace place holders in response file
 cp $ORACLE_BASE/$CONFIG_RSP $ORACLE_BASE/dbca.rsp

--- a/OracleDatabase/dockerfiles/12.1.0.2/createDB.sh
+++ b/OracleDatabase/dockerfiles/12.1.0.2/createDB.sh
@@ -8,26 +8,21 @@
 # Description: Creates an Oracle Database based on following parameters:
 #              $ORACLE_SID: The Oracle SID and CDB name
 #              $ORACLE_PDB: The PDB name
+#              $ORACLE_PWD: The Oracle password
 # 
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 # 
 
 
-ORACLE_SID=$1
 # Check whether ORACLE_SID is passed on
-if [ "$ORACLE_SID" == "" ]; then
-  ORACLE_SID=ORCLCDB
-fi;
+export ORACLE_SID=${1:-ORCLCDB}
 
-ORACLE_PDB=$2
 # Check whether ORACLE_PDB is passed on
-if [ "$ORACLE_PDB" == "" ]; then
-  ORACLE_PDB=ORCLPDB1
-fi;
+export ORACLE_PDB=${2:-ORCLPDB1}
 
-# Auto generate ORACLE PWD
-ORACLE_PWD="`openssl rand -base64 8`1"
-echo "ORACLE AUTO GENERATED PASSWORD FOR SYS, SYSTEM AND PDBAMIN: $ORACLE_PWD";
+# Auto generate ORACLE PWD if not passed on
+export ORACLE_PWD=${3:-"`openssl rand -base64 8`1"}
+echo "ORACLE PASSWORD FOR SYS, SYSTEM AND PDBAMIN: $ORACLE_PWD";
 
 # Replace place holders in response file
 cp $ORACLE_BASE/$CONFIG_RSP $ORACLE_BASE/dbca.rsp

--- a/OracleDatabase/dockerfiles/12.1.0.2/runOracle.sh
+++ b/OracleDatabase/dockerfiles/12.1.0.2/runOracle.sh
@@ -126,14 +126,10 @@ else
 fi;
 
 # Default for ORACLE PDB
-if [ "$ORACLE_PDB" == "" ]; then
-   export ORACLE_PDB=ORCLPDB1
-fi;
+export ORACLE_PDB=${ORACLE_PDB:-ORCLPDB1}
 
 # Default for ORACLE CHARACTERSET
-if [ "$ORACLE_CHARACTERSET" == "" ]; then
-   export ORACLE_CHARACTERSET=AL32UTF8
-fi;
+export ORACLE_CHARACTERSET=${ORACLE_CHARACTERSET:-AL32UTF8}
 
 # Check whether database already exists
 if [ -d $ORACLE_BASE/oradata/$ORACLE_SID ]; then
@@ -154,7 +150,7 @@ else
    rm -f $ORACLE_HOME/network/admin/tnsnames.ora
    
    # Create database
-   $ORACLE_BASE/$CREATE_DB_FILE $ORACLE_SID $ORACLE_PDB;
+   $ORACLE_BASE/$CREATE_DB_FILE $ORACLE_SID $ORACLE_PDB $ORACLE_PWD;
    
    # Move database operational files to oradata
    moveFiles;

--- a/OracleDatabase/dockerfiles/12.2.0.1/createDB.sh
+++ b/OracleDatabase/dockerfiles/12.2.0.1/createDB.sh
@@ -22,7 +22,7 @@ export ORACLE_PDB=${2:-ORCLPDB1}
 
 # Auto generate ORACLE PWD if not passed on
 export ORACLE_PWD=${3:-"`openssl rand -base64 8`1"}
-echo "ORACLE PASSWORD FOR SYS, SYSTEM AND PDBAMIN: $ORACLE_PWD";
+echo "ORACLE PASSWORD FOR SYS, SYSTEM AND PDBADMIN: $ORACLE_PWD";
 
 # Replace place holders in response file
 cp $ORACLE_BASE/$CONFIG_RSP $ORACLE_BASE/dbca.rsp

--- a/OracleDatabase/dockerfiles/12.2.0.1/createDB.sh
+++ b/OracleDatabase/dockerfiles/12.2.0.1/createDB.sh
@@ -8,26 +8,21 @@
 # Description: Creates an Oracle Database based on following parameters:
 #              $ORACLE_SID: The Oracle SID and CDB name
 #              $ORACLE_PDB: The PDB name
+#              $ORACLE_PWD: The Oracle password
 # 
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 # 
 
 
-ORACLE_SID=$1
 # Check whether ORACLE_SID is passed on
-if [ "$ORACLE_SID" == "" ]; then
-  ORACLE_SID=ORCLCDB
-fi;
+export ORACLE_SID=${1:-ORCLCDB}
 
-ORACLE_PDB=$2
 # Check whether ORACLE_PDB is passed on
-if [ "$ORACLE_PDB" == "" ]; then
-  ORACLE_PDB=ORCLPDB1
-fi;
+export ORACLE_PDB=${2:-ORCLPDB1}
 
-# Auto generate ORACLE PWD
-ORACLE_PWD="`openssl rand -base64 8`1"
-echo "ORACLE AUTO GENERATED PASSWORD FOR SYS, SYSTEM AND PDBAMIN: $ORACLE_PWD";
+# Auto generate ORACLE PWD if not passed on
+export ORACLE_PWD=${3:-"`openssl rand -base64 8`1"}
+echo "ORACLE PASSWORD FOR SYS, SYSTEM AND PDBAMIN: $ORACLE_PWD";
 
 # Replace place holders in response file
 cp $ORACLE_BASE/$CONFIG_RSP $ORACLE_BASE/dbca.rsp

--- a/OracleDatabase/dockerfiles/12.2.0.1/runOracle.sh
+++ b/OracleDatabase/dockerfiles/12.2.0.1/runOracle.sh
@@ -126,14 +126,10 @@ else
 fi;
 
 # Default for ORACLE PDB
-if [ "$ORACLE_PDB" == "" ]; then
-   export ORACLE_PDB=ORCLPDB1
-fi;
+export ORACLE_PDB=${ORACLE_PDB:-ORCLPDB1}
 
 # Default for ORACLE CHARACTERSET
-if [ "$ORACLE_CHARACTERSET" == "" ]; then
-   export ORACLE_CHARACTERSET=AL32UTF8
-fi;
+export ORACLE_CHARACTERSET=${ORACLE_CHARACTERSET:-AL32UTF8}
 
 # Check whether database already exists
 if [ -d $ORACLE_BASE/oradata/$ORACLE_SID ]; then
@@ -154,7 +150,7 @@ else
    rm -f $ORACLE_HOME/network/admin/tnsnames.ora
    
    # Create database
-   $ORACLE_BASE/$CREATE_DB_FILE $ORACLE_SID $ORACLE_PDB;
+   $ORACLE_BASE/$CREATE_DB_FILE $ORACLE_SID $ORACLE_PDB $ORACLE_PWD;
    
    # Move database operational files to oradata
    moveFiles;


### PR DESCRIPTION
The Docker images now support user defined passwords. If a user wants to specify a password the images will automatically pick it up via the environment variable `ORACLE_PWD`. By default, the password is still auto generated and this is the preferred secure method. That is, create the container with an auto generated password and reset the password once the container is running.

This change also makes extending the image easier by being able to pass on a password which is used by the upper stack.