### PR TITLE
Better location for information on server JRE

### DIFF
--- a/OracleJava/README.md
+++ b/OracleJava/README.md
@@ -2,7 +2,7 @@ Oracle Java on Docker
 =====
 Build a Docker image containing Oracle Java (Server JRE specifically).
 
-The Oracle Java Server JRE provides the same features as Oracle Java JDK commonly required for Server-side Applications (i.e. Java EE application servers). For more information about Server JRE, visit this [release notes](http://www.oracle.com/technetwork/java/javase/7u21-relnotes-1932873.html#serverjre).
+The Oracle Java Server JRE provides the same features as Oracle Java JDK commonly required for Server-side Applications (i.e. Java EE application servers). For more information about Server JRE, visit the [Understanding the Server JRE](https://blogs.oracle.com/java-platform-group/understanding-the-server-jre) blog entry from the Java Product Management team.
 
 ## Java 8
 [Download Server JRE 8](http://www.oracle.com/technetwork/java/javase/downloads/server-jre8-downloads-2133154.html) `.tar.gz` file and drop it inside folder `java-8`. 


### PR DESCRIPTION
A blog with more information on the server JRE is now a better source of information on what that package option is  and why it is being offered.