### PR TITLE
Remove Bruno from the list of code owners.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # The last matching pattern has the most precedence.
-*                         @brunoborges @Djelibeybi
+*                         @Djelibeybi
 /OracleDatabase/          @gvenzl
 /OracleRestDataServices/  @gvenzl
 /OracleCoherence/         @thegridman


### PR DESCRIPTION
As @brunoborges has decided to venture off on a new adventure, we'll have to somehow manage without him. 

Signed-off-by: Avi Miller <avi.miller@oracle.com>