### PR TITLE
Allow for user to define environment variables at runtime 

### DIFF
--- a/OracleWebLogic/dockerfiles/12.2.1.2/Dockerfile.developer
+++ b/OracleWebLogic/dockerfiles/12.2.1.2/Dockerfile.developer
@@ -37,6 +37,7 @@ MAINTAINER Monica Riccelli <monica.riccelli@oracle.com>
 # --------------------------------------------------------------------
 ENV ORACLE_HOME=/u01/oracle \
     USER_MEM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
+    SCRIPT_FILE=/u01/oracle/createAndStartEmptyDomain.sh \
     PATH=$PATH:/usr/java/default/bin:/u01/oracle/oracle_common/common/bin:/u01/oracle/wlserver/common/bin
     
 # Setup filesystem and oracle user
@@ -50,17 +51,23 @@ RUN mkdir -p /u01 && \
 #-------------
 COPY container-scripts/createAndStartEmptyDomain.sh container-scripts/create-wls-domain.py /u01/oracle/
 
-ENV SCRIPT_FILE=/u01/oracle/createAndStartEmptyDomain.sh \
-    DOMAIN_NAME="${DOMAIN_NAME:-base_domain}" \
+# Domain and Server environment variables
+# ------------------------------------------------------------
+ENV DOMAIN_NAME="${DOMAIN_NAME:-base_domain}" \
     DOMAIN_HOME=/u01/oracle/user_projects/domains/${DOMAIN_NAME:-base_domain} \
-    ADMIN_PORT="${ADMIN_PORT:-7001}" 
+    ADMIN_PORT="${ADMIN_PORT:-7001}"  \
+    ADMIN_USERNAME="${ADMIN_USERNAME:-weblogic}" \
+    ADMIN_NAME="${ADMIN_NAME:-AdminServer}" \
+    ADMIN_PASSWORD="${ADMIN_PASSWORD:-""}" \
+    DEBUG_FLAG=true \
+    PRODUCTION_MODE=dev 
+    
+    
     
 # Environment variables required for this build (do NOT change)
 # -------------------------------------------------------------
 ENV FMW_PKG=fmw_12.2.1.2.0_wls_quick_Disk1_1of1.zip \
-    FMW_JAR=fmw_12.2.1.2.0_wls_quick.jar \
-    DEBUG_FLAG=true \
-    PRODUCTION_MODE=dev 
+    FMW_JAR=fmw_12.2.1.2.0_wls_quick.jar 
     
 # Copy packages
 # -------------

--- a/OracleWebLogic/dockerfiles/12.2.1.2/Dockerfile.generic
+++ b/OracleWebLogic/dockerfiles/12.2.1.2/Dockerfile.generic
@@ -37,6 +37,7 @@ MAINTAINER Monica Riccelli <monica.riccelli@oracle.com>
 # --------------------------------------------------------------------
 ENV ORACLE_HOME=/u01/oracle \
     USER_MEM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
+    SCRIPT_FILE=/u01/oracle/createAndStartEmptyDomain.sh \
     PATH=$PATH:/usr/java/default/bin:/u01/oracle/oracle_common/common/bin:/u01/oracle/wlserver/common/bin
     
 # Setup filesystem and oracle user
@@ -50,10 +51,15 @@ RUN mkdir -p /u01 && \
 #-------------
 COPY container-scripts/createAndStartEmptyDomain.sh container-scripts/create-wls-domain.py /u01/oracle/
 
-ENV SCRIPT_FILE=/u01/oracle/createAndStartEmptyDomain.sh \
-    DOMAIN_NAME="${DOMAIN_NAME:-base_domain}" \
+# Domain and Server environment variables
+# ------------------------------------------------------------  
+ENV DOMAIN_NAME="${DOMAIN_NAME:-base_domain}" \
     DOMAIN_HOME=/u01/oracle/user_projects/domains/${DOMAIN_NAME:-base_domain} \
