### PR TITLE
Correct the FROM directive

### DIFF
--- a/OracleSOASuite/dockerfiles/12.2.1.2-soabpm/Dockerfile
+++ b/OracleSOASuite/dockerfiles/12.2.1.2-soabpm/Dockerfile
@@ -12,7 +12,7 @@
 #
 # Pull base image
 # ---------------
-FROM middleware/fmw-infrastructure:12.2.1.2
+FROM oracle/fmw-infrastructure:12.2.1.2
 #
 # Maintainer
 # ----------


### PR DESCRIPTION
Switch `middleware` to `oracle` in the FROM directive to match the documentation of the upstream image.

Signed-off by: Avi Miller <avi.miller@oracle.com>