### PR TITLE
Oracle GoldenGate on Docker

### DIFF
--- a/OracleGoldenGate/Dockerfile
+++ b/OracleGoldenGate/Dockerfile
@@ -45,16 +45,19 @@ ENV         JAVA_HOME=/usr/lib/jvm/jre \
 ADD         ${OGG_TARFILE} ${OGG_HOME}/
 COPY        runOracleGoldenGate.sh /
 
+#
+# Initial setup
+# - This image will be smaller if the oracle:oinstall user has the numeric identifiers 54321:54321
+# - 'vi' is used by the Oracle GoldenGate 'ggsci' utility to edit parameter
+#    files and must be run from inside the container.
+# - Installation of additional software packages depends on the value of ${OGG_EDITION}
+#
 RUN         if [[ -z "${OGG_VERSION}" || -z "${OGG_EDITION}" || -z "${OGG_TARFILE}" ]]; then \
                 echo "----------------------------------------------------------------------------------" && \
                 echo "-- Missing build argument for Dockerfile. See README.md for usage instructions. --" && \
                 echo "----------------------------------------------------------------------------------" && \
                 exit 1; \
             fi; \
-#
-# Initial setup
-# - This image will be smaller if the oracle:oinstall user has the numeric identifiers 54321:54321
-#
             groupadd -g 54321    oinstall        || /bin/true; \
             useradd  -u 54321 -g oinstall oracle || /bin/true; \
             chown oracle:oinstall ${OGG_HOME}; \
@@ -65,18 +68,10 @@ RUN         if [[ -z "${OGG_VERSION}" || -z "${OGG_EDITION}" || -z "${OGG_TARFIL
                 echo "----------------------------------------------------------------------------------" && \
                 chown -R oracle:oinstall ${OGG_HOME}; \
             fi; \
-#
-# Additional installation for Oracle GoldenGate Standard Edition
-# - 'vi' is used by the Oracle GoldenGate 'ggsci' utility to edit parameter
-#    files and must be run from inside the container.
-#
             if [[ "${OGG_EDITION}" == "standard" ]]; then \
                 yum -y install util-linux vi java-1.8.0-openjdk-headless && \
                 yum -y clean  all; \
             fi; \
-#
-# Additional installation for Oracle GoldenGate Microservices Architecture
-#
             if [[ "${OGG_EDITION}" == "microservices" ]]; then \
                 . /etc/os-release && MAJOR_VERSION="${VERSION/.*/}" && \
                 yum -y --enablerepo ol${MAJOR_VERSION}_software_collections install openssl rh-nginx18 java-1.8.0-openjdk-headless && \

--- a/OracleGoldenGate/README.md
+++ b/OracleGoldenGate/README.md
@@ -1,6 +1,6 @@
 Oracle GoldenGate on Docker
 ===============
-Sample Docker build files to provide an installation of Oracle GoldenGate for DevOps users. For more information about Oracle GoldenGate please see the [Oracle GoldenGate On-line Documentation](https://docs.oracle.com/goldengate/c1221/gg-winux/index.html).
+Sample Docker build files to provide an installation of Oracle GoldenGate for DevOps users. For more information about Oracle GoldenGate please see the [Oracle GoldenGate 12c On-line Documentation](https://docs.oracle.com/goldengate/c1230/gg-winux/index.html).
 
 **IMPORTANT:** To create images for Oracle GoldenGate on Docker, you must use Docker version 17.05.0 or later. You can check the version of Docker on your system with the `docker version` command.
 


### PR DESCRIPTION
 - Re-arrange comments in Dockerfile to fix "[WARNING]: Empty continuation lines will become errors in a future release." reported in Docker version 17.07.0-ce
 - Change link for Oracle GoldenGate documentation to the current release, 12.3.0.1.0

Signed-off-by: Stephen Balousek <stephen.balousek@oracle.com>