### PR TITLE
Replacing yum -y clean all across the repo

### DIFF
--- a/OracleGoldenGate/Dockerfile
+++ b/OracleGoldenGate/Dockerfile
@@ -70,12 +70,12 @@ RUN         if [[ -z "${OGG_VERSION}" || -z "${OGG_EDITION}" || -z "${OGG_TARFIL
             fi; \
             if [[ "${OGG_EDITION}" == "standard" ]]; then \
                 yum -y install util-linux vi java-1.8.0-openjdk-headless && \
-                yum -y clean  all; \
+                rm -rf /var/cache/yum; \
             fi; \
             if [[ "${OGG_EDITION}" == "microservices" ]]; then \
                 . /etc/os-release && MAJOR_VERSION="${VERSION/.*/}" && \
                 yum -y --enablerepo ol${MAJOR_VERSION}_software_collections install openssl rh-nginx18 java-1.8.0-openjdk-headless && \
-                yum -y clean  all && \
+                rm -rf /var/cache/yum && \
                 ln -s /etc/opt/rh/rh-nginx18/nginx /etc/nginx && \
                 sh /etc/ssl/certs/make-dummy-cert  /etc/nginx/ogg.pem && \
                 mkdir -p              ${OGG_DEPLOY_BASE} && \

--- a/OracleTuxedo/core/dockerfiles/12.1.3/Dockerfile
+++ b/OracleTuxedo/core/dockerfiles/12.1.3/Dockerfile
@@ -21,7 +21,7 @@ ENV ORACLE_HOME=/u01/oracle \
 # Setup filesystem and oracle user
 # Adjust file permissions, go to /u01 as user 'oracle' to proceed with WLS installation
 # ------------------------------------------------------------
-RUN yum -y install unzip gcc file hostname which util-linux && yum -y clean all && \
+RUN yum -y install unzip gcc file hostname which util-linux && rm -rf /var/cache/yum && \
     mkdir -p /u01 && chmod a+xr /u01 && \
     groupadd -g 1000 oracle && useradd -b /u01 -m -g oracle -u 1000 -s /bin/bash oracle 
 

--- a/OracleTuxedo/core/dockerfiles/12.2.2/Dockerfile
+++ b/OracleTuxedo/core/dockerfiles/12.2.2/Dockerfile
@@ -21,7 +21,7 @@ ENV ORACLE_HOME=/u01/oracle \
 # Setup filesystem and oracle user
 # Adjust file permissions, go to /u01 as user 'oracle' to proceed with WLS installation
 # ------------------------------------------------------------
-RUN yum -y install unzip gcc file hostname which util-linux && yum -y clean all && \
+RUN yum -y install unzip gcc file hostname which util-linux && rm -rf /var/cache/yum && \
     mkdir -p /u01 && chmod a+xr /u01 && \
     groupadd -g 1000 oracle && useradd -b /u01 -m -g oracle -u 1000 -s /bin/bash oracle 
 


### PR DESCRIPTION
* Replacing yum -y clean all with rm -rf /var/cache/yum to avoid the annoying yum message that now appears.

Signed-off-by: Stephen Balousek <stephen.balousek@oracle.com>