### PR TITLE
Fixes issue #502 - Remove oracle user password in Coherence Dockerfiles

### DIFF
--- a/OracleCoherence/dockerfiles/12.2.1.0.0/Dockerfile.quickinstall
+++ b/OracleCoherence/dockerfiles/12.2.1.0.0/Dockerfile.quickinstall
@@ -48,7 +48,6 @@ COPY start.sh                          /start.sh
 COPY extend-cache-config.xml           $COHERENCE_HOME/conf/extend-cache-config.xml
 
 RUN useradd -b /u01 -m -s /bin/bash oracle && \
-   echo oracle:oracle | chpasswd && \
    chmod 755 /start.sh && \
    chmod a+xr /u01 && \
    chown -R oracle:oracle /u01

--- a/OracleCoherence/dockerfiles/12.2.1.0.0/Dockerfile.standalone
+++ b/OracleCoherence/dockerfiles/12.2.1.0.0/Dockerfile.standalone
@@ -48,7 +48,6 @@ COPY start.sh                          /start.sh
 COPY extend-cache-config.xml           $COHERENCE_HOME/conf/extend-cache-config.xml
 
 RUN useradd -b /u01 -m -s /bin/bash oracle && \
-   echo oracle:oracle | chpasswd && \
    chmod 755 /start.sh && \
    chmod a+xr /u01 && \
    chown -R oracle:oracle /u01

--- a/OracleCoherence/dockerfiles/12.2.1.2.0/Dockerfile.quickinstall
+++ b/OracleCoherence/dockerfiles/12.2.1.2.0/Dockerfile.quickinstall
@@ -48,7 +48,6 @@ COPY start.sh                          /start.sh
 COPY extend-cache-config.xml           $COHERENCE_HOME/conf/extend-cache-config.xml
 
 RUN useradd -b /u01 -m -s /bin/bash oracle && \
-   echo oracle:oracle | chpasswd && \
    chmod 755 /start.sh && \
    chmod a+xr /u01 && \
    chown -R oracle:oracle /u01

--- a/OracleCoherence/dockerfiles/12.2.1.2.0/Dockerfile.standalone
+++ b/OracleCoherence/dockerfiles/12.2.1.2.0/Dockerfile.standalone
@@ -48,7 +48,6 @@ COPY start.sh                          /start.sh
 COPY extend-cache-config.xml           $COHERENCE_HOME/conf/extend-cache-config.xml
 
 RUN useradd -b /u01 -m -s /bin/bash oracle && \
-   echo oracle:oracle | chpasswd && \
    chmod 755 /start.sh && \
    chmod a+xr /u01 && \
    chown -R oracle:oracle /u01


### PR DESCRIPTION
Apart from being in breach of the contribution rules, these passwords are not actually required. I built and tested the images locally without them and everything worked.