### PR TITLE
fix(OracleDatabase): add save/restore oratab to runOracle.sh

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/11.2.0.2/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/11.2.0.2/runOracle.sh
@@ -44,6 +44,8 @@ function moveFiles {
    su -p oracle -c "mv $ORACLE_HOME/network/admin/listener.ora $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/"
    su -p oracle -c "mv $ORACLE_HOME/network/admin/tnsnames.ora $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/"
    mv /etc/sysconfig/oracle-xe $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/
+
+   cp /etc/oratab $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/
       
    symLinkFiles;
 }
@@ -70,6 +72,8 @@ function symLinkFiles {
    if [ ! -L /etc/sysconfig/oracle-xe ]; then
       ln -s $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/oracle-xe /etc/sysconfig/oracle-xe
    fi;
+
+   cp $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/oratab /etc/oratab
 }
 
 ########### SIGTERM handler ############


### PR DESCRIPTION
Merge save/restore handling from runOracle.sh 12.2.0.1

OracleDatabase/SingleInstance/11.2.0.2/xe does not start proper due missing /etc/oratab file on second container start.

Merge of lines:
https://github.com/oracle/docker-images/blob/dae5e50be1b651c14c2a680cc5ea56ca8d08993f/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/runOracle.sh#L27

https://github.com/oracle/docker-images/blob/dae5e50be1b651c14c2a680cc5ea56ca8d08993f/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/runOracle.sh#L56
