### PR TITLE
Amend Coherence images to make them runnable

### DIFF
--- a/OracleCoherence/README.md
+++ b/OracleCoherence/README.md
@@ -49,16 +49,18 @@ Follow this procedure:
 
 5. The resulting image file will be called oracle/coherence:${version}-${distribution}, for example if the Standalone installer is used the image will be `oracle/coherence:12.2.1.0.0-standalone`
 
+6. The image is built with a shell script as its ENTRYPOINT that allows the image to be run using the normal Docker run command. See the [Image Usage](00.imageusage) documentation.
+
 ## Documentation
 Documentation covering the different aspects of running Oracle Coherence in Docker containers is covered in the [docs](docs) section.
 
-1. [Setup](docs/0.setup) - Setting up a demo Docker Machine environment
-2. [Clustering](docs/1.clustering) - Running Coherence Clusters in Docker
-3. [Coherence Extend](docs/2.extend) - Running Coherence Extend in Docker
-4. [Federated Caching](docs/3.federation) - Federated Caching in Docker
-5. [Disc Based Functionality](docs/4.disc_based) - Elastic Data and Persistence in Docker
-6. [JMX Monitoring](docs/5.monitoring) - Using JMX in Docker
-
+1. [Image Usage](00.imageusage) - Usage instructions for running the Coherence image
+2. [Setup](0.setup) - Setting Up a Demo Docker Machine Environment
+3. [Clustering](1.clustering) - Running Coherence Clusters in Docker
+4. [Coherence Extend](2.extend) - Running Coherence Extend in Docker
+5. [Federated Caching](3.federation) - Federated Caching in Docker
+6. [Disc Based Functionality](4.disc_based) - Elastic Data and Persistence in Docker
+7. [JMX Monitoring](5.monitoring) - Using JMX in Docker
 
 ## Issues
 If you find any issues with this Docker project, please report through the [GitHub Issues page](https://github.com/oracle/docker-images/issues).

--- a/OracleCoherence/dockerfiles/12.2.1.0.0/Dockerfile.quickinstall
+++ b/OracleCoherence/dockerfiles/12.2.1.0.0/Dockerfile.quickinstall
@@ -44,14 +44,22 @@ ENV COHERENCE_HOME=$ORACLE_HOME/coherence
 
 # Copy files required to build this image
 COPY $FMW_PKG install.file oraInst.loc /u01/
+COPY start.sh                          /start.sh
+COPY extend-cache-config.xml           $COHERENCE_HOME/conf/extend-cache-config.xml
+
+RUN useradd -b /u01 -m -s /bin/bash oracle && \
+   echo oracle:oracle | chpasswd && \
+   chmod +x /start.sh && \
+   chmod a+xr /u01 && \
+   chown -R oracle:oracle /u01
+
+USER oracle
 
 # Install and configure Oracle JDK
 # Setup required packages (unzip), filesystem, and oracle user
 # ------------------------------------------------------------
-RUN chmod a+xr /u01 && \
-    useradd -b /u01 -m -s /bin/bash oracle && \
-    echo oracle:oracle | chpasswd && \
-    cd /u01 && $JAVA_HOME/bin/jar xf /u01/$FMW_PKG && cd - && \
-    su -c "$JAVA_HOME/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME" - oracle && \
-    chown oracle:oracle -R /u01 && \
+RUN cd /u01 && $JAVA_HOME/bin/jar xf /u01/$FMW_PKG && cd - && \
+    $JAVA_HOME/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME && \
     rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file
+
+ENTRYPOINT ["/start.sh"]

--- a/OracleCoherence/dockerfiles/12.2.1.0.0/extend-cache-config.xml
+++ b/OracleCoherence/dockerfiles/12.2.1.0.0/extend-cache-config.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0"?>
+
+<!--
+This XML document is a default Coherence Cache Configuration deployment descriptor that should be
+customized (or replaced) for your particular caching and deployment requirements.
+
+This configuration is usable in servers, proxies, clustered clients, and non-clustered extend clients.
+
+When used from within a server such a DefaultCacheServer, the server will automatically host a storage enabled cache
+service as well as a proxy service to allow extend clients to access the caches.  Clients using the configuration are
+storage disabled by default.
+
+This configuration defines a number of inter-related cache schemes:
+
+ - server      - this scheme defines the storage tier for all caches
+ - thin-direct - this scheme is for use by cluster members to access the caches hosted by the "server" scheme
+ - near-direct - this scheme adds near caching to "thin-direct"
+ - thin-remote - conceptually similar to "thin-direct" but for use by extend clients
+ - near-remote - conceptually similar to "near-direct" but for use by extend clients
+
+The default scheme for caches is "near-direct".  This default can be overridden via two system properties.  The
+"coherence.profile" system property controls the first portion of the scheme name and defines the approach used for
+in-process caching, i.e. "near" (on-demand) or "thin" (none).  The "coherence.client" system property controls how a
+client connects to the cluster, i.e. "direct" (cluster member) or "remote" (extend client).
+
+Note: System properties defined within this cache configuration are specific to this configuration and are not
+meaningful to other cache configurations unless similarly defined there.
+-->
+<cache-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xmlns="http://xmlns.oracle.com/coherence/coherence-cache-config"
+              xsi:schemaLocation="http://xmlns.oracle.com/coherence/coherence-cache-config coherence-cache-config.xsd">
+  <caching-scheme-mapping>
+    <cache-mapping>
+      <cache-name>*</cache-name>
+      <scheme-name>${coherence.profile near}-${coherence.client direct}</scheme-name>
+    </cache-mapping>
+  </caching-scheme-mapping>
+
+  <caching-schemes>
+    <!-- near caching scheme for clustered clients -->
+    <near-scheme>
+      <scheme-name>near-direct</scheme-name>
+      <front-scheme>
+        <local-scheme>
+          <high-units>{front-limit-entries 10000}</high-units>
+        </local-scheme>
+      </front-scheme>
+      <back-scheme>
+        <distributed-scheme>
+          <scheme-ref>thin-direct</scheme-ref>
+        </distributed-scheme>
+      </back-scheme>
+    </near-scheme>
+
+    <!-- near caching scheme for extend clients -->
+    <near-scheme>
+      <scheme-name>near-remote</scheme-name>
+      <scheme-ref>near-direct</scheme-ref>
+      <back-scheme>
+        <remote-cache-scheme>
+          <scheme-ref>thin-remote</scheme-ref>
+        </remote-cache-scheme>
+      </back-scheme>
+    </near-scheme>
+
+    <!-- remote caching scheme for accessing the proxy from extend clients -->
+    <remote-cache-scheme>
+      <scheme-name>thin-remote</scheme-name>
+      <service-name>RemoteCache</service-name>
+      <proxy-service-name>Proxy</proxy-service-name>
+    </remote-cache-scheme>
+
+    <!-- partitioned caching scheme for clustered clients -->
+    <distributed-scheme>
+      <scheme-name>thin-direct</scheme-name>
+      <scheme-ref>server</scheme-ref>
+      <local-storage system-property="coherence.distributed.localstorage">false</local-storage>
+      <autostart>false</autostart>
+    </distributed-scheme>
+
+    <!-- partitioned caching scheme for servers -->
+    <distributed-scheme>
+      <scheme-name>server</scheme-name>
+      <service-name>PartitionedCache</service-name>
+      <local-storage system-property="coherence.distributed.localstorage">true</local-storage>
+      <backing-map-scheme>
+        <local-scheme>
+          <high-units>{back-limit-bytes 0B}</high-units>
+        </local-scheme>
+      </backing-map-scheme>
+      <autostart>true</autostart>
+    </distributed-scheme>
+
+    <!-- proxy scheme that allows extend clients to connect to the cluster over TCP/IP -->
+    <proxy-scheme>
+      <service-name>Proxy</service-name>
+      <acceptor-config>
+        <tcp-acceptor>
+          <local-address>
+            <address system-property="coherence.extend.address"/>
+            <port system-property="coherence.extend.port"/>
+          </local-address>
+        </tcp-acceptor>
+      </acceptor-config>
+      <autostart>true</autostart>
+    </proxy-scheme>
+  </caching-schemes>
+</cache-config>

--- a/OracleCoherence/dockerfiles/12.2.1.0.0/start.sh
+++ b/OracleCoherence/dockerfiles/12.2.1.0.0/start.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env sh
+
+#!/bin/sh -e -x -u
+
+trap "echo TRAPed signal" HUP INT QUIT KILL TERM
+
+main() {
+
+    COMMAND=server
+    SCRIPT_NAME=$(basename "${0}")
+    MAIN_CLASS="com.tangosol.net.DefaultCacheServer"
+
+    case "${1}" in
+        server) COMMAND=${1}; shift ;;
+        console) COMMAND=${1}; shift ;;
+        queryplus) COMMAND=queryPlus; shift ;;
+        help) COMMAND=${1}; shift ;;
+    esac
+
+    case ${COMMAND} in
+        server) server ;;
+        console) console ;;
+        queryPlus) queryPlus ;;
+        help) usage; exit ;;
+        *) server ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Display the help text for this script
+# ---------------------------------------------------------------------------
+usage() {
+    echo "Usage: ${SCRIPT_NAME} [type] [args]"
+    echo ""
+    echo "type: - the type of process to run, must be one of:"
+    echo "    server  - runs a storage enabled DefaultCacheServer"
+    echo "              (server is the default if type is omitted)"
+    echo "    console - runs a storage disabled Coherence console"
+    echo "    query   - runs a storage disabled QueryPlus session"
+    echo "    help    - displays this usage text"
+    echo ""
+    echo "args: - any subsequent arguments are passed as program args to the main class"
+    echo ""
+    echo "Environment Variables: The following environment variables affect the script operation"
+    echo ""
+    echo "JAVA_OPTS       - this environment variable adds Java options to the start command,"
+    echo "                  for example memory and other system properties"
+    echo ""
+    echo "COH_WKA         - Sets the WKA address to use to discover a Coherence cluster."
+    echo ""
+    echo "COH_EXTEND_PORT - If set the Extend Proxy Service will listen on this port instead"
+    echo "                  of the default ephemeral port."
+    echo ""
+    echo "Any jar files added to the /lib folder will be pre-pended to the classpath."
+    echo "The /conf folder is on the classpath so any files in this folder can be loaded by the process."
+    echo ""
+}
+
+server() {
+    PROPS=""
+    CLASSPATH=""
+    MAIN_CLASS="com.tangosol.net.DefaultCacheServer"
+    start
+}
+
+console() {
+    PROPS="-Dcoherence.localstorage=false"
+    CLASSPATH=""
+    MAIN_CLASS="com.tangosol.net.CacheFactory"
+    start
+}
+
+queryPlus() {
+    PROPS="-Dcoherence.localstorage=false"
+    CLASSPATH="${COHERENCE_HOME}/lib/jline.jar"
+    MAIN_CLASS="com.tangosol.coherence.dslquery.QueryPlus"
+    start
+}
+
+start() {
+
+    if [ "${COH_WKA}" != "" ]
+    then
+       PROPS="${PROPS} -Dcoherence.wka=${COH_WKA}"
+    fi
+
+    if [ "${COH_EXTEND_PORT}" != "" ]
+    then
+       PROPS="${PROPS} -Dcoherence.cacheconfig=extend-cache-config.xml -Dcoherence.extend.port=${COH_EXTEND_PORT}"
+    fi
+
+    CLASSPATH="/conf:/lib/*:${CLASSPATH}:${COHERENCE_HOME}/conf:${COHERENCE_HOME}/lib/coherence.jar"
+
+    CMD="${JAVA_HOME}/bin/java -cp ${CLASSPATH} ${PROPS} ${JAVA_OPTS} ${MAIN_CLASS} ${COH_MAIN_ARGS}"
+
+    echo "Starting Coherence ${COMMAND} using ${CMD}"
+
+    exec ${CMD}
+}
+
+main "$@"

