### PR TITLE
Changes to the FMW Infrastructire 12.2.1.2  Image

### DIFF
--- a/OracleFMWInfrastructure/README.md
+++ b/OracleFMWInfrastructure/README.md
@@ -18,8 +18,10 @@ You must first download the Oracle Server JRE binary and drop in folder `../Orac
         $ cd ../OracleJava/java-8
         $ sh build.sh
 
-You can also pull the Oracle Server JRE 8 image from [Oracle Container Registry](https://container-registry.oracle.com) or the [Docker Store](https://store.docker.com/images/oracle-serverjre-8).  If you pull the Server JRE 8 from the Oracle Container Registry you must edit you Dockerfile and change the FROM clause to be "FROM container-registry.oracle.com/java/serverjre". If you pull the Server JRE 8 from the DockerStore you must edit you Dockerfile and change the FROM clause to be "FROM store/oracle/serverjre:8".
-
+You can also pull the Oracle Server JRE 8 image from [Oracle Container Registry](https://container-registry.oracle.com) or the [Docker Store](https://store.docker.com/images/oracle-serverjre-8). When pulling the Server JRE 8 image retag the image so that it works with the existing Dockerfiles.
+        $ docker tag container-registry.oracle.com/java/serverjre:8 oracle/serverjre:8
+        $ docker tag store/oracle/serverjre:8 oracle/serverjre:8
+        
 ### Building the Oracle FMW Infrastructure 12.2.1.2 base image
 **IMPORTANT:**If you are building the Oracle FMW Infrastructure image you must first download the Oracle FMW Infrastructure 12.2.1.2 binary and drop in folder `../OracleFMWInfrastructure/dockerfiles/12.2.1.2`. 
 
@@ -75,7 +77,7 @@ If you need to find the passwords at a later time, grep for "password" in the Do
 The best way to create your own domain or extend an existing domain is by using the [WebLogic Scripting Tool](https://docs.oracle.com/middleware/1221/cross/wlsttasks.htm). You can find an example of a WLST script to create domains at [createInfraDomain.py](dockerfiles/12.2.1.2/container-scripts/createInfraDomain.py). You may want to tune this script with your own setup to create DataSources and Connection pools, Security Realms, deploy artifacts, and so on. You can also extend images and override an existing domain, or create a new one with WLST.
 
 ## Running the Oracle FMW Infrastructure Domain Docker Image
-To try a sample of a FMW Infrastructure Domain image configured, you will need the FMW Infrastructure Domain image and an Oracle Database which could be running in a container. If you are interested in using the the Oracle Database image, you can pull it from the [DockerStore](https://store.docker.com/images/oracle-database-enterprise-edition) or the [Oracle Container Registry](https://container-registry.oracle.com) or you can build your own using the Dockerfiles and scripts in GitHub. 
+To run a FMW Infrastructure Domain sample container, you will need the FMW Infrastructure Domain image and an Oracle Database. The Oracle Database could be remote or running in a container. If you want to run Oracle Database in a container, you can either pull the image from the [Docker Store](https://store.docker.com/images/oracle-database-enterprise-edition) or the [Oracle Container Registry](https://container-registry.oracle.com) or build your own image using the Dockerfiles and Scripts in this Git repository.
 
 Follow the steps below:
 
@@ -111,7 +113,7 @@ Follow the steps below:
   
   5. Start a container to launch the Admin Server from the image created in step 3. The environment variables used to configure the InfraDomain are defined in infraDomain.env.list file. Call docker run from the **dockerfiles/12.2.1.2** directory where the infraDomain.env.list file is and pass the file name at runtime. To run an Admin Server container call: 
 
-        $ docker run --detach=true -p 9001:7001 --network=InfraNET -v \<host volume\>:/u01/oracle/user_projects --name InfraAdminContainer --env-file ./infraDomain.env.list oracle/fmw-infrastructure:12.2.1.2
+        $ docker run -d -p 9001:7001 --network=InfraNET -v $HOST_VOLUME:/u01/oracle/user_projects --name InfraAdminContainer --env-file ./infraDomain.env.list oracle/fmw-infrastructure:12.2.1.2
 
   6. Access the administration console
 
@@ -122,7 +124,7 @@ Follow the steps below:
   
   7. Start a container to launch the Managed Server from the image created in step 3. The environment variables used to run the Managed Server image are defined in the file infraserver.env.list. Call docker run from the **dockerfiles/12.2.1.2** directory where the infraserver.env.list file is and pass the file name at runtime. To run a Managed Server container call:
 
-        $ docker run --detach=true -p 9801:8001 --network=InfraNET --volumes-from InfraAdminContainer --name InfraManagedContainer --env-file ./infraServer.env.list oracle/fmw-infrastructure:12.2.1.2 startManagedServer.sh
+        $ docker run -d -p 9801:8001 --network=InfraNET --volumes-from InfraAdminContainer --name InfraManagedContainer --env-file ./infraServer.env.list oracle/fmw-infrastructure:12.2.1.2 startManagedServer.sh
 
 ## Copyright
 Copyright (c) 2014-2017 Oracle and/or its affiliates. All rights reserved.

--- a/OracleFMWInfrastructure/README.md
+++ b/OracleFMWInfrastructure/README.md
@@ -72,10 +72,10 @@ If you need to find the passwords at a later time, grep for "password" in the Do
         $ docker logs --details <Container-id>
 
 ### Write your own Oracle Fusion Middleware Infrastructure domain with WLST
-The best way to create your own, or extend domains is by using [WebLogic Scripting Tool](https://docs.oracle.com/middleware/1221/cross/wlsttasks.htm). You can find an example of a WLST script to create domains at [createInfraDomain.py](dockerfiles/12.2.1.2/container-scripts/createInfraDomain.py). You may want to tune this script with your own setup to create DataSources and Connection pools, Security Realms, deploy artifacts, and so on. You can also extend images and override an existing domain, or create a new one with WLST.
+The best way to create your own domain or extend an existing domain is by using the [WebLogic Scripting Tool](https://docs.oracle.com/middleware/1221/cross/wlsttasks.htm). You can find an example of a WLST script to create domains at [createInfraDomain.py](dockerfiles/12.2.1.2/container-scripts/createInfraDomain.py). You may want to tune this script with your own setup to create DataSources and Connection pools, Security Realms, deploy artifacts, and so on. You can also extend images and override an existing domain, or create a new one with WLST.
 
 ## Running the Oracle FMW Infrastructure Domain Docker Image
-To try a sample of a FMW Infrastructure Domain image configured, you will need two images, the FMW Infrastructure Domain image and an Oracle Database image. The Oracle Database image can be pulled from the [DockerStore](https://store.docker.com/images/oracle-database-enterprise-edition) or the [Oracle Container Registry](https://container-registry.oracle.com) or you can build your own using the Dockerfiles and scripts in GitHub. 
+To try a sample of a FMW Infrastructure Domain image configured, you will need the FMW Infrastructure Domain image and an Oracle Database which could be running in a container. If you are interested in using the the Oracle Database image, you can be pull it from the [DockerStore](https://store.docker.com/images/oracle-database-enterprise-edition) or the [Oracle Container Registry](https://container-registry.oracle.com) or you can build your own using the Dockerfiles and scripts in GitHub. 
 
 Follow the steps below:
 
@@ -109,9 +109,9 @@ Follow the steps below:
 
         $ docker images
   
-  5. Start a container to launch the Admin Server from the image created in step 3. The environment variables used to configure the InfraDomain are defined in infraDomain.env.list file. Call docker run from the **dockerfiles/12.2.1.2** directory where the infraDomain.env.list file is and pass the file name at runtime. To run a Admin Server container call: 
+  5. Start a container to launch the Admin Server from the image created in step 3. The environment variables used to configure the InfraDomain are defined in infraDomain.env.list file. Call docker run from the **dockerfiles/12.2.1.2** directory where the infraDomain.env.list file is and pass the file name at runtime. To run an Admin Server container call: 
 
-        $ docker run --detach=true -p 9001:7001 --network=InfraNET -v "host volume":/u01/oracle/user_projects --name InfraAdminContainer --env-file ./infraDomain.env.list oracle/fmw-infrastructure:12.2.1.2
+        $ docker run --detach=true -p 9001:7001 --network=InfraNET -v <host volume>:/u01/oracle/user_projects --name InfraAdminContainer --env-file ./infraDomain.env.list oracle/fmw-infrastructure:12.2.1.2
 
   6. Access the administration console
 

--- a/OracleFMWInfrastructure/README.md
+++ b/OracleFMWInfrastructure/README.md
@@ -75,7 +75,7 @@ If you need to find the passwords at a later time, grep for "password" in the Do
 The best way to create your own domain or extend an existing domain is by using the [WebLogic Scripting Tool](https://docs.oracle.com/middleware/1221/cross/wlsttasks.htm). You can find an example of a WLST script to create domains at [createInfraDomain.py](dockerfiles/12.2.1.2/container-scripts/createInfraDomain.py). You may want to tune this script with your own setup to create DataSources and Connection pools, Security Realms, deploy artifacts, and so on. You can also extend images and override an existing domain, or create a new one with WLST.
 
 ## Running the Oracle FMW Infrastructure Domain Docker Image
-To try a sample of a FMW Infrastructure Domain image configured, you will need the FMW Infrastructure Domain image and an Oracle Database which could be running in a container. If you are interested in using the the Oracle Database image, you can be pull it from the [DockerStore](https://store.docker.com/images/oracle-database-enterprise-edition) or the [Oracle Container Registry](https://container-registry.oracle.com) or you can build your own using the Dockerfiles and scripts in GitHub. 
+To try a sample of a FMW Infrastructure Domain image configured, you will need the FMW Infrastructure Domain image and an Oracle Database which could be running in a container. If you are interested in using the the Oracle Database image, you can pull it from the [DockerStore](https://store.docker.com/images/oracle-database-enterprise-edition) or the [Oracle Container Registry](https://container-registry.oracle.com) or you can build your own using the Dockerfiles and scripts in GitHub. 
 
 Follow the steps below:
 

--- a/OracleFMWInfrastructure/README.md
+++ b/OracleFMWInfrastructure/README.md
@@ -20,8 +20,8 @@ You must first download the Oracle Server JRE binary and drop in folder `../Orac
 
 You can also pull the Oracle Server JRE 8 image from [Oracle Container Registry](https://container-registry.oracle.com) or the [Docker Store](https://store.docker.com/images/oracle-serverjre-8).
 
-### Building the Oracle WebLogic Infrastructure 12.2.1.2 base image
-**IMPORTANT:**If you are building the Oracle WebLogic Infrastructure image you must first download the Oracle WebLogic Infrastructure 12.2.1.2 binary and drop in folder `../OracleFMWInfrastructure/dockerfiles/12.2.1.2`. 
+### Building the Oracle FMW Infrastructure 12.2.1.2 base image
+**IMPORTANT:**If you are building the Oracle FMW Infrastructure image you must first download the Oracle WebLogic FMW Infrastructure 12.2.1.2 binary and drop in folder `../OracleFMWInfrastructure/dockerfiles/12.2.1.2`. 
 
         $ sh buildDockerImage.sh
         Usage: buildDockerImage.sh -v [version]
@@ -110,7 +110,7 @@ Follow the steps below:
   
   5. Start a container to launch the Admin Server from the image created in step 3. The environment variables used to configure the InfraDomain are defined in infraDomain.env.list file. Call docker run from the **dockerfiles/12.2.1.2** directory where the infraDomain.env.list file is and pass the file name at runtime. To run a Admin Server container call: 
 
-        $ docker run --detach=true -p 9001:7001 --network=InfraNET -v <host volume>:/u01/oracle/user_projects --name InfraAdminContainer --env-file ./infraDomain.env.list oracle/fmw-infrastructure:12.2.1.2
+        $ docker run --detach=true -p 9001:7001 --network=InfraNET -v "host volume":/u01/oracle/user_projects --name InfraAdminContainer --env-file ./infraDomain.env.list oracle/fmw-infrastructure:12.2.1.2
 
   6. Access the administration console
 

--- a/OracleFMWInfrastructure/README.md
+++ b/OracleFMWInfrastructure/README.md
@@ -21,7 +21,7 @@ You must first download the Oracle Server JRE binary and drop in folder `../Orac
 You can also pull the Oracle Server JRE 8 image from [Oracle Container Registry](https://container-registry.oracle.com) or the [Docker Store](https://store.docker.com/images/oracle-serverjre-8).
 
 ### Building the Oracle FMW Infrastructure 12.2.1.2 base image
-**IMPORTANT:**If you are building the Oracle FMW Infrastructure image you must first download the Oracle WebLogic FMW Infrastructure 12.2.1.2 binary and drop in folder `../OracleFMWInfrastructure/dockerfiles/12.2.1.2`. 
+**IMPORTANT:**If you are building the Oracle FMW Infrastructure image you must first download the Oracle FMW Infrastructure 12.2.1.2 binary and drop in folder `../OracleFMWInfrastructure/dockerfiles/12.2.1.2`. 
 
         $ sh buildDockerImage.sh
         Usage: buildDockerImage.sh -v [version]
@@ -31,6 +31,7 @@ You can also pull the Oracle Server JRE 8 image from [Oracle Container Registry]
            -v: version to build. Required.
            Choose : 12.2.1.2
            -c: enables Docker image layer cache during build
+           -s: skips the MD5 check of packages
 
         LICENSE CDDL 1.0 + GPL 2.0
 

--- a/OracleFMWInfrastructure/README.md
+++ b/OracleFMWInfrastructure/README.md
@@ -4,23 +4,24 @@ This Docker configuration has been used to create the Oracle Fusion Middleware I
 
 The certification of Oracle FMW Infrastructure on Docker does not require the use of any file presented in this repository. Customers and users are welcome to use them as starters, and customize/tweak, or create from scratch new scripts and Dockerfiles.
 
+The FMW Infrastructure image is created using the  WebLogic 12.2.1.2 FMW Infrastructure installer. If you are interested in building the root WebLogic Infrastructure image use the files provided in `../OracleWebLogic/dockerfiles/12.2.1.2` and build that image. For more information, visit the [OracleWebLogic](../OracleWebLogic) folder's [README](../OracleWebLogic/README.md) file.
+
 
 ## How to build and run
 This project offers a sample Dockerfile and scripts to build a Oracle Fusion Middleware Infrastructue 12cR2 (12.2.1.2) image. To assist in building the image, you can use the [buildDockerImage.sh](dockerfiles/buildDockerImage.sh) script. See below for instructions and usage.
 
 The `buildDockerImage.sh` script is just a utility shell script that takes the version of the image that needs to be built. Expert users are welcome to directly call `docker build` with their prefered set of parameters.
 
+### Building Oracle JDK (Server JRE) base image
+You must first download the Oracle Server JRE binary and drop in folder `../OracleJava/java-8` and build that image. For more information, visit the [OracleJava](../OracleJava) folder's [README](../OracleJava/README.md) file.
+
+        $ cd ../OracleJava/java-8
+        $ sh build.sh
+
+You can also pull the Oracle Server JRE 8 image from [Oracle Container Registry](https://container-registry.oracle.com) or the [Docker Store](https://store.docker.com/images/oracle-serverjre-8).
 
 ### Building the Oracle WebLogic Infrastructure 12.2.1.2 base image
-**IMPORTANT:**If you are building the Oracle WebLogic Infrastructure image you must first download the Oracle WebLogic Infrastructure 12.2.1.2 binary and drop in folder `../OracleWebLogic/dockerfiles/12.2.1.2` and build that image. For more information, visit the [OracleWeblogic](../OracleWebLogic) folder's [README](../OracleWebLogic/README.md) file.
-
-        $ cd ../OracleWebLogic/dockerfiles
-        $ ./buildDockerImage.sh -v 12.2.1.2 -i
-
-### Building Oracle FMW Infrastructure Docker  Image
-**IMPORTANT:**The Oracle FMW Infrastructure image extends the Oracle WebLogic 12.2.1.2 Infrastructure install image. You must build the Oracle WebLogic Infrastructure image. See "Building the Oracle WebLogic Infrastructure 12.2.1.2 base image".
-
-Choose which version of the image you want to build, go into the **dockerfiles** folder and run the **buildDockerImage.sh** script as root.
+**IMPORTANT:**If you are building the Oracle WebLogic Infrastructure image you must first download the Oracle WebLogic Infrastructure 12.2.1.2 binary and drop in folder `../OracleFMWInfrastructure/dockerfiles/12.2.1.2`. 
 
         $ sh buildDockerImage.sh
         Usage: buildDockerImage.sh -v [version]
@@ -33,7 +34,7 @@ Choose which version of the image you want to build, go into the **dockerfiles**
 
         LICENSE CDDL 1.0 + GPL 2.0
 
-        Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+        Copyright (c) 2014-2017 Oracle and/or its affiliates. All rights reserved.
 
 **IMPORTANT:** the resulting images will have a domain with an Admin Server and one Managed Server by default. You must extend the image with your own Dockerfile, and create your domain using WLST.
 
@@ -55,7 +56,7 @@ The image **oracle/fmw-infrastructure:12.2.1.2** will configure a **base_domain*
  * Production Mode: `production`
   
 
-###Admin Password and Database Schema Password
+### Admin Password and Database Schema Password
 
 On the first startup of the container a random password will be generated for the Administration of the domain. You can find this password in the output line:
 
@@ -72,7 +73,7 @@ If you need to find the passwords at a later time, grep for "password" in the Do
 ### Write your own Oracle Fusion Middleware Infrastructure domain with WLST
 The best way to create your own, or extend domains is by using [WebLogic Scripting Tool](https://docs.oracle.com/middleware/1221/cross/wlsttasks.htm). You can find an example of a WLST script to create domains at [createInfraDomain.py](dockerfiles/12.2.1.2/container-scripts/createInfraDomain.py). You may want to tune this script with your own setup to create DataSources and Connection pools, Security Realms, deploy artifacts, and so on. You can also extend images and override an existing domain, or create a new one with WLST.
 
-## Building and Running the Oracle FMW Infrastructure Docker Image
+## Running the Oracle FMW Infrastructure Domain Docker Image
 To try a sample of a FMW Infrastructure Domain image configured, you will need two images, the FMW Infrastructure Domain image and an Oracle Database image. The Oracle Database image can be pulled from the [DockerStore](https://store.docker.com/images/oracle-database-enterprise-edition) or the [Oracle Container Registry](https://container-registry.oracle.com) or you can build your own using the Dockerfiles and scripts in GitHub. 
 
 Follow the steps below:
@@ -109,7 +110,7 @@ Follow the steps below:
   
   5. Start a container to launch the Admin Server from the image created in step 3. The environment variables used to configure the InfraDomain are defined in infraDomain.env.list file. Call docker run from the **dockerfiles/12.2.1.2** directory where the infraDomain.env.list file is and pass the file name at runtime. To run a Admin Server container call: 
 
-        $ docker run --detach=true -i -t -p 9001:7001 --network=InfraNET -v <Host Volume>:/u01/oracle/user_projects --name InfraAdminContainer --env-file ./infraDomain.env.list oracle/fmw-infrastructure:12.2.1.2
+        $ docker run --detach=true -p 9001:7001 --network=InfraNET -v <host volume>:/u01/oracle/user_projects --name InfraAdminContainer --env-file ./infraDomain.env.list oracle/fmw-infrastructure:12.2.1.2
 
   6. Access the administration console
 
@@ -120,7 +121,7 @@ Follow the steps below:
   
   7. Start a container to launch the Managed Server from the image created in step 3. The environment variables used to run the Managed Server image are defined in the file infraserver.env.list. Call docker run from the **dockerfiles/12.2.1.2** directory where the infraserver.env.list file is and pass the file name at runtime. To run a Managed Server container call:
 
-        $ docker run --detach=true -i -t -p 9801:8001 --network=InfraNET --volumes-from InfraAdminContainer --name InfraManagedContainer --env-file ./infraServer.env.list oracle/fmw-infrastructure:12.2.1.2 startManagedServer.sh
+        $ docker run --detach=true -p 9801:8001 --network=InfraNET --volumes-from InfraAdminContainer --name InfraManagedContainer --env-file ./infraServer.env.list oracle/fmw-infrastructure:12.2.1.2 startManagedServer.sh
 
 ## Copyright
-Copyright (c) 2014-2016 Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2014-2017 Oracle and/or its affiliates. All rights reserved.

--- a/OracleFMWInfrastructure/README.md
+++ b/OracleFMWInfrastructure/README.md
@@ -111,7 +111,7 @@ Follow the steps below:
   
   5. Start a container to launch the Admin Server from the image created in step 3. The environment variables used to configure the InfraDomain are defined in infraDomain.env.list file. Call docker run from the **dockerfiles/12.2.1.2** directory where the infraDomain.env.list file is and pass the file name at runtime. To run an Admin Server container call: 
 
-        $ docker run --detach=true -p 9001:7001 --network=InfraNET -v <host volume>:/u01/oracle/user_projects --name InfraAdminContainer --env-file ./infraDomain.env.list oracle/fmw-infrastructure:12.2.1.2
+        $ docker run --detach=true -p 9001:7001 --network=InfraNET -v \<host volume\>:/u01/oracle/user_projects --name InfraAdminContainer --env-file ./infraDomain.env.list oracle/fmw-infrastructure:12.2.1.2
 
   6. Access the administration console
 

--- a/OracleFMWInfrastructure/README.md
+++ b/OracleFMWInfrastructure/README.md
@@ -18,7 +18,7 @@ You must first download the Oracle Server JRE binary and drop in folder `../Orac
         $ cd ../OracleJava/java-8
         $ sh build.sh
 
-You can also pull the Oracle Server JRE 8 image from [Oracle Container Registry](https://container-registry.oracle.com) or the [Docker Store](https://store.docker.com/images/oracle-serverjre-8).
+You can also pull the Oracle Server JRE 8 image from [Oracle Container Registry](https://container-registry.oracle.com) or the [Docker Store](https://store.docker.com/images/oracle-serverjre-8).  If you pull the Server JRE 8 from the Oracle Container Registry you must edit you Dockerfile and change the FROM clause to be "FROM container-registry.oracle.com/java/serverjre". If you pull the Server JRE 8 from the DockerStore you must edit you Dockerfile and change the FROM clause to be "FROM store/oracle/serverjre:8".
 
 ### Building the Oracle FMW Infrastructure 12.2.1.2 base image
 **IMPORTANT:**If you are building the Oracle FMW Infrastructure image you must first download the Oracle FMW Infrastructure 12.2.1.2 binary and drop in folder `../OracleFMWInfrastructure/dockerfiles/12.2.1.2`. 

--- a/OracleFMWInfrastructure/README.md
+++ b/OracleFMWInfrastructure/README.md
@@ -19,6 +19,7 @@ You must first download the Oracle Server JRE binary and drop in folder `../Orac
         $ sh build.sh
 
 You can also pull the Oracle Server JRE 8 image from [Oracle Container Registry](https://container-registry.oracle.com) or the [Docker Store](https://store.docker.com/images/oracle-serverjre-8). When pulling the Server JRE 8 image retag the image so that it works with the existing Dockerfiles.
+
         $ docker tag container-registry.oracle.com/java/serverjre:8 oracle/serverjre:8
         $ docker tag store/oracle/serverjre:8 oracle/serverjre:8
         

--- a/OracleFMWInfrastructure/dockerfiles/12.2.1.2/Checksum
+++ b/OracleFMWInfrastructure/dockerfiles/12.2.1.2/Checksum
@@ -1,0 +1,5 @@
+# Download FMW Infrastructure Installer 12.2.1.2
+# 
+# - http://www.oracle.com/technetwork/middleware/weblogic/downloads/wls-for-dev-1703574.html 
+#
+f993b98e2eef2b60a2c5a6b0e5b518cc  fmw_12.2.1.2.0_infrastructure_Disk1_1of1.zip

--- a/OracleFMWInfrastructure/dockerfiles/12.2.1.2/Dockerfile
+++ b/OracleFMWInfrastructure/dockerfiles/12.2.1.2/Dockerfile
@@ -1,6 +1,6 @@
 # LICENSE CDDL 1.0 + GPL 2.0
 #
-# Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014-2017 Oracle and/or its affiliates. All rights reserved.
 #
 # ORACLE DOCKERFILES PROJECT
 # --------------------------
@@ -18,7 +18,7 @@
 #
 # From 
 # -------------------------
-FROM oracle/weblogic:12.2.1.2-infrastructure
+FROM oracle/serverjre:8
 
 # Maintainer
 # ----------
@@ -28,27 +28,46 @@ MAINTAINER Monica Riccelli <monica.riccelli@oracle.com>
 # Common environment variables required for this build 
 # ----------------------------------------------------
 ENV ORACLE_HOME=/u01/oracle \
+    SCRIPT_FILE=/u01/oracle/container-scripts/createInfraDomainAndStartAdmin.sh \
     USER_MEM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
     DOMAIN_NAME="${DOMAIN_NAME:-InfraDomain}" \
     DOMAIN_HOME=/u01/oracle/user_projects/domains/${DOMAIN_NAME:-InfraDomain} \
     PATH=$PATH:/usr/java/default/bin:/u01/oracle/oracle_common/common/bin:/u01/oracle/wlserver/common/bin:/u01/oracle/container-scripts
 
 
-USER root    
-# Setup subdirectory container-scripts
-# ------------------------------------------------------------  
-RUN mkdir -p /u01/oracle/container-scripts
+#USER root    
+# Setup subdirectory for FMW install package and container-scripts
+# -----------------------------------------------------------------  
+RUN mkdir -p /u01 && \ 
+    chmod a+xr /u01 && \
+    useradd -b /u01 -d /u01/oracle -m -s /bin/bash oracle && \
+    mkdir -p /u01/oracle/container-scripts
 
 
 # Copy packages and scripts
 # -------------
 COPY container-scripts/* /u01/oracle/container-scripts/
 
-RUN chmod +x /u01/oracle/container-scripts/*.sh && \
-    yum install -y libaio && \
-    yum clean all
+# Environment variables required for this build (do NOT change)
+# -------------------------------------------------------------
+ENV FMW_PKG=fmw_12.2.1.2.0_infrastructure_Disk1_1of1.zip \
+    FMW_JAR=fmw_12.2.1.2.0_infrastructure.jar
 
+# Copy packages
+# -------------
+COPY $FMW_PKG install.file oraInst.loc /u01/
+RUN chown oracle:oracle -R /u01 && \
+    chmod +xr $SCRIPT_FILE && \
+    yum install -y libaio && \
+    yum clean all 
+
+# Install 
+# ------------------------------------------------------------
 USER oracle
+RUN  cd /u01 && $JAVA_HOME/bin/jar xf /u01/$FMW_PKG && cd - && \
+    $JAVA_HOME/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME INSTALL_TYPE="WebLogic Server" && \
+    rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file
+
 WORKDIR ${ORACLE_HOME}
 
 # Define default command to start script.

--- a/OracleFMWInfrastructure/dockerfiles/12.2.1.2/container-scripts/createInfraDomainAndStartAdmin.sh
+++ b/OracleFMWInfrastructure/dockerfiles/12.2.1.2/container-scripts/createInfraDomainAndStartAdmin.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014-2017 Oracle and/or its affiliates. All rights reserved.
 #
 # If AdminServer.log does not exists, container is starting for 1st time
 # So it should start NM and also associate with AdminServer

--- a/OracleFMWInfrastructure/dockerfiles/12.2.1.2/container-scripts/update_listenaddress.py
+++ b/OracleFMWInfrastructure/dockerfiles/12.2.1.2/container-scripts/update_listenaddress.py
@@ -2,7 +2,7 @@
 #
 # Author:swati.mukundan@oracle.com
 #
-# Copyright (c) 2016-2017 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014-2017 Oracle and/or its affiliates. All rights reserved.
 #
 # SOA on Docker Default Domain
 #

--- a/OracleFMWInfrastructure/dockerfiles/12.2.1.2/fmw_12.2.1.2.0_infrastructure_Disk1_1of1.zip.download
+++ b/OracleFMWInfrastructure/dockerfiles/12.2.1.2/fmw_12.2.1.2.0_infrastructure_Disk1_1of1.zip.download
@@ -1,0 +1,5 @@
+# Download WebLogic Server Infrastructure  Installer 12.2.1.2
+# 
+# - http://www.oracle.com/technetwork/middleware/weblogic/downloads/wls-for-dev-1703574.html 
+#
+f993b98e2eef2b60a2c5a6b0e5b518cc  fmw_12.2.1.2.0_infrastructure_Disk1_1of1.zip

--- a/OracleFMWInfrastructure/dockerfiles/12.2.1.2/install.file
+++ b/OracleFMWInfrastructure/dockerfiles/12.2.1.2/install.file
@@ -1,0 +1,10 @@
+# Copyright (c) 2014-2017 Oracle and/or its affiliates. All rights reserved.
+[ENGINE]
+
+#DO NOT CHANGE THIS.
+Response File Version=1.0.0.0.0
+
+[GENERIC]
+
+DECLINE_SECURITY_UPDATES=true
+SECURITY_UPDATES_VIA_MYORACLESUPPORT=false

--- a/OracleFMWInfrastructure/dockerfiles/12.2.1.2/oraInst.loc
+++ b/OracleFMWInfrastructure/dockerfiles/12.2.1.2/oraInst.loc
@@ -1,0 +1,2 @@
+inventory_loc=/u01/oracle/.inventory
+inst_group=oracle


### PR DESCRIPTION
The Oracle FMW Infrastructure image now installs the binaries using the FMW Infrastructure 12.2.1.2 installer and has the scripts to build a base JRF enabled domain with an Admin Server and Managed Server.