### PR TITLE
Update new codeowner github user

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,7 +13,7 @@
 /OracleEDQ/               @subhashsutrave
 /OracleFMWInfrastructure/ @mriccell
 /OracleGoldenGate/        @sbalousek
-/OracleHTTPServer/        @prkishor
+/OracleHTTPServer/        @Prabhat-Kishore
 /OracleInstantClient/     @gvenzl
 /OracleJava/              @aureliogrb
 /OracleRestDataServices/  @gvenzl


### PR DESCRIPTION
Replace old GitHub user with new one.

Signed-off-by: Gerald Venzl <gerald.venzl@gmail.com>