### PR TITLE
Add OpenGrok Dockerfiles

### DIFF
--- a/OpenGrok/Dockerfile
+++ b/OpenGrok/Dockerfile
@@ -1,0 +1,46 @@
+FROM tomcat:9-jre8
+MAINTAINER Nathan Guimaraes "dev.nathan.guimaraes@gmail.com"
+
+#PREPARING OPENGROK BINARIES AND FOLDERS
+ADD https://github.com/OpenGrok/OpenGrok/releases/download/1.0/opengrok-1.0.tar.gz /opengrok.tar.gz
+RUN tar -zxvf /opengrok.tar.gz && mv opengrok-* /opengrok && chmod -R +x /opengrok/bin
+RUN mkdir /src
+RUN mkdir /data
+RUN ln -s /data /var/opengrok
+RUN ln -s /src /var/opengrok/src
+
+#INSTALLING DEPENDENCIES
+RUN apt-get update && apt-get install -y exuberant-ctags git subversion mercurial unzip openssh-server cron inotify-tools
+
+#SSH configuration
+RUN mkdir /var/run/sshd
+RUN echo 'root:root' |chpasswd
+RUN sed -ri 's/[ #]*PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN sed -ri 's/[ #]*UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
+
+# CRON for Reindex configuration
+RUN echo "*/10 * * * * root  /scripts/index.sh" > /etc/cron.d/opengrok-cron
+RUN chmod 0644 /etc/cron.d/opengrok-cron
+
+#ENVIRONMENT VARIABLES CONFIGURATION
+ENV SRC_ROOT /src
+ENV DATA_ROOT /data
+ENV OPENGROK_TOMCAT_BASE /usr/local/tomcat
+ENV CATALINA_HOME /usr/local/tomcat
+ENV PATH $CATALINA_HOME/bin:$PATH
+ENV PATH /opengrok/bin:$PATH
+ENV CATALINA_BASE /usr/local/tomcat
+ENV CATALINA_HOME /usr/local/tomcat
+ENV CATALINA_TMPDIR /usr/local/tomcat/temp
+ENV JRE_HOME /usr
+ENV CLASSPATH /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
+
+WORKDIR $CATALINA_HOME
+RUN /opengrok/bin/OpenGrok deploy
+
+EXPOSE 8080
+EXPOSE 22
+
+ADD scripts /scripts
+RUN chmod -R +x /scripts
+CMD ["/scripts/start.sh"]

--- a/OpenGrok/README.md
+++ b/OpenGrok/README.md
@@ -1,0 +1,24 @@
+# A docker container for opengrok 1.0!
+
+## Opengrok release 1.0 from oficial source:
+Directly downloaded from oficial source:
+https://github.com/OpenGrok/OpenGrok/releases/tag/1.0
+
+## Additional info about the container:
+* SSH with root access;
+* Tomcat 9
+* JRE 8(Required for Opengrok 1.0);
+* Preconfigured cron task for reindexing(every 10 min);
+
+## How to run:
+docker run -d -v <path/to/your/src>:/src -p 8080:8080 nagui/opengrok:latest
+
+## SSH:
+First inspect the docker container so you can find the address to connect, then ssh into it using the following credentials:
+* user:root
+* pass:root
+
+## Default URL:
+localhost:8080/source
+
+Enjoy.

--- a/OpenGrok/scripts/index.sh
+++ b/OpenGrok/scripts/index.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+date +"%R Indexing starting">>/opengrok/indexing.log
+/opengrok/bin/OpenGrok index /src >>/opengrok/indexing.log
+date +"%R Indexing finishing">>/opengrok/indexing.log

--- a/OpenGrok/scripts/start.sh
+++ b/OpenGrok/scripts/start.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#START METHOD FOR INDEXING OF OPENGROK
+start_opengrok(){
+    # wait for tomcat startup
+    date +"%R Waiting for tomcat startup..">>/opengrok/indexing.log
+    while ! ( grep -q "org.apache.catalina.startup.Catalina.start Server startup"  /usr/local/tomcat/logs/catalina.*.log ); do
+        sleep 1;
+    done
+    date +"%R Startup finished..">>/opengrok/indexing.log
+    /scripts/index.sh
+}
+
+#START ALL NECESSARY SERVICES.	
+start_opengrok & 
+catalina.sh run &
+cron &
+/usr/sbin/sshd -D


### PR DESCRIPTION
OpenGrok is an Oracle project that was being hosted under github.com/OpenGrok. This PR is part of the migration of OpenGrok to the Oracle organization. One of their assets is a Dockerfile for creating a Docker image with the project pre-installed.

The latest version of those files are in this PR.