-    ADMIN_PORT="${ADMIN_PORT:-7001}" 
+    ADMIN_PORT="${ADMIN_PORT:-7001}" \
+    ADMIN_USERNAME="${ADMIN_USERNAME:-weblogic}" \
+    ADMIN_NAME="${ADMIN_NAME:-AdminServer}" \
+    ADMIN_PASSWORD="${ADMIN_PASSWORD:-""}"
+
 
 # Environment variables required for this build (do NOT change)
 # -------------------------------------------------------------

--- a/OracleWebLogic/dockerfiles/12.2.1.2/Dockerfile.infrastructure
+++ b/OracleWebLogic/dockerfiles/12.2.1.2/Dockerfile.infrastructure
@@ -34,6 +34,7 @@ MAINTAINER Monica Riccelli <monica.riccelli@oracle.com>
 # --------------------------------------------------------------------
 ENV ORACLE_HOME=/u01/oracle \
     USER_MEM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
+    SCRIPT_FILE=/u01/oracle/createAndStartEmptyDomain.sh \
     PATH=$PATH:/usr/java/default/bin:/u01/oracle/oracle_common/common/bin:/u01/oracle/wlserver/common/bin
     
 # Setup filesystem and oracle user
@@ -47,10 +48,16 @@ RUN mkdir -p /u01 && \
 #-------------
 COPY container-scripts/createAndStartEmptyDomain.sh container-scripts/create-wls-domain.py /u01/oracle/
 
+# Domain and Server environment variables
+# ------------------------------------------------------------
 ENV SCRIPT_FILE=/u01/oracle/createAndStartEmptyDomain.sh \
     DOMAIN_NAME="${DOMAIN_NAME:-base_domain}" \
     DOMAIN_HOME=/u01/oracle/user_projects/domains/${DOMAIN_NAME:-base_domain} \
-    ADMIN_PORT="${ADMIN_PORT:-7001}" 
+    ADMIN_PORT="${ADMIN_PORT:-7001}" \
+    ADMIN_USERNAME="${ADMIN_USERNAME:-weblogic}" \
+    ADMIN_NAME="${ADMIN_NAME:-AdminServer}" \
+    ADMIN_PASSWORD="${ADMIN_PASSWORD:-""}"
+
 
 # Environment variables required for this build (do NOT change)
 # -------------------------------------------------------------

--- a/OracleWebLogic/dockerfiles/12.2.1.2/README.md
+++ b/OracleWebLogic/dockerfiles/12.2.1.2/README.md
@@ -1,6 +1,6 @@
 Oracle WebLogic Server on Docker
 =================================
-These  Docker configurations have been used to create the Oracle WebLogic Server image. Providing this WLS image facilitates the configuration, and environment setup for DevOps users. This project includes the installation and the creation of an empty WebLogic Server domain (only an Admin Server). These Oracle WebLogic Server 12.2.1.2 images are based on Oracle Linux and Oracle JDK 8 (Server).
+These  Docker configurations have been used to create the Oracle WebLogic Server image. Providing this WLS image facilitates the configuration, and environment setup for DevOps users. This project includes the installation and the creation of an empty WebLogic Server domain (only an Admin Server). These Oracle WebLogic Server 12.2.1.2 images are based on Oracle Linux and Oracle JRE 8 (Server).
 
 The certification of Oracle WebLogic Server on Docker does not require the use of any file presented in this repository. Customers and users are welcome to use them as starters, and customize/tweak, or create from scratch new scripts and Dockerfiles.
 
@@ -13,7 +13,7 @@ The `buildDockerImage.sh` script is just a utility shell script that performs MD
 
 
 ### Building Oracle WebLogic Server Docker Install Images
