### PR TITLE
Fix grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Docker Images from Oracle
 
-This repository stores Dockerfiles and samples to build Docker images for Oracle products and Open Source projects.
+This repository contains Dockerfiles and samples to build Docker images for Oracle products and open source projects.
 
  - [Oracle Coherence](https://github.com/oracle/docker-images/tree/master/OracleCoherence)
  - [Oracle Database](https://github.com/oracle/docker-images/tree/master/OracleDatabase)


### PR DESCRIPTION
Docker sounds better with "contains" than "stores" and "open source" isn't a proper noun, hence capitalisation removed.