### PR TITLE
Correct OPatch command and Provide instruction to verify patch has been applied

### DIFF
--- a/OracleWebLogic/samples/12211-patch/Dockerfile
+++ b/OracleWebLogic/samples/12211-patch/Dockerfile
@@ -38,7 +38,7 @@ COPY $PSU_PKG /u01/
 # --------------------------------------------
 USER oracle
 RUN cd /u01 && $JAVA_HOME/bin/jar xf /u01/$PSU_PKG && cd - && \
-    cd /u01/24286152 && $ORACLE_HOME/OPatch/opatch apply -silent - oracle && \
+    cd /u01/24286152 && $ORACLE_HOME/OPatch/opatch apply -silent && \
     rm /u01/$PSU_PKG
 
 WORKDIR ${ORACLE_HOME}

--- a/OracleWebLogic/samples/12211-patch/README.md
+++ b/OracleWebLogic/samples/12211-patch/README.md
@@ -23,5 +23,21 @@ Go to your browser and start the Adminsitration console by running:
         http://localhost:7001/console
 
 Extend this patched image to create a domain image and start WebLogic Servers running in containers.
+
+## Verify that the Patch has been applied correctly
+Run a container from the image
+
+        $ docker run --name verify_patch 12211-psu24286152
+
+Go into the image
+
+        $ docker exec -it verify_patch /bin/bash
+
+cd OPatch and run:
+
+        ./opatch lsinventory 
+
+The patch will show in the inventory of applied patches.
+
 # Copyright
 Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.


### PR DESCRIPTION
Remove invalid option - oracle from OPatch command.
Add to README instructions to verify that a patch has been applied correctly.