### PR TITLE
Add NoSQL EE 4.5 Dockerfile and README update

### DIFF
--- a/NoSQL/4.5.12/Dockerfile
+++ b/NoSQL/4.5.12/Dockerfile
@@ -1,0 +1,41 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# 
+# Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+#
+# ORACLE DOCKERFILES PROJECT
+# --------------------------
+# This is the Dockerfile for Oracle NoSQL Database Release 4.5.12 Enterprise Edition
+# 
+# REQUIRED FILES TO BUILD THIS IMAGE
+# ----------------------------------
+# (1) kv-ee-4.5.12.tar.gz
+#     Download Oracle NoSQL Database Enterprise Edition for Linux x64
+#     http://www.oracle.com/technetwork/database/database-technologies/nosqldb/downloads/index.html
+#
+# HOW TO BUILD THIS IMAGE
+# -----------------------
+# Put all downloaded files (in tar.gz format) in the same directory as this Dockerfile
+# Run: 
+#      $ docker build -t oracle/nosqlee:4.5.12 . 
+#
+# Pull base image
+# ---------------
+FROM oracle/serverjre:8
+
+MAINTAINER Mayuresh A Nirhali <mayuresh.nirhali@oracle.com>
+
+ENV VERSION="4.5.12" \
+    KVHOME=/kv-4.5.12 \
+    PACKAGE="kv-ee" \
+    EXTENSION="tar.gz" \
+    _JAVA_OPTIONS="-Djava.security.egd=file:/dev/./urandom"
+
+ADD ${PACKAGE}-${VERSION}.${EXTENSION} /
+ 
+VOLUME ["/kvroot"]
+
+WORKDIR "$KVHOME"
+
+EXPOSE 5000 5010-5020
+
+CMD ["java", "-jar", "lib/kvstore.jar", "kvlite", "-secure-config", "disable", "-root", "/kvroot"]

--- a/NoSQL/README.md
+++ b/NoSQL/README.md
@@ -2,6 +2,7 @@
 Sample Docker build files to facilitate installation and environment setup for DevOps users. For more information about Oracle NoSQL Database please see the [Oracle NoSQL Database Online Documentation](http://docs.oracle.com/cd/NOSQL/html/).
 
 This project offers sample Dockerfiles for:
+ * Oracle NoSQL Database (4.5.12) Enterprise Edition 
  * Oracle NoSQL Database (4.4.6) Enterprise Edition 
  * Oracle NoSQL Database (4.3.11) Community Edition 
  * Oracle NoSQL Database (4.0.9) Community Edition 
@@ -11,9 +12,9 @@ This project offers sample Dockerfiles for:
 # Quickstart Building docker images for Oracle NoSQL Database
 For Enterprise Edition, download the bundle (in tar.gz format) from [Oracle Technology Network](http://www.oracle.com/technetwork/database/database-technologies/nosqldb/downloads/index.html) and copy it in the same directory as the Enterprise Edition Dockerfile. then build the docker image as per below,
 
-        $ docker build -t oracle/nosqlee:4.4.6 .
+        $ docker build -t oracle/nosqlee:4.5.12 .
 
-For Community Edition, the zip bundle is already downloaded and available in the oracle/nosql:latest docker image.
+For Community Edition, the zip bundle is already downloaded and available in the oracle/nosql:latest docker image. There is no need to build docker image for Community Edition.
 
 # Quickstart Running Oracle NoSQL Database on Docker
 The steps outlined below are using Oracle NoSQL Database community edition, if you are using Oracle NoSQL Database Enterprise Edition, please use the appropriate docker image name.


### PR DESCRIPTION
Oracle NoSQL Enterprise Edition v4.5 was released earlier this week. Adding a Dockerfile to build a docker image for that version.