### PR TITLE
Don't run check script via su

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/11.2.0.2/Dockerfile.xe
+++ b/OracleDatabase/SingleInstance/dockerfiles/11.2.0.2/Dockerfile.xe
@@ -81,6 +81,6 @@ RUN yum -y install unzip libaio bc initscripts net-tools openssl && \
 VOLUME ["$ORACLE_BASE/oradata"]
 EXPOSE 1521 8080
 HEALTHCHECK --interval=1m --start-period=5m \
-   CMD [ "su", "-p", "oracle", "-c", "$ORACLE_BASE/$CHECK_DB_FILE > /dev/null || exit 1" ] 
+   CMD "$ORACLE_BASE/$CHECK_DB_FILE" >/dev/null || exit 1
 
 CMD exec $ORACLE_BASE/$RUN_FILE


### PR DESCRIPTION
Bugfix for #858: Don't run health check shell as `oracle` as it's already taken care of inside the script.

Signed-off-by: Gerald Venzl <gerald.venzl@gmail.com>