### PR TITLE
Use the proper runme for MP sample

### DIFF
--- a/OracleTuxedo/samples/mp/Dockerfile
+++ b/OracleTuxedo/samples/mp/Dockerfile
@@ -16,4 +16,4 @@ RUN hostname; mkdir /home/oracle/simpappmp
 
 WORKDIR /home/oracle/simpappmp
 
-RUN sh -x ../simpapp_runme.sh
+RUN sh -x ../simpappmp_runme.sh


### PR DESCRIPTION
The Dockerfile for the MP sample incorrectly uses the simpapp_runme.sh instead of the simpappmp_runme.sh