### PR TITLE
Fix Permission and ADMIN_PASSWORD issue for 12212-domain

### DIFF
--- a/OracleWebLogic/samples/12212-domain/Dockerfile
+++ b/OracleWebLogic/samples/12212-domain/Dockerfile
@@ -25,7 +25,7 @@ MAINTAINER Monica Riccelli <monica.riccelli@oracle.com>
 
 # WLS Configuration (editable during build time)
 # ------------------------------
-ARG ADMIN_PASSWORD
+ARG ADMIN_PASS
 ARG DOMAIN_NAME
 ARG ADMIN_PORT
 ARG CLUSTER_NAME
@@ -35,6 +35,7 @@ ARG PRODUCTION_MODE
 # WLS Configuration (editable during runtime)
 # ---------------------------
 ENV ADMIN_HOST="wlsadmin" \
+    ADMIN_PASSWORD="${ADMIN_PASS:-welcome1}" \
     NM_PORT="5556" \
     MS_PORT="7001" \
     DEBUG_PORT="8453" \

--- a/OracleWebLogic/samples/12212-domain/Dockerfile
+++ b/OracleWebLogic/samples/12212-domain/Dockerfile
@@ -51,8 +51,10 @@ ENV DOMAIN_NAME="${DOMAIN_NAME:-base_domain}" \
     PATH=$PATH:/u01/oracle/oracle_common/common/bin:/u01/oracle/wlserver/common/bin:/u01/oracle/user_projects/domains/${DOMAIN_NAME:-base_domain}/bin:/u01/oracle
 
 # Add files required to build this image
-USER oracle
+USER root
 COPY container-scripts/* /u01/oracle/
+RUN  chown oracle:oracle /u01/oracle/*
+USER oracle
 
 # Configuration of WLS Domain
 RUN /u01/oracle/wlst /u01/oracle/create-wls-domain.py && \

--- a/OracleWebLogic/samples/12212-domain/README.md
+++ b/OracleWebLogic/samples/12212-domain/README.md
@@ -7,7 +7,7 @@ Util scripts are copied into the image enabling users to plug NodeManager automa
 # How to build and run
 First make sure you have built **oracle/weblogic:12.2.1.2-developer**. Now to build this sample, run:
 
-        $ docker build -t 12212-domain --build-arg ADMIN_PASSWORD=welcome1 .
+        $ docker build -t 12212-domain --build-arg ADMIN_PASS=welcome1 .
 
 To start the containerized Admin Server, run:
 

--- a/OracleWebLogic/samples/12212-domain/build.sh
+++ b/OracleWebLogic/samples/12212-domain/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 if [ "$#" -eq 0 ]; then echo "Inform a password for the domain as first argument."; exit; fi
-docker build --build-arg ADMIN_PASSWORD=$1 -t 12212-domain . 
+docker build --build-arg ADMIN_PASS=$1 -t 12212-domain .


### PR DESCRIPTION
There are two commits that apply to be merged:
- 12212-domain: Make user setting Weblogic password successfully
   While specifying the "--build-arg ADMIN_PASSWORD=welcome1" option for building image the 
   varible ADMIN_PASSWORD defined in Dockerfile will never be set due to Docker known 
   mechanism block this behavior. It causes the image will not be built successfully, so this patch 
   intends to fix this issue.

- 12212-domain: Fix the permission issue while building image
   This patch intends to fix the following failure while building image:
   "/bin/sh: /u01/oracle/wlst: Permission denied"

Could you please review those two patches ? Any suggestions are appreciated.