### PR TITLE
Make DB image smaller, correct checkSpace.sh for 12.1.0.2

### DIFF
--- a/OracleDatabase/dockerfiles/12.1.0.2/checkSpace.sh
+++ b/OracleDatabase/dockerfiles/12.1.0.2/checkSpace.sh
@@ -11,7 +11,8 @@
 # 
 
 REQUIRED_SPACE_GB=12
-if [ `df -B 1G . | tail -n 1 | awk '{print $4'}` -lt $REQUIRED_SPACE_GB ]; then
+
+if [ `df -B 1G . | tail -n 1 | awk '{ print $4 }'` -lt $REQUIRED_SPACE_GB ]; then
   script_name=`basename "$0"`
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   echo "$script_name: ERROR - There is not enough space available in the docker container."

--- a/OracleDatabase/dockerfiles/12.1.0.2/installDBBinaries.sh
+++ b/OracleDatabase/dockerfiles/12.1.0.2/installDBBinaries.sh
@@ -45,14 +45,35 @@ fi;
 # ---------------------
 sed -i -e "s|###ORACLE_EDITION###|$EDITION|g" $INSTALL_DIR/$INSTALL_RSP && \
 sed -i -e "s|###ORACLE_BASE###|$ORACLE_BASE|g" $INSTALL_DIR/$INSTALL_RSP && \
-sed -i -e "s|###ORACLE_HOME###|$ORACLE_HOME|g" $INSTALL_DIR/$INSTALL_RSP && \
+sed -i -e "s|###ORACLE_HOME###|$ORACLE_HOME|g" $INSTALL_DIR/$INSTALL_RSP
+
+# Install Oracle binaries
 cd $INSTALL_DIR       && \
 unzip $INSTALL_FILE_1 && \
 rm $INSTALL_FILE_1    && \
 unzip $INSTALL_FILE_2 && \
 rm $INSTALL_FILE_2    && \
 $INSTALL_DIR/database/runInstaller -silent -force -waitforcompletion -responsefile $INSTALL_DIR/$INSTALL_RSP -ignoresysprereqs -ignoreprereq && \
-rm -rf $INSTALL_DIR/database && \
+cd $HOME
+
+# Remove not needed components
+rm -rf $ORACLE_HOME/apex && \
+rm -rf $ORACLE_HOME/jdbc && \
+# ZDLRA installer files
+rm -rf $ORACLE_HOME/lib/ra*.zip && \
+rm -rf $ORACLE_HOME/ords && \
+rm -rf $ORACLE_HOME/sqldeveloper && \
+rm -rf $ORACLE_HOME/ucp && \
+# OUI backup
+rm -rf $ORACLE_HOME/inventory/backup/* && \
+# Network tools help
+rm -rf $ORACLE_HOME/network/tools/help/mgr/help_* && \
+# Temp location
+rm -rf /tmp/* && \
+# Database files directory
+rm -rf $INSTALL_DIR/database
+
+# Link password reset file to home directory
 ln -s $ORACLE_BASE/$PWD_FILE $HOME/
 
 # Check whether Perl is working

--- a/OracleDatabase/dockerfiles/12.2.0.1/checkSpace.sh
+++ b/OracleDatabase/dockerfiles/12.2.0.1/checkSpace.sh
@@ -11,7 +11,7 @@
 # 
 
 REQUIRED_SPACE_GB=15
-AVAILABLE_SPACE_GB=`df -B 1G / | tail -n 1 | awk '{print $4}'`
+AVAILABLE_SPACE_GB=`df -B 1G / | tail -n 1 | awk '{ print $4 }'`
 
 if [ $AVAILABLE_SPACE_GB -lt $REQUIRED_SPACE_GB ]; then
   script_name=`basename "$0"`

--- a/OracleDatabase/dockerfiles/12.2.0.1/installDBBinaries.sh
+++ b/OracleDatabase/dockerfiles/12.2.0.1/installDBBinaries.sh
@@ -51,15 +51,24 @@ sed -i -e "s|###ORACLE_HOME###|$ORACLE_HOME|g" $INSTALL_DIR/$INSTALL_RSP
 cd $INSTALL_DIR       && \
 unzip $INSTALL_FILE_1 && \
 rm $INSTALL_FILE_1    && \
-$INSTALL_DIR/database/runInstaller -silent -force -waitforcompletion -responsefile $INSTALL_DIR/$INSTALL_RSP -ignoresysprereqs -ignoreprereq
+$INSTALL_DIR/database/runInstaller -silent -force -waitforcompletion -responsefile $INSTALL_DIR/$INSTALL_RSP -ignoresysprereqs -ignoreprereq && \
+cd $HOME
 
 # Remove not needed components
 rm -rf $ORACLE_HOME/apex && \
 rm -rf $ORACLE_HOME/jdbc && \
+# ZDLRA installer files
 rm -rf $ORACLE_HOME/lib/ra*.zip && \
 rm -rf $ORACLE_HOME/ords && \
 rm -rf $ORACLE_HOME/sqldeveloper && \
 rm -rf $ORACLE_HOME/ucp && \
+# OUI backup
+rm -rf $ORACLE_HOME/inventory/backup/* && \
+# Network tools help
+rm -rf $ORACLE_HOME/network/tools/help/mgr/help_* && \
+# Temp location
+rm -rf /tmp/* && \
+# Database files directory
 rm -rf $INSTALL_DIR/database
 
 # Link password reset file to home directory


### PR DESCRIPTION
The bulk of these changes save 430+MB of both, 12.2.0.1 and 12.1.0.2 images.
There is also one correction of the required space in 12.1.0.2 in `checkSpace.sh` where the required space is only 12GB rather than 15GB for 12.2.