### PR TITLE
12212-domain: Fix the permission issue while building image

### DIFF
--- a/OracleWebLogic/samples/12212-domain/Dockerfile
+++ b/OracleWebLogic/samples/12212-domain/Dockerfile
@@ -51,8 +51,10 @@ ENV DOMAIN_NAME="${DOMAIN_NAME:-base_domain}" \
     PATH=$PATH:/u01/oracle/oracle_common/common/bin:/u01/oracle/wlserver/common/bin:/u01/oracle/user_projects/domains/${DOMAIN_NAME:-base_domain}/bin:/u01/oracle
 
 # Add files required to build this image
-USER oracle
+USER root
 COPY container-scripts/* /u01/oracle/
+RUN  chown oracle:oracle /u01/oracle/*
+USER oracle
 
 # Configuration of WLS Domain
 RUN /u01/oracle/wlst /u01/oracle/create-wls-domain.py && \


### PR DESCRIPTION
This patch intends to fix the following failure while building image:
"/bin/sh: /u01/oracle/wlst: Permission denied"

Signed-off-by: Dong Zhu <dong.zhu@oracle.com>