### PR TITLE
OracleCoherence: Fix the permission issue while running the container

### DIFF
--- a/OracleCoherence/dockerfiles/12.2.1.0.0/Dockerfile.quickinstall
+++ b/OracleCoherence/dockerfiles/12.2.1.0.0/Dockerfile.quickinstall
@@ -49,7 +49,7 @@ COPY extend-cache-config.xml           $COHERENCE_HOME/conf/extend-cache-config.
 
 RUN useradd -b /u01 -m -s /bin/bash oracle && \
    echo oracle:oracle | chpasswd && \
-   chmod +x /start.sh && \
+   chmod 755 /start.sh && \
    chmod a+xr /u01 && \
    chown -R oracle:oracle /u01
 

--- a/OracleCoherence/dockerfiles/12.2.1.0.0/Dockerfile.standalone
+++ b/OracleCoherence/dockerfiles/12.2.1.0.0/Dockerfile.standalone
@@ -49,7 +49,7 @@ COPY extend-cache-config.xml           $COHERENCE_HOME/conf/extend-cache-config.
 
 RUN useradd -b /u01 -m -s /bin/bash oracle && \
    echo oracle:oracle | chpasswd && \
-   chmod +x /start.sh && \
+   chmod 755 /start.sh && \
    chmod a+xr /u01 && \
    chown -R oracle:oracle /u01
 

--- a/OracleCoherence/dockerfiles/12.2.1.2.0/Dockerfile.quickinstall
+++ b/OracleCoherence/dockerfiles/12.2.1.2.0/Dockerfile.quickinstall
@@ -49,7 +49,7 @@ COPY extend-cache-config.xml           $COHERENCE_HOME/conf/extend-cache-config.
 
 RUN useradd -b /u01 -m -s /bin/bash oracle && \
    echo oracle:oracle | chpasswd && \
-   chmod +x /start.sh && \
+   chmod 755 /start.sh && \
    chmod a+xr /u01 && \
    chown -R oracle:oracle /u01
 

--- a/OracleCoherence/dockerfiles/12.2.1.2.0/Dockerfile.standalone
+++ b/OracleCoherence/dockerfiles/12.2.1.2.0/Dockerfile.standalone
@@ -49,7 +49,7 @@ COPY extend-cache-config.xml           $COHERENCE_HOME/conf/extend-cache-config.
 
 RUN useradd -b /u01 -m -s /bin/bash oracle && \
    echo oracle:oracle | chpasswd && \
-   chmod +x /start.sh && \
+   chmod 755 /start.sh && \
    chmod a+xr /u01 && \
    chown -R oracle:oracle /u01
 


### PR DESCRIPTION
Got the following error while running the Coherence container:

  "sh: /start.sh: Permission denied"

This patch intends to fix it.

Signed-off-by: Dong Zhu <dong.zhu@oracle.com>