--- a/OracleCoherence/dockerfiles/12.2.1.2.0/Dockerfile.quickinstall
+++ b/OracleCoherence/dockerfiles/12.2.1.2.0/Dockerfile.quickinstall
@@ -2,7 +2,7 @@
 #
 # ORACLE DOCKERFILES PROJECT
 # --------------------------
-# This is the Dockerfile for Coherence 12.2.1 Standalone Distribution
+# This is the Dockerfile for Coherence 12.2.1 Quick Install Distribution
 # 
 # REQUIRED BASE IMAGE TO BUILD THIS IMAGE
 # ---------------------------------------
@@ -11,18 +11,18 @@
 #
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
-# (1) fmw_12.2.1.0.0_coherence_Disk1_1of1.zip
+# (1) fmw_12.2.1.2.0_coherence_quick_Disk1_1of1
 #
-#     Download the Standalone installer from http://www.oracle.com/technetwork/middleware/coherence/downloads/index.html
+#     Download the Quick installer from http://www.oracle.com/technetwork/middleware/coherence/downloads/index.html
 #
 # HOW TO BUILD THIS IMAGE
 # -----------------------
 # Put all downloaded files in the same directory as this Dockerfile
 # Run: 
-#      $ sh buildDockerImage.sh -s
+#      $ sh buildDockerImage.sh -q
 #
 # or if your Docker client requires root access you can run:
