### PR TITLE
Update README.md

### DIFF
--- a/NoSQL/README.md
+++ b/NoSQL/README.md
@@ -70,8 +70,6 @@ OpenJDK is licensed under the [GNU General Public License v2.0 with the Classpat
 The files in this repository folder are licensed under the [Universal Permissive License 1.0](http://oss.oracle.com/licenses/upl)
 
 # Commercial Support on Docker Containers
-Oracle NoSQL Enterprise Edition is **not** certified on Docker.
-
 Oracle NoSQL Community Edition has **no** commercial support.
 
 # Copyright


### PR DESCRIPTION
Now that Oracle NoSQL Enterprise Edition is supported on Docker - taking away the line that says not supported.