### PR TITLE
OracleCoherence: Fix warnings while building image

### DIFF
--- a/OracleCoherence/dockerfiles/12.2.1.0.0/Dockerfile.quickinstall
+++ b/OracleCoherence/dockerfiles/12.2.1.0.0/Dockerfile.quickinstall
@@ -42,13 +42,15 @@ ENV FMW_PKG=fmw_12.2.1.0.0_coherence_quick_Disk1_1of1.zip \
 
 ENV COHERENCE_HOME=$ORACLE_HOME/coherence
 
+RUN mkdir -p /u01 && \
+   useradd -b /u01 -d /u01/oracle -m -s /bin/bash oracle
+
 # Copy files required to build this image
 COPY $FMW_PKG install.file oraInst.loc /u01/
 COPY start.sh                          /start.sh
 COPY extend-cache-config.xml           $COHERENCE_HOME/conf/extend-cache-config.xml
 
-RUN useradd -b /u01 -m -s /bin/bash oracle && \
-   chmod 755 /start.sh && \
+RUN chmod 755 /start.sh && \
    chmod a+xr /u01 && \
    chown -R oracle:oracle /u01
 

--- a/OracleCoherence/dockerfiles/12.2.1.0.0/Dockerfile.standalone
+++ b/OracleCoherence/dockerfiles/12.2.1.0.0/Dockerfile.standalone
@@ -42,13 +42,15 @@ ENV FMW_PKG=fmw_12.2.1.0.0_coherence_Disk1_1of1.zip \
 
 ENV COHERENCE_HOME=$ORACLE_HOME/coherence
 
+RUN mkdir -p /u01 && \
+   useradd -b /u01 -d /u01/oracle -m -s /bin/bash oracle
+
 # Copy files required to build this image
 COPY $FMW_PKG install.file oraInst.loc /u01/
 COPY start.sh                          /start.sh
 COPY extend-cache-config.xml           $COHERENCE_HOME/conf/extend-cache-config.xml
 
-RUN useradd -b /u01 -m -s /bin/bash oracle && \
-   chmod 755 /start.sh && \
+RUN chmod 755 /start.sh && \
    chmod a+xr /u01 && \
    chown -R oracle:oracle /u01
 

--- a/OracleCoherence/dockerfiles/12.2.1.2.0/Dockerfile.quickinstall
+++ b/OracleCoherence/dockerfiles/12.2.1.2.0/Dockerfile.quickinstall
@@ -42,13 +42,15 @@ ENV FMW_PKG=fmw_12.2.1.2.0_coherence_quick_Disk1_1of1.zip \
 
 ENV COHERENCE_HOME=$ORACLE_HOME/coherence
 
+RUN mkdir -p /u01 && \
+   useradd -b /u01 -d /u01/oracle -m -s /bin/bash oracle
+
 # Copy files required to build this image
 COPY $FMW_PKG install.file oraInst.loc /u01/
 COPY start.sh                          /start.sh
 COPY extend-cache-config.xml           $COHERENCE_HOME/conf/extend-cache-config.xml
 
-RUN useradd -b /u01 -m -s /bin/bash oracle && \
-   chmod 755 /start.sh && \
+RUN chmod 755 /start.sh && \
    chmod a+xr /u01 && \
    chown -R oracle:oracle /u01
 

--- a/OracleCoherence/dockerfiles/12.2.1.2.0/Dockerfile.standalone
+++ b/OracleCoherence/dockerfiles/12.2.1.2.0/Dockerfile.standalone
@@ -42,13 +42,15 @@ ENV FMW_PKG=fmw_12.2.1.2.0_coherence_Disk1_1of1.zip \
 
 ENV COHERENCE_HOME=$ORACLE_HOME/coherence
 
+RUN mkdir -p /u01 && \
+   useradd -b /u01 -d /u01/oracle -m -s /bin/bash oracle
+
 # Copy files required to build this image
 COPY $FMW_PKG install.file oraInst.loc /u01/
 COPY start.sh                          /start.sh
 COPY extend-cache-config.xml           $COHERENCE_HOME/conf/extend-cache-config.xml
 
-RUN useradd -b /u01 -m -s /bin/bash oracle && \
-   chmod 755 /start.sh && \
+RUN chmod 755 /start.sh && \
    chmod a+xr /u01 && \
    chown -R oracle:oracle /u01
 


### PR DESCRIPTION
Got the following warning while building the image:

  "useradd: warning: the home directory already exists.
  Not copying any file from skel directory into it."

This patch intends to fix it.

Signed-off-by: Dong Zhu <dong.zhu@oracle.com>