### PR TITLE
Add note to README.md for Express Edition.

### DIFF
--- a/OracleDatabase/README.md
+++ b/OracleDatabase/README.md
@@ -166,7 +166,8 @@ After the database is setup and/or started the scripts in those folders will be 
 SQL scripts will be executed as sysdba, shell scripts will be executed as the current user. To ensure proper order it is
 recommended to prefix your scripts with a number. For example `01_users.sql`, `02_permissions.sql`, etc.
 
-**Note:** The startup scripts will also be executed after the first time database setup is complete.
+**Note:** The startup scripts will also be executed after the first time database setup is complete.  
+**Note:** Use `/u01/app/oracle/scripts/` instead of `/opt/oracle/scripts/setup` for Express Edition.  
 
 The example below mounts the local directory myScripts to `/opt/oracle/myScripts` which is then searched for custom startup scripts:
 

--- a/OracleDatabase/README.md
+++ b/OracleDatabase/README.md
@@ -167,7 +167,7 @@ SQL scripts will be executed as sysdba, shell scripts will be executed as the cu
 recommended to prefix your scripts with a number. For example `01_users.sql`, `02_permissions.sql`, etc.
 
 **Note:** The startup scripts will also be executed after the first time database setup is complete.  
-**Note:** Use `/u01/app/oracle/scripts/` instead of `/opt/oracle/scripts/setup` for Express Edition.  
+**Note:** Use `/u01/app/oracle/scripts/` instead of `/opt/oracle/scripts/` for Express Edition.  
 
 The example below mounts the local directory myScripts to `/opt/oracle/myScripts` which is then searched for custom startup scripts:
 


### PR DESCRIPTION
Enterprise and Standard Edition 2 uses ``/opt/oracle/scripts/``.  
Express Edition uses ``/u01/app/oracle/scripts``.  
To clear specification, ``Add note to under Running scripts after setup and on startup`` section.