-#      $ sudo sh buildDockerImage.sh -s
+#      $ sudo sh buildDockerImage.sh -q
 #
 
 # Pull base image
@@ -34,8 +34,8 @@ FROM oracle/serverjre:8
 MAINTAINER Jonathan Knight
 
 # Environment variables required for this build (do NOT change)
-ENV FMW_PKG=fmw_12.2.1.0.0_coherence_Disk1_1of1.zip \
-    FMW_JAR=fmw_12.2.1.0.0_coherence.jar \
+ENV FMW_PKG=fmw_12.2.1.2.0_coherence_quick_Disk1_1of1.zip \
+    FMW_JAR=fmw_12.2.1.2.0_coherence_quick.jar \
     ORACLE_HOME=/u01/oracle/oracle_home \
     PATH=$PATH:/usr/java/default/bin:/u01/oracle/oracle_home/oracle_common/common/bin \
     CONFIG_JVM_ARGS="-Djava.security.egd=file:/dev/./urandom"

--- a/OracleCoherence/dockerfiles/12.2.1.2.0/Dockerfile.standalone
+++ b/OracleCoherence/dockerfiles/12.2.1.2.0/Dockerfile.standalone
@@ -11,7 +11,7 @@
 #
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
-# (1) fmw_12.2.1.0.0_coherence_Disk1_1of1.zip
+# (1) fmw_12.2.1.2.0_coherence_Disk1_1of1.zip
 #
 #     Download the Standalone installer from http://www.oracle.com/technetwork/middleware/coherence/downloads/index.html
 #