-**IMPORTANT:** you have to download the binary of Oracle WebLogic Server and put it in place (see `.download` files inside dockerfiles/<version>).
+**IMPORTANT:** you have to download the binary of Oracle WebLogic Server and put it in place (see `.download` files inside dockerfiles/<version>). The WebLogic image extends the Oracle JRE 8 image, you must either build the imageing Dockerfile in [../../../OracleJava/java8](https://github.com/oracle/docker-images/tree/master/OracleJava/java-8) or pull the latest image from the [Oracle Cointainer Registry](https://container-registry.oracle.com) or the [Docker Store](https://store.docker.com).
 
 Before you build, choose which version and distribution you want to build an image,then download the required packages (see .download files) and drop them in the folder of your distribution version of choice. Then go into the **dockerfiles** folder and run the **buildDockerImage.sh** script as root.
 
@@ -80,8 +80,17 @@ To try a sample of a WebLogic Server image with a base domain configured, follow
         $ docker images
 
   3. Start a container from the image created in step 1: 
+     You can override the default values of the following parameters during runtime with the -e option:
+      * ADMIN_NAME     (default: AdminServer) 
+      * ADMIN_PORT     (default: 7001) 
+      * ADMIN_USERNAME (default: weblogic)
+      * ADMIN_PASSWORD (default: Auto Generated)
+      * DOMAIN_NAME    (default: base_domain)
+      * DOMAIN_HOME    (default: /u01/oracle/user_projects/domains/base_domain)
 
-        $ docker run -d oracle/weblogic:12.2.1.2-developer
+**NOTE** To set the DOMAIN_NAME, you must set both DOMAIN_NAME and DOMAIN_HOME.
+
+        $ docker run -d -e ADMIN_USERNAME=weblogic -e ADMIN_PASSWORD=welcome1 -e DOMAIN_HOME=/u01/oracle/user_projects/domains/abc_domain -e DOMAIN_NAME=abc_domain oracle/weblogic:12.2.1.2-developer
 
   4. Run the administration console
 

--- a/OracleWebLogic/dockerfiles/12.2.1.2/README.md
+++ b/OracleWebLogic/dockerfiles/12.2.1.2/README.md
@@ -13,7 +13,7 @@ The `buildDockerImage.sh` script is just a utility shell script that performs MD
 
 
 ### Building Oracle WebLogic Server Docker Install Images
-**IMPORTANT:** you have to download the binary of Oracle WebLogic Server and put it in place (see `.download` files inside dockerfiles/<version>). The WebLogic image extends the Oracle JRE 8 image, you must either build the imageing Dockerfile in [../../../OracleJava/java8](https://github.com/oracle/docker-images/tree/master/OracleJava/java-8) or pull the latest image from the [Oracle Cointainer Registry](https://container-registry.oracle.com) or the [Docker Store](https://store.docker.com).
+**IMPORTANT:** you have to download the binary of Oracle WebLogic Server and put it in place (see `.download` files inside dockerfiles/<version>). The WebLogic image extends the Oracle JRE Server 8 image, you must either build the image by using the Dockerfile in [../../../OracleJava/java8](https://github.com/oracle/docker-images/tree/master/OracleJava/java-8) or pull the latest image from the [Oracle Cointainer Registry](https://container-registry.oracle.com) or the [Docker Store](https://store.docker.com).
 
 Before you build, choose which version and distribution you want to build an image,then download the required packages (see .download files) and drop them in the folder of your distribution version of choice. Then go into the **dockerfiles** folder and run the **buildDockerImage.sh** script as root.
 

--- a/OracleWebLogic/dockerfiles/12.2.1.2/container-scripts/create-wls-domain.py
+++ b/OracleWebLogic/dockerfiles/12.2.1.2/container-scripts/create-wls-domain.py
@@ -8,8 +8,10 @@
 # Author: bruno.borges@oracle.com
 # ==============================================
 domain_name  = os.environ.get("DOMAIN_NAME", "base_domain")
+admin_name  = os.environ.get("ADMIN_NAME", "AdminServer")
+admin_username  = os.environ.get("ADMIN_USERNAME", "weblogic")
+admin_pass  = "ADMIN_PASSWORD"
 admin_port   = int(os.environ.get("ADMIN_PORT", "7001"))
-admin_pass   = "ADMIN_PASSWORD" 
 domain_path  = '/u01/oracle/user_projects/domains/%s' % domain_name
 production_mode = os.environ.get("PRODUCTION_MODE", "prod")
 
@@ -18,6 +20,8 @@ print('admin_port      : [%s]' % admin_port);
 print('domain_path     : [%s]' % domain_path);
 print('production_mode : [%s]' % production_mode);
 print('admin password  : [%s]' % admin_pass);
+print('admin name      : [%s]' % admin_name);
+print('admin username  : [%s]' % admin_username);
 
 # Open default domain template
 # ======================
@@ -33,6 +37,7 @@ setOption('DomainName', domain_name)
 # Configure the Administration Server and SSL port.
 # =========================================================
 cd('/Servers/AdminServer')
+set('Name', admin_name)
 set('ListenAddress', '')
 set('ListenPort', admin_port)
 
@@ -57,7 +62,7 @@ set('LogLevel', 'FINEST')
 
 # Set the Node Manager user name and password (domain name will change after writeDomain)
 cd('/SecurityConfiguration/base_domain')
-set('NodeManagerUsername', 'weblogic')
+set('NodeManagerUsername', admin_username)
 set('NodeManagerPasswordEncrypted', admin_pass)
 
 # Write Domain

--- a/OracleWebLogic/dockerfiles/12.2.1.2/container-scripts/createAndStartEmptyDomain.sh
+++ b/OracleWebLogic/dockerfiles/12.2.1.2/container-scripts/createAndStartEmptyDomain.sh
@@ -32,28 +32,32 @@ fi
 # Create Domain only if 1st execution
 if [ $ADD_DOMAIN -eq 0 ]; then
 
-# Auto generate Oracle WebLogic Server admin password
-while true; do
-s=$(cat /dev/urandom | tr -dc "A-Za-z0-9" | fold -w 8 | head -n 1)
-if [[ ${#s} -ge 8 && "$s" == *[A-Z]* && "$s" == *[a-z]* && "$s" == *[0-9]*  ]]; then
-    break
+if [ -z $ADMIN_PASSWORD ]; then
+   # Auto generate Oracle WebLogic Server admin password
+   while true; do
+     s=$(cat /dev/urandom | tr -dc "A-Za-z0-9" | fold -w 8 | head -n 1)
+     if [[ ${#s} -ge 8 && "$s" == *[A-Z]* && "$s" == *[a-z]* && "$s" == *[0-9]*  ]]; then
+         break
+     else
+         echo "Password does not Match the criteria, re-generating..."
+     fi
+   done
+
+   echo ""
+   echo "    Oracle WebLogic Server Auto Generated Empty Domain:"
+   echo ""
+   echo "      ----> 'weblogic' admin password: $s"
+   echo ""
 else
-    echo "Password does not Match the criteria, re-generating..."
-fi
-done
-
-echo ""
-echo "    Oracle WebLogic Server Auto Generated Empty Domain:"
-echo ""
-echo "      ----> 'weblogic' admin password: $s"
-echo ""
-
+   s=${ADMIN_PASSWORD}
+   echo "      ----> 'weblogic' admin password: $s"
+fi 
 sed -i -e "s|ADMIN_PASSWORD|$s|g" /u01/oracle/create-wls-domain.py
 
 # Create an empty domain
 wlst.sh -skipWLSModuleScanning /u01/oracle/create-wls-domain.py
 mkdir -p ${DOMAIN_HOME}/servers/AdminServer/security/ 
-echo "username=weblogic" > /u01/oracle/user_projects/domains/$DOMAIN_NAME/servers/AdminServer/security/boot.properties 
+echo "username=${ADMIN_USERNAME}" > /u01/oracle/user_projects/domains/$DOMAIN_NAME/servers/AdminServer/security/boot.properties 
 echo "password=$s" >> /u01/oracle/user_projects/domains/$DOMAIN_NAME/servers/AdminServer/security/boot.properties 
 ${DOMAIN_HOME}/bin/setDomainEnv.sh 
 fi


### PR DESCRIPTION
Allow for user to define environment variables at runtime for the WebLogic Domain creation:
DOMAIN_NAME
DOMAIN_HOME
ADMIN_NAME
ADMIN_USERNAME
ADMIN_PASSWORD
ADMIN_PORT