### PR TITLE
Add Dockerfile for multi-stage build of oracle/database:18.3.0-se2

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/18.3.0/Dockerfile.se2-multistage
+++ b/OracleDatabase/SingleInstance/dockerfiles/18.3.0/Dockerfile.se2-multistage
@@ -1,0 +1,96 @@
+# LICENSE UPL 1.0
+#
+# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+#
+# ORACLE DOCKERFILES PROJECT
+# --------------------------
+# This is the Dockerfile for Oracle Database 12c Release 2 Enterprise Edition
+# 
+# REQUIRED FILES TO BUILD THIS IMAGE
+# ----------------------------------
+# (1) db_home.zip
+#     Download Oracle Database 18c Standard Edition 2 for Linux x64
+#     from http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html
+#
+# HOW TO BUILD THIS IMAGE
+# -----------------------
+# Put all downloaded files in the same directory as this Dockerfile
+# Run: 
+#      $ docker build -t oracle/database:18.3.0-se2 . 
+#
+# Pull base image
+# ---------------
+FROM oraclelinux:7-slim as base
+
+# Maintainer
+# ----------
+MAINTAINER Gerald Venzl <gerald.venzl@oracle.com>
+
+# Environment variables required for this build (do NOT change)
+# -------------------------------------------------------------
+ENV ORACLE_BASE=/opt/oracle \
+    ORACLE_HOME=/opt/oracle/product/18c/dbhome_1 \
+    INSTALL_FILE_1="LINUX.X64_180000_db_home.zip" \
+    INSTALL_RSP="db_inst.rsp" \
+    CONFIG_RSP="dbca.rsp.tmpl" \
+    PWD_FILE="setPassword.sh" \
+    RUN_FILE="runOracle.sh" \
+    START_FILE="startDB.sh" \
+    CREATE_DB_FILE="createDB.sh" \
+    SETUP_LINUX_FILE="setupLinuxEnv.sh" \
+    CHECK_SPACE_FILE="checkSpace.sh" \
+    CHECK_DB_FILE="checkDBStatus.sh" \
+    USER_SCRIPTS_FILE="runUserScripts.sh" \
+    INSTALL_DB_BINARIES_FILE="installDBBinaries.sh"
+
+# Use second ENV so that variable get substituted
+ENV INSTALL_DIR=$ORACLE_BASE/install \
+    PATH=$ORACLE_HOME/bin:$ORACLE_HOME/OPatch/:/usr/sbin:$PATH \
+    LD_LIBRARY_PATH=$ORACLE_HOME/lib:/usr/lib \
+    CLASSPATH=$ORACLE_HOME/jlib:$ORACLE_HOME/rdbms/jlib
+
+# Copy files needed during both installation and runtime
+COPY $INSTALL_RSP $SETUP_LINUX_FILE $CHECK_SPACE_FILE $INSTALL_DB_BINARIES_FILE $INSTALL_DIR/
+COPY $RUN_FILE $START_FILE $CREATE_DB_FILE $CONFIG_RSP $PWD_FILE $CHECK_DB_FILE $USER_SCRIPTS_FILE $ORACLE_BASE/
+
+RUN chmod ug+x $INSTALL_DIR/*.sh && \
+    sync && \
+    $INSTALL_DIR/$CHECK_SPACE_FILE && \
+    $INSTALL_DIR/$SETUP_LINUX_FILE
+
+# Start new stage for installing the database
+# -------------------------------------------
+FROM base AS builder
+
+COPY $INSTALL_FILE_1 $INSTALL_DIR/
+
+# Install DB software binaries
+USER oracle
+RUN $INSTALL_DIR/$INSTALL_DB_BINARIES_FILE SE2
+
+# Immediately delete installation zipfile
+USER root
+RUN rm -rf $INSTALL_FILE_1
+
+
+# Start new layer for database runtime
+# ------------------------------------
+FROM base
+
+USER oracle
+COPY --chown=oracle:dba --from=builder $ORACLE_BASE $ORACLE_BASE
+
+USER root
+RUN $ORACLE_BASE/oraInventory/orainstRoot.sh && \
+    $ORACLE_HOME/root.sh
+
+USER oracle
+WORKDIR /home/oracle
+
+VOLUME ["$ORACLE_BASE/oradata"]
+EXPOSE 1521 5500
+HEALTHCHECK --interval=1m --start-period=5m \
+   CMD "$ORACLE_BASE/$CHECK_DB_FILE" >/dev/null || exit 1
+    
+# Define default command to start Oracle Database. 
+CMD exec $ORACLE_BASE/$RUN_FILE

--- a/OracleDatabase/SingleInstance/dockerfiles/buildDockerImage.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/buildDockerImage.sh
@@ -23,6 +23,7 @@ Parameters:
    -x: creates image based on 'Express Edition'
    -i: ignores the MD5 checksums
    -o: passes on Docker build option
+   -m: Minimize image size by using multistage build (Requires Docker 17.05 to build)
 
 * select one edition only: -e, -s, or -x
 
@@ -64,8 +65,9 @@ EXPRESS=0
 VERSION="18.3.0"
 SKIPMD5=0
 DOCKEROPS=""
+MULTISTAGE=""
 
-while getopts "hesxiv:o:" optname; do
+while getopts "hesximv:o:" optname; do
   case "$optname" in
     "h")
       usage
@@ -87,6 +89,9 @@ while getopts "hesxiv:o:" optname; do
       ;;
     "o")
       DOCKEROPS="$OPTARG"
+      ;;
+    "m")
+      MULTISTAGE="-multistage"
       ;;
     "?")
       usage;
@@ -163,7 +168,7 @@ echo "Building image '$IMAGE_NAME' ..."
 
 # BUILD THE IMAGE (replace all environment variables)
 BUILD_START=$(date '+%s')
-docker build --force-rm=true --no-cache=true $DOCKEROPS $PROXY_SETTINGS -t $IMAGE_NAME -f Dockerfile.$EDITION . || {
+docker build --force-rm=true --no-cache=true $DOCKEROPS $PROXY_SETTINGS -t $IMAGE_NAME -f Dockerfile.$EDITION$MULTISTAGE . || {
   echo ""
   echo "ERROR: Oracle Database Docker Image was NOT successfully created."
   echo "ERROR: Check the output and correct any reported problems with the docker build operation."


### PR DESCRIPTION
Add a new Dockerfile that uses the multi-stage build feature of
Docker 17.05 (or newer), to avoid having the installation source
file as part of the final image. This reduces the size of the
built image from 18GB to 9GB.

Issue #945 exists for this problem. This merge request implements multi-stage build only for a single docker image (oracle/database:18.3.0-se2), and if successful, should probably also be implemented for (many) other images.

Using the new feature requires using the "-m" option when running buildDockerImage.sh.