@@ -34,8 +34,8 @@ FROM oracle/serverjre:8
 MAINTAINER Jonathan Knight
 
 # Environment variables required for this build (do NOT change)
-ENV FMW_PKG=fmw_12.2.1.0.0_coherence_Disk1_1of1.zip \
-    FMW_JAR=fmw_12.2.1.0.0_coherence.jar \
+ENV FMW_PKG=fmw_12.2.1.2.0_coherence_Disk1_1of1.zip \
+    FMW_JAR=fmw_12.2.1.2.0_coherence.jar \
     ORACLE_HOME=/u01/oracle/oracle_home \
     PATH=$PATH:/usr/java/default/bin:/u01/oracle/oracle_home/oracle_common/common/bin \
     CONFIG_JVM_ARGS="-Djava.security.egd=file:/dev/./urandom"

--- a/OracleCoherence/dockerfiles/12.2.1.2.0/extend-cache-config.xml
+++ b/OracleCoherence/dockerfiles/12.2.1.2.0/extend-cache-config.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0"?>
+
+<!--
+This XML document is a default Coherence Cache Configuration deployment descriptor that should be
+customized (or replaced) for your particular caching and deployment requirements.
+
+This configuration is usable in servers, proxies, clustered clients, and non-clustered extend clients.
+
+When used from within a server such a DefaultCacheServer, the server will automatically host a storage enabled cache
+service as well as a proxy service to allow extend clients to access the caches.  Clients using the configuration are
+storage disabled by default.
+
+This configuration defines a number of inter-related cache schemes:
+
+ - server      - this scheme defines the storage tier for all caches
+ - thin-direct - this scheme is for use by cluster members to access the caches hosted by the "server" scheme
+ - near-direct - this scheme adds near caching to "thin-direct"
+ - thin-remote - conceptually similar to "thin-direct" but for use by extend clients
+ - near-remote - conceptually similar to "near-direct" but for use by extend clients
+
+The default scheme for caches is "near-direct".  This default can be overridden via two system properties.  The
+"coherence.profile" system property controls the first portion of the scheme name and defines the approach used for
+in-process caching, i.e. "near" (on-demand) or "thin" (none).  The "coherence.client" system property controls how a
+client connects to the cluster, i.e. "direct" (cluster member) or "remote" (extend client).
+
+Note: System properties defined within this cache configuration are specific to this configuration and are not
+meaningful to other cache configurations unless similarly defined there.
+-->
+<cache-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xmlns="http://xmlns.oracle.com/coherence/coherence-cache-config"
+              xsi:schemaLocation="http://xmlns.oracle.com/coherence/coherence-cache-config coherence-cache-config.xsd">
+  <caching-scheme-mapping>
+    <cache-mapping>
+      <cache-name>*</cache-name>
+      <scheme-name>${coherence.profile near}-${coherence.client direct}</scheme-name>
+    </cache-mapping>
+  </caching-scheme-mapping>
+
+  <caching-schemes>
+    <!-- near caching scheme for clustered clients -->
+    <near-scheme>
+      <scheme-name>near-direct</scheme-name>
+      <front-scheme>
+        <local-scheme>
+          <high-units>{front-limit-entries 10000}</high-units>
+        </local-scheme>
+      </front-scheme>
+      <back-scheme>
+        <distributed-scheme>
+          <scheme-ref>thin-direct</scheme-ref>
+        </distributed-scheme>
+      </back-scheme>
+    </near-scheme>
+
+    <!-- near caching scheme for extend clients -->
+    <near-scheme>
+      <scheme-name>near-remote</scheme-name>
+      <scheme-ref>near-direct</scheme-ref>
+      <back-scheme>
+        <remote-cache-scheme>
+          <scheme-ref>thin-remote</scheme-ref>
+        </remote-cache-scheme>
+      </back-scheme>
+    </near-scheme>
+
+    <!-- remote caching scheme for accessing the proxy from extend clients -->
+    <remote-cache-scheme>
+      <scheme-name>thin-remote</scheme-name>
+      <service-name>RemoteCache</service-name>
+      <proxy-service-name>Proxy</proxy-service-name>
+    </remote-cache-scheme>
+
+    <!-- partitioned caching scheme for clustered clients -->
+    <distributed-scheme>
+      <scheme-name>thin-direct</scheme-name>
+      <scheme-ref>server</scheme-ref>
+      <local-storage system-property="coherence.distributed.localstorage">false</local-storage>
+      <autostart>false</autostart>
+    </distributed-scheme>
+
+    <!-- partitioned caching scheme for servers -->
+    <distributed-scheme>
+      <scheme-name>server</scheme-name>
+      <service-name>PartitionedCache</service-name>
+      <local-storage system-property="coherence.distributed.localstorage">true</local-storage>
+      <backing-map-scheme>
+        <local-scheme>
+          <high-units>{back-limit-bytes 0B}</high-units>
+        </local-scheme>
+      </backing-map-scheme>
+      <autostart>true</autostart>
+    </distributed-scheme>
+
+    <!-- proxy scheme that allows extend clients to connect to the cluster over TCP/IP -->
+    <proxy-scheme>
+      <service-name>Proxy</service-name>
+      <acceptor-config>
+        <tcp-acceptor>
+          <local-address>
+            <address system-property="coherence.extend.address"/>
+            <port system-property="coherence.extend.port"/>
+          </local-address>
+        </tcp-acceptor>
+      </acceptor-config>
+      <autostart>true</autostart>
+    </proxy-scheme>
+  </caching-schemes>
+</cache-config>

