### PR TITLE
Note to apply  patch if the Administration port is enabled.  

### DIFF
--- a/OracleWebLogic/dockerfiles/12.2.1.3/README.md
+++ b/OracleWebLogic/dockerfiles/12.2.1.3/README.md
@@ -69,7 +69,7 @@ You can override the default values of the following parameters during runtime w
       * `ADMINISTRATION_PORT_ENABLED` (default: `true`)
       * `ADMINISTRATION_PORT`         (default: `9002`)
 
-**NOTE**: To set the `DOMAIN_NAME`, you must set both `DOMAIN_NAME` and `DOMAIN_HOME`. For security, the Administration port 9002 is enabled by default. If you would like to disable it, then set `ADMINISTRTATION_PORT_ENABLED` to false. If you intend to run these images in production, then you must change the Production Mode to `production`.
+**NOTE**: For security, the Administration port 9002 is enabled by default, before running the container in WebLogic 12.2.1.3 the patch 27117282 must be applied. Please download the patch and apply it after you have built the 12.2.1.3 image. You can follow the sample https://github.com/oracle/docker-images/tree/master/OracleWebLogic/samples/12213-patch to see how to patch. An alternative is to not enable Administration port when you issue the docker run command, set `ADMINISTRTATION_PORT_ENABLED` to false. If you intend to run these images in production, then you must change the Production Mode to `production`. To set the `DOMAIN_NAME`, you must set both `DOMAIN_NAME` and `DOMAIN_HOME`.
 
 	$docker run -d -p 7001:7001 -p 9002:9002  -v `HOST PATH where the domain.properties file is`:/u01/oracle/properties -e ADMINISTRATION_PORT_ENABLED=true -e DOMAIN_HOME=/u01/oracle/user_projects/domains/abc_domain -e DOMAIN_NAME=abc_domain oracle/weblogic:12.2.1.3-developer
 

--- a/OracleWebLogic/samples/12213-patch/Dockerfile
+++ b/OracleWebLogic/samples/12213-patch/Dockerfile
@@ -1,0 +1,47 @@
+# LICENSE UPL 1.0
+#
+# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+#
+# ORACLE DOCKERFILES PROJECT
+# --------------------------
+# This Dockerfile extends the Oracle WebLogic install image and applies a patch.
+
+# REQUIRED FILES TO BUILD THIS IMAGE
+# ----------------------------------
+# (1) p27117282_122130_Generic.zip
+#     Download the patch from http://support.oracle.com
+#
+# HOW TO BUILD THIS IMAGE
+# -----------------------
+# Put all downloaded files in the same directory as this Dockerfile
+# Run:
+#      $ sudo docker build -t oracle/weblogic:12213-p27117282 .
+#
+
+# Pull base image
+# ---------------
+FROM oracle/weblogic:12.2.1.3-developer
+
+# Maintainer
+# ----------
+MAINTAINER Monica Riccelli <monica.riccelli@oracle.com>
+
+# Environment variables required for this build (do NOT change)
+# -------------------------------------------------------------
+ENV PATCH_PKG="p27117282_122130_Generic.zip"
+
+# Copy supplemental package and scripts
+# --------------------------------
+COPY $PATCH_PKG /u01/
+
+# Installation of Supplemental Quick Installer
+# --------------------------------------------
+USER oracle
+RUN cd /u01 && $JAVA_HOME/bin/jar xf /u01/$PATCH_PKG && cd - && \
+    cd /u01/27117282 && $ORACLE_HOME/OPatch/opatch apply -silent && \
+    rm /u01/$PATCH_PKG
+
+WORKDIR ${ORACLE_HOME}
+
+
+CMD ["/u01/oracle/createAndStartEmptyDomain.sh"]

