### PR TITLE
Fixed a typo in admin console URL in README.md

### DIFF
--- a/OracleWebLogic/dockerfiles/12.2.1.3/README.md
+++ b/OracleWebLogic/dockerfiles/12.2.1.3/README.md
@@ -95,7 +95,7 @@ To try a sample of a WebLogic Server image with a base domain configured, follow
   4. Run the administration console
 
         $ docker inspect --format '{{.NetworkSettings.IPAddress}}' <container-name>
-        This returns the IPAddress (example xxx.xx.x.x) of the container.  Got to your browser and enter http://xxx.xx.x.x:8001/console
+        This returns the IPAddress (example xxx.xx.x.x) of the container.  Got to your browser and enter http://xxx.xx.x.x:7001/console
         
 
 ## Choose your Oracle WebLogic Server Distribution


### PR DESCRIPTION
Changed "8001" to "7001" as it is inconsistent with rest of instructions, so the line:
        This returns the IPAddress (example xxx.xx.x.x) of the container.  Got to your browser and enter http://xxx.xx.x.x:8001/console
is now:
        This returns the IPAddress (example xxx.xx.x.x) of the container.  Got to your browser and enter http://xxx.xx.x.x:7001/console