--- a/OracleCoherence/dockerfiles/12.2.1.2.0/install.file
+++ b/OracleCoherence/dockerfiles/12.2.1.2.0/install.file
@@ -1,0 +1,13 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# 
+# Copyright (c) 2016 Oracle and/or its affiliates. All rights reserved.
+[ENGINE]
+
+#DO NOT CHANGE THIS.
+Response File Version=1.0.0.0.0
+
+[GENERIC]
+
+DECLINE_AUTO_UPDATES=true
+ORACLE_HOME=/u01/oracle/oracle_home
+INSTALL_TYPE=Typical

--- a/OracleCoherence/dockerfiles/12.2.1.2.0/oraInst.loc
+++ b/OracleCoherence/dockerfiles/12.2.1.2.0/oraInst.loc
@@ -1,0 +1,2 @@
+inventory_loc=/u01/oracle/.inventory
+inst_group=oracle

--- a/OracleCoherence/dockerfiles/12.2.1.2.0/start.sh
+++ b/OracleCoherence/dockerfiles/12.2.1.2.0/start.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env sh
+
+#!/bin/sh -e -x -u
+
+trap "echo TRAPed signal" HUP INT QUIT KILL TERM
+
+main() {
+
+    COMMAND=server
+    SCRIPT_NAME=$(basename "${0}")
+    MAIN_CLASS="com.tangosol.net.DefaultCacheServer"
+
+    case "${1}" in
+        server) COMMAND=${1}; shift ;;
+        console) COMMAND=${1}; shift ;;
+        queryplus) COMMAND=queryPlus; shift ;;
+        help) COMMAND=${1}; shift ;;
+    esac
+
+    case ${COMMAND} in
+        server) server ;;
+        console) console ;;
+        queryPlus) queryPlus ;;
+        help) usage; exit ;;
+        *) server ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Display the help text for this script
+# ---------------------------------------------------------------------------
+usage() {
+    echo "Usage: ${SCRIPT_NAME} [type] [args]"
+    echo ""
+    echo "type: - the type of process to run, must be one of:"
+    echo "    server  - runs a storage enabled DefaultCacheServer"
+    echo "              (server is the default if type is omitted)"
+    echo "    console - runs a storage disabled Coherence console"
+    echo "    query   - runs a storage disabled QueryPlus session"
+    echo "    help    - displays this usage text"
+    echo ""
+    echo "args: - any subsequent arguments are passed as program args to the main class"
+    echo ""
+    echo "Environment Variables: The following environment variables affect the script operation"
+    echo ""
+    echo "JAVA_OPTS       - this environment variable adds Java options to the start command,"
+    echo "                  for example memory and other system properties"
+    echo ""
+    echo "COH_WKA         - Sets the WKA address to use to discover a Coherence cluster."
+    echo ""
+    echo "COH_EXTEND_PORT - If set the Extend Proxy Service will listen on this port instead"
+    echo "                  of the default ephemeral port."
+    echo ""
+    echo "Any jar files added to the /lib folder will be pre-pended to the classpath."
+    echo "The /conf folder is on the classpath so any files in this folder can be loaded by the process."
+    echo ""
+}
+
+server() {
+    PROPS=""
+    CLASSPATH=""
+    MAIN_CLASS="com.tangosol.net.DefaultCacheServer"
+    start
+}
+
+console() {
+    PROPS="-Dcoherence.localstorage=false"
+    CLASSPATH=""
+    MAIN_CLASS="com.tangosol.net.CacheFactory"
+    start
+}
+
+queryPlus() {
+    PROPS="-Dcoherence.localstorage=false"
+    CLASSPATH="${COHERENCE_HOME}/lib/jline.jar"
+    MAIN_CLASS="com.tangosol.coherence.dslquery.QueryPlus"
+    start
+}
+
+start() {
+
+    if [ "${COH_WKA}" != "" ]
+    then
+       PROPS="${PROPS} -Dcoherence.wka=${COH_WKA}"
+    fi
+
+    if [ "${COH_EXTEND_PORT}" != "" ]
+    then
+       PROPS="${PROPS} -Dcoherence.cacheconfig=extend-cache-config.xml -Dcoherence.extend.port=${COH_EXTEND_PORT}"
+    fi
+
+    CLASSPATH="/conf:/lib/*:${CLASSPATH}:${COHERENCE_HOME}/conf:${COHERENCE_HOME}/lib/coherence.jar"
+
+    CMD="${JAVA_HOME}/bin/java -cp ${CLASSPATH} ${PROPS} ${JAVA_OPTS} ${MAIN_CLASS} ${COH_MAIN_ARGS}"
+
+    echo "Starting Coherence ${COMMAND} using ${CMD}"
+
+    exec ${CMD}
+}
+
+main "$@"

--- a/OracleCoherence/dockerfiles/buildDockerImage.sh
+++ b/OracleCoherence/dockerfiles/buildDockerImage.sh
@@ -12,7 +12,7 @@
 usage() {
 cat << EOF
 
-Usage: buildDockerImage.sh -v [version] [-q | -s] [-s]
+Usage: buildDockerImage.sh -v [version] [-q | -s]
 Builds a Docker Image for Oracle Coherence.
   
 Parameters:

--- a/OracleCoherence/docs/00.imageusage/README.md
+++ b/OracleCoherence/docs/00.imageusage/README.md
@@ -1,0 +1,99 @@
+#Running the Coherence Docker Image
+
+##Start a Basic Storage Enabled DefaultCacheServer
+If the Coherence Docker image is run out of the box using Docker run then by default this will start a storage enabled DefaultCacheServer process. The script in the image uses arguments and environment variables to control its operations. The full run command format is
+
+```
+docker run [docker-args] \
+   [-e COH_WKA=<wka-address>] \
+   [-e JAVA_OPTS=<opts>] \
+   [-e COH_EXTEND_PORT=<port>] \
+   [-v <lib-dir>:/lib ] \
+   [-v <config-dir>:/conf] \
+   oracle/coherence:12.2.1.2 [type] [args]
+```
+
+All of the arguments shown above are optional. For example:
+ 
+`docker run -d oracle/coherence:12.2.1.1.0`
+
+The above command will start a storage enabled DefaultCacheServer.
+
+##Clustering
+Because container environments such as Docker typically do not work with multicast Coherence must use well know addresses for cluster discovery. By setting the `COH_WKA` environment variable in the Docker run command it is possible to pass in the address that should be used for WKA. For example:
+     
+`docker run -d -e COH_WKA=foo.oracle.com oracle/coherence:12.2.1.2`
+
+where the `foo.oracle.com` address will be used for cluster discovery. In environments that can map a DNS lookup to multiple addresses (for example Docker Swarm) then all of the addresses returned by the DNS lookup will be used by Coherence for cluster discover. For example, in Docker Swarm if a service is created called `datagrid` then Docker DNS allows all the IP addresses of the services' containers to be looked up with the address `tasks.datagrid` so this can be used in the service create command like this:
+  
+```
+docker service create --name datagrid --network coh-net \
+     -e COH_WKA=tasks.datagrid --replicas=3 oracle/coherence:12.2.1.2
+```  
+
+The command above will create a Docker service with three storage enabled cluster members that will all use the `tasks.datagrid` DNS lookup to discover the addresses of the other cluster members. The service can then be easily scaled up and down.
+     
+##Java Options
+It is possible to pass in different options to the JVM and set System properties, for example heap settings or Coherence properties. This can be done by setting the `JAVA_OPTS` environment variable. For example:
+     
+`docker run -d -e JAVA_OPTS="-Xmx1G -Xms1G" oracle/coherence:12.2.1.2`
+     
+The above command sets the heap size to 1GB.
+
+```
+docker run -d -e JAVA_OPTS="-Dcoherence.role=storage -Dcoherence.cluster=datagrid" \
+     oracle/coherence:12.2.1.2
+```
+The above command passes system properties to Coherence. Any valid JVM argument or propery may be passed in to the `JAVA_OPTS` variable.
+      
+##Using Coherence *Extend
+The cache configuration file used by the script in the image is the file from the Coherence jar. By default this starts an Extend proxy service that will listen on an ephemeral port. Normally and Extend client will discover the set of Extend ports using the Coherence NameService. If the Extend client application is running inside another container on the same network that the storage member containers are on then this will all work correctly. But, if the Extend client is outside of the cluster's network then a fixed port needs to be used for the Extend Proxy service so that it can be exposed by Docker. This is done using the `COH_EXTEND_PORT` environment variable; for example:
+
+```
+docker run -d -p 20000:20000 -e COH_EXTEND_PORT=20000 oracle/coherence:12.2.1.2
+```
+The above command sets the Extend port to 20000 and the Docker `-p` option is used to make sure that Docker maps this port onto the host.
+
+If using Docker Swarm is is possible to expose the Extend port in the service, for example:
+```
+docker service create --name datagrid --network coh-net \
+     -e COH_EXTEND_PORT=20000 --publish 20000
+     -e COH_WKA=tasks.datagrid --replicas=3 oracle/coherence:12.2.1.2
+```  
+Docker will now take care of exposing the Etxend port for the `datagrid` service.
+
+##Adding To The JVM ClassPath
+Typically when building an application that will use Coherence in Docker a custom image will be built, probably using the official Coherence image as the base, and then adding any application jar files, configuration and start scripts on top. For development and experimentation it is possible to run a container from the default image and map extra jar files onto the classpath. The shell script in the image adds the `/conf` folder and all jar files in the `/lib` folder to the front of the classpath. These folders can be mapped to folders on the host that might contain custom configurations and code. For example:
+  
+```
+docker run -d -v /dev/my-project/lib:/lib \
+    -v /dev/my-project/config:/conf \
+    oracle/coherence:12.2.1.2
+```  
+The command above will map the `/dev/my-project/lib` folder on the host to the `/lib` folder in the container so any jar file in the `/dev/my-project/lib` folder will be on the Coherence DefaultCacheServer classpath. It will also map the `/dev/my-project/config` folder on the host to the `/conf` folder in the container so any configuration files in this folder will also be on the classpath.
+          
+##Container Arguments
+Any arguments appended to the end of the Docker run command are passed to the shell script as usual with Docker run. These arguments are then passed to the start class's main method as command line arguments. This applies to all arguments except for the the first argument when it matches a vaild process type that the shell script recognises; these are `server` `console` and `queryplus`. These arguments control the type of process started.
+
+###Start a DefaultCacheServer
+The `server` parameter tells the shell script to start a DefaultCacheServer. This is also the default so can be omitted if desired.
+
+###Start a Coherence Console
+The `console` parameter starts a Coherence CacheFactory console and typically this would be started interactively; for example:
+
+`docker run -it oracle/coherence:12.2.1.2 console`
+
+The above command will start the Docker in interactive mode and run the Coherence CacheFactory console.
+
+###Start Coherence QueryPlus
+The `queryplus` parameter starts a Coherence QueryPlus console and again typically this would be started interactively; for example:
+
+`docker run -it oracle/coherence:12.2.1.2 queryplus`
+
+The above command will start the Docker in interactive mode and run the Coherence QueryPlus console. Because subsequent parameters are passed to the main class as parameters is is possible to pass in any valid QueryPlus parameter; for example:
+
+`docker run -it oracle/coherence:12.2.1.2 queryplus -t`
+
+In the above command the `-t` parameter is passed to QueryPlus to enabled trace output.  
+
+

--- a/OracleCoherence/docs/README.md
+++ b/OracleCoherence/docs/README.md
@@ -1,9 +1,10 @@
 #Documentation
 This section includes documentation on running Oracle Coherence clusters inside Docker.
 
-1. [Setup](0.setup) - Setting Up a Demo Docker Machine Environment
-2. [Clustering](1.clustering) - Running Coherence Clusters in Docker
-3. [Coherence Extend](2.extend) - Running Coherence Extend in Docker
-4. [Federated Caching](3.federation) - Federated Caching in Docker
-5. [Disc Based Functionality](4.disc_based) - Elastic Data and Persistence in Docker
-6. [JMX Monitoring](5.monitoring) - Using JMX in Docker
+1. [Image Usage](00.imageusage) - Usage instructions for running the Coherence image
+2. [Setup](0.setup) - Setting Up a Demo Docker Machine Environment
+3. [Clustering](1.clustering) - Running Coherence Clusters in Docker
+4. [Coherence Extend](2.extend) - Running Coherence Extend in Docker
+5. [Federated Caching](3.federation) - Federated Caching in Docker
+6. [Disc Based Functionality](4.disc_based) - Elastic Data and Persistence in Docker
+7. [JMX Monitoring](5.monitoring) - Using JMX in Docker


### PR DESCRIPTION
These changes contain amendments to the Coherence images so that they contain a shell script entry point to make them runnable. Alongside this are corresponding changes to the documentation.