--- a/OracleWebLogic/samples/12213-patch/README.md
+++ b/OracleWebLogic/samples/12213-patch/README.md
@@ -1,0 +1,62 @@
+Example of Image with WLS Domain
+================================
+This Dockerfile extends the Oracle WebLogic image by applying a patch.
+
+# How to build and run
+First make sure you have built **oracle/weblogic:12.2.1.3-developer**.
+
+Then download file [p27117282_122130_Generic.zip](http://support.oracle.com) and place it next to this README.
+
+To build, run:
+
+        $ docker build -t oracle/weblogic:12213-p27117282 .
+
+## Run Single Server Domain
+#### Providing the Administration Server user name and password
+The user name and password must be supplied in a `domain.properties` file located in a HOST directory that you will map at Docker runtime with the `-v` option to the image directory `/u01/oracle/properties`. The properties file enables the scripts to configure the correct authentication for the WebLogic Administration Server.
+
+The format of the `domain.properties` file is key=value pair:
+
+        username=myadminusername
+        password=myadminpassword
+
+**Note**: Oracle recommends that the `domain.properties` file be deleted or secured after the container and the WebLogic Server are started so that the user name and password are not inadvertently exposed.
+
+#### Start the container
+Start a container from the image created in step 1.
+You can override the default values of the following parameters during runtime with the `-e` option:
+
+      * `ADMIN_NAME`                  (default: `AdminServer`)
+      * `ADMIN_LISTEN_PORT`           (default: `7001`)
+      * `DOMAIN_NAME`                 (default: `base_domain`)
+      * `DOMAIN_HOME`                 (default: `/u01/oracle/user_projects/domains/base_domain`)
+      * `ADMINISTRATION_PORT_ENABLED` (default: `true`)
+      * `ADMINISTRATION_PORT`         (default: `9002`)
+
+**NOTE**: For security, the Administration port 9002 is enabled by default. If you would not like to enable the Administration port, set `ADMINISTRTATION_PORT_ENABLED` to false. If you intend to run these images in production, then you must change the Production Mode to `production`. To set the `DOMAIN_NAME`, you must set both `DOMAIN_NAME` and `DOMAIN_HOME`.
+
+        $docker run -d -p 7001:7001 -p 9002:9002  -v `HOST PATH where the domain.properties file is`:/u01/oracle/properties -e ADMINISTRATION_PORT_ENABLED=true -e DOMAIN_HOME=/u01/oracle/user_projects/domains/abc_domain -e DOMAIN_NAME=abc_domain oracle/weblogic:12213-p27117282 
+
+Run the WLS Administration Console:
+
+        $ docker inspect --format '{{.NetworkSettings.IPAddress}}' <container-name>
+
+In your browser, enter `https://xxx.xx.x.x:9002/console`. Your browser will request that you accept the Security Exception. To avoid the Security Exception, you must update the WebLogic Server SSL configuration with a custom identity certificate.
+
+## Verify that the Patch has been applied correctly
+Run a container from the image
+
+        $ docker run --name verify_patch oracle/weblogic:12213-p27117282
+
+Go into the image
+
+        $ docker exec -it verify_patch /bin/bash
+
+cd OPatch and run:
+
+        ./opatch lsinventory 
+
+The patch will show in the inventory of applied patches.
+
+# Copyright
+Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleWebLogic/samples/12213-patch/README.md
+++ b/OracleWebLogic/samples/12213-patch/README.md
@@ -33,7 +33,7 @@ You can override the default values of the following parameters during runtime w
       * `ADMINISTRATION_PORT_ENABLED` (default: `true`)
       * `ADMINISTRATION_PORT`         (default: `9002`)
 
-**NOTE**: For security, the Administration port 9002 is enabled by default. If you would not like to enable the Administration port, set `ADMINISTRTATION_PORT_ENABLED` to false. If you intend to run these images in production, then you must change the Production Mode to `production`. To set the `DOMAIN_NAME`, you must set both `DOMAIN_NAME` and `DOMAIN_HOME`.
+**NOTE**: For security, the Administration port 9002 is enabled by default. If you would like to disable the Administration port, set `ADMINISTRTATION_PORT_ENABLED` to false. If you intend to run these images in production, then you must change the Production Mode to `production`. To set the `DOMAIN_NAME`, you must set both `DOMAIN_NAME` and `DOMAIN_HOME`.
 
         $docker run -d -p 7001:7001 -p 9002:9002  -v `HOST PATH where the domain.properties file is`:/u01/oracle/properties -e ADMINISTRATION_PORT_ENABLED=true -e DOMAIN_HOME=/u01/oracle/user_projects/domains/abc_domain -e DOMAIN_NAME=abc_domain oracle/weblogic:12213-p27117282 
 

--- a/OracleWebLogic/samples/12213-patch/p27117282_122130_Generic.download
+++ b/OracleWebLogic/samples/12213-patch/p27117282_122130_Generic.download
@@ -1,0 +1,8 @@
+# Download this file from the following address:
+#
+# https://support.oracle.com
+#
+# 1)  Download the ZIP file "Patch" for WebLogic 12.2.1.3
+# 2) Put the ZIP file in the same location as this .download file
+# 
+06c65edaedc7310db673b8d1e650a504  p27117282_122130_Generic.zip


### PR DESCRIPTION
Add note to the README that asks user to apply  patch to the install image of WebLogic if the Administration port is enabled.  
Add WebLogic 12.2.1.3 patching sample.
This resolves issue #923.