### PR TITLE
Add missing bracket in docker build command in script

### DIFF
--- a/OracleFMWInfrastructure/dockerfiles/buildDockerImage.sh
+++ b/OracleFMWInfrastructure/dockerfiles/buildDockerImage.sh
@@ -120,7 +120,7 @@ echo "Building image '$IMAGE_NAME' ..."
 
 # BUILD THE IMAGE (replace all environment variables)
 BUILD_START=$(date '+%s')
-docker build --force-rm=$NOCACHE --no-cache=$NOCACHE $PROXY_SETTINGS -t $IMAGE_NAME -f Dockerfile . ||
+docker build --force-rm=$NOCACHE --no-cache=$NOCACHE $PROXY_SETTINGS -t $IMAGE_NAME -f Dockerfile . || {
   echo "There was an error building the image."
   exit 1
 }


### PR DESCRIPTION
Correcting issue #816 Missing character in build command in script buildDockeImage.sh