### PR TITLE
Update contribution guide 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,14 +71,16 @@ a pull request.
 
 ### Base Image Rules
 
-1. All Oracle product images must use an Oracle Linux base image.
 1. Extend an existing product image wherever possible. For example, if your
 product requires WebLogic, then extend the WebLogic image instead of creating
 your own WebLogic installation.
+1. If you can't extend an existing image, your image must use the
+`oraclelinux:7-slim` base image as this image provides the smallest
+attack surface and is updated whenever a CVE errata is published.
 1. Re-use existing scripts wherever possible. If a particular base image or
 script doesn't have the functionality you need, open an issue and work with
 the image owner to implement it.
-1. Specify a fixed version in the `FROM` directive, i.e. use
+1. Specify a version in the `FROM` directive, i.e. use
 `FROM oraclelinux:7-slim` or `FROM java/serverjre:8`.
 1. All images must provide a `CMD` or `ENTRYPOINT`. If your image is designed
 to be extended, then this should output documentation on how to extend the


### PR DESCRIPTION
This makes it clear that images must use `oraclelinux:7-slim` when a more specific product image is not applicable. 

The `7-slim` variant has the smallest attack surface because it has the least amount of packages installed and is updated whenever a CVE patch is released for any package within the image.

Signed-off-by: Avi Miller <avi.miller@oracle.com>