### PR TITLE
12212-domain: Make user setting Weblogic password successfully

### DIFF
--- a/OracleWebLogic/samples/12212-domain/Dockerfile
+++ b/OracleWebLogic/samples/12212-domain/Dockerfile
@@ -25,7 +25,7 @@ MAINTAINER Monica Riccelli <monica.riccelli@oracle.com>
 
 # WLS Configuration (editable during build time)
 # ------------------------------
-ARG ADMIN_PASSWORD
+ARG ADMIN_PASSD
 ARG DOMAIN_NAME
 ARG ADMIN_PORT
 ARG CLUSTER_NAME
@@ -35,6 +35,7 @@ ARG PRODUCTION_MODE
 # WLS Configuration (editable during runtime)
 # ---------------------------
 ENV ADMIN_HOST="wlsadmin" \
+    ADMIN_PASSWORD="${ADMIN_PASSD}" \
     NM_PORT="5556" \
     MS_PORT="7001" \
     DEBUG_PORT="8453" \
@@ -55,11 +56,7 @@ USER oracle
 COPY container-scripts/* /u01/oracle/
 
 # Configuration of WLS Domain
-RUN /u01/oracle/wlst /u01/oracle/create-wls-domain.py && \
-    mkdir -p /u01/oracle/user_projects/domains/$DOMAIN_NAME/servers/AdminServer/security && \
-    echo "username=weblogic" > /u01/oracle/user_projects/domains/$DOMAIN_NAME/servers/AdminServer/security/boot.properties && \
-    echo "password=$ADMIN_PASSWORD" >> /u01/oracle/user_projects/domains/$DOMAIN_NAME/servers/AdminServer/security/boot.properties && \
-    echo ". /u01/oracle/user_projects/domains/$DOMAIN_NAME/bin/setDomainEnv.sh" >> /u01/oracle/.bashrc 
+RUN configureWLSDomain.sh
 
 # Expose Node Manager default port, and also default for admin and managed server 
 EXPOSE $NM_PORT $ADMIN_PORT $MS_PORT $DEBUG_PORT

--- a/OracleWebLogic/samples/12212-domain/README.md
+++ b/OracleWebLogic/samples/12212-domain/README.md
@@ -7,7 +7,7 @@ Util scripts are copied into the image enabling users to plug NodeManager automa
 # How to build and run
 First make sure you have built **oracle/weblogic:12.2.1.2-developer**. Now to build this sample, run:
 
-        $ docker build -t 12212-domain --build-arg ADMIN_PASSWORD=welcome1 .
+        $ docker build -t 12212-domain --build-arg ADMIN_PASSD=welcome1 .
 
 To start the containerized Admin Server, run:
 

--- a/OracleWebLogic/samples/12212-domain/build.sh
+++ b/OracleWebLogic/samples/12212-domain/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 if [ "$#" -eq 0 ]; then echo "Inform a password for the domain as first argument."; exit; fi
-docker build --build-arg ADMIN_PASSWORD=$1 -t 12212-domain . 
+docker build --build-arg ADMIN_PASSD=$1 -t 12212-domain .

--- a/OracleWebLogic/samples/12212-domain/container-scripts/configureWLSDomain.sh
+++ b/OracleWebLogic/samples/12212-domain/container-scripts/configureWLSDomain.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+if [ -z $ADMIN_PASSWORD ]; then
+	# Auto generate Oracle WebLogic Server admin password
+	echo 'Admin Password is not specified, generating ...'
+	while true; do
+		s=$(cat /dev/urandom | tr -dc "A-Za-z0-9" | fold -w 8 | head -n 1)
+		if [[ ${#s} -ge 8 && "$s" == *[A-Z]* && "$s" == *[a-z]* && "$s" == *[0-9]*  ]]; then
+			ADMIN_PASSWORD=$s
+			break
+		else
+			echo "!Password does not Match the criteria, re-generating..."
+		fi
+	done
+fi
+
+echo ""
+echo "      ----> 'weblogic' admin password: ${ADMIN_PASSWORD}"
+echo ""
+
+/u01/oracle/wlst /u01/oracle/create-wls-domain.py
+mkdir -p /u01/oracle/user_projects/domains/$DOMAIN_NAME/servers/AdminServer/security
+echo "username=weblogic" > /u01/oracle/user_projects/domains/$DOMAIN_NAME/servers/AdminServer/security/boot.properties
+echo "password=$ADMIN_PASSWORD" >> /u01/oracle/user_projects/domains/$DOMAIN_NAME/servers/AdminServer/security/boot.properties
+echo ". /u01/oracle/user_projects/domains/$DOMAIN_NAME/bin/setDomainEnv.sh" >> /u01/oracle/.bashrc


### PR DESCRIPTION
While specifying the `--build-arg ADMIN_PASSWORD=welcome1` option for building image the variable `ADMIN_PASSWORD` defined in Dockerfile will never be set due to Docker known mechanism block this behaviour. It causes the image will not be built successfully, so this patch intends to fix this issue. User can specify the password or not. If not the building process will generate the password automatically.

Signed-off-by: Dong Zhu <dong.zhu@oracle.com>