### PR TITLE
Updating OpenJDK images 

### DIFF
--- a/OpenJDK/java-6/Dockerfile
+++ b/OpenJDK/java-6/Dockerfile
@@ -4,11 +4,11 @@
 # 
 # Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
 # 
-FROM oraclelinux:latest
+FROM oraclelinux:7-slim
 
 MAINTAINER Bruno Borges <bruno.borges@oracle.com>
 
-RUN yum -y install java-1.6.0-openjdk-devel && rm -rf /var/cache/yum/*
+RUN yum -y install java-1.6.0-openjdk-devel && yum clean all
 
 ENV JAVA_HOME /usr/lib/jvm/java-openjdk
 

--- a/OpenJDK/java-7/Dockerfile
+++ b/OpenJDK/java-7/Dockerfile
@@ -4,11 +4,11 @@
 # 
 # Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
 # 
-FROM oraclelinux:latest
+FROM oraclelinux:7-slim
 
 MAINTAINER Bruno Borges <bruno.borges@oracle.com>
 
-RUN yum -y install java-1.7.0-openjdk-devel && rm -rf /var/cache/yum/*
+RUN yum -y install java-1.7.0-openjdk-devel && yum clean all
 
 ENV JAVA_HOME /usr/lib/jvm/java-openjdk
 

--- a/OpenJDK/java-8/Dockerfile
+++ b/OpenJDK/java-8/Dockerfile
@@ -4,11 +4,11 @@
 # 
 # Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
 # 
-FROM oraclelinux:latest
+FROM oraclelinux:7-slim
 
 MAINTAINER Bruno Borges <bruno.borges@oracle.com>
 
-RUN yum -y install java-1.8.0-openjdk-devel && rm -rf /var/cache/yum/*
+RUN yum -y install java-1.8.0-openjdk-devel && yum clean all
 
 ENV JAVA_HOME /usr/lib/jvm/java-openjdk
 


### PR DESCRIPTION
This switches OpenJDK to use the `7-slim` base image and does a `yum clean` instead of a hard `rm`.

Signed-off-by: Avi Miller <avi.miller@oracle.com>