### PR TITLE
Make ORACLE_SID and ORACLE_PDB always uppercase

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/runOracle.sh
@@ -120,13 +120,17 @@ trap _kill SIGKILL
 if [ "$ORACLE_SID" == "" ]; then
    export ORACLE_SID=ORCLCDB
 else
+  # Make ORACLE_SID upper case
+  # Github issue # 984
+  export ORACLE_SID=${ORACLE_SID^^}
+
   # Check whether SID is no longer than 12 bytes
   # Github issue #246: Cannot start OracleDB image
   if [ "${#ORACLE_SID}" -gt 12 ]; then
      echo "Error: The ORACLE_SID must only be up to 12 characters long."
      exit 1;
   fi;
-  
+
   # Check whether SID is alphanumeric
   # Github issue #246: Cannot start OracleDB image
   if [[ "$ORACLE_SID" =~ [^a-zA-Z0-9] ]]; then
@@ -137,6 +141,10 @@ fi;
 
 # Default for ORACLE PDB
 export ORACLE_PDB=${ORACLE_PDB:-ORCLPDB1}
+
+# Make ORACLE_PDB upper case
+# Github issue # 984
+export ORACLE_PDB=${ORACLE_PDB^^}
 
 # Default for ORACLE CHARACTERSET
 export ORACLE_CHARACTERSET=${ORACLE_CHARACTERSET:-AL32UTF8}

--- a/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/runOracle.sh
@@ -120,13 +120,17 @@ trap _kill SIGKILL
 if [ "$ORACLE_SID" == "" ]; then
    export ORACLE_SID=ORCLCDB
 else
+  # Make ORACLE_SID upper case
+  # Github issue # 984
+  export ORACLE_SID=${ORACLE_SID^^}
+
   # Check whether SID is no longer than 12 bytes
   # Github issue #246: Cannot start OracleDB image
   if [ "${#ORACLE_SID}" -gt 12 ]; then
      echo "Error: The ORACLE_SID must only be up to 12 characters long."
      exit 1;
   fi;
-  
+
   # Check whether SID is alphanumeric
   # Github issue #246: Cannot start OracleDB image
   if [[ "$ORACLE_SID" =~ [^a-zA-Z0-9] ]]; then
@@ -137,6 +141,10 @@ fi;
 
 # Default for ORACLE PDB
 export ORACLE_PDB=${ORACLE_PDB:-ORCLPDB1}
+
+# Make ORACLE_PDB upper case
+# Github issue # 984
+export ORACLE_PDB=${ORACLE_PDB^^}
 
 # Default for ORACLE CHARACTERSET
 export ORACLE_CHARACTERSET=${ORACLE_CHARACTERSET:-AL32UTF8}

--- a/OracleDatabase/SingleInstance/dockerfiles/18.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/18.3.0/runOracle.sh
@@ -120,13 +120,17 @@ trap _kill SIGKILL
 if [ "$ORACLE_SID" == "" ]; then
    export ORACLE_SID=ORCLCDB
 else
+  # Make ORACLE_SID upper case
+  # Github issue # 984
+  export ORACLE_SID=${ORACLE_SID^^}
+
   # Check whether SID is no longer than 12 bytes
   # Github issue #246: Cannot start OracleDB image
   if [ "${#ORACLE_SID}" -gt 12 ]; then
      echo "Error: The ORACLE_SID must only be up to 12 characters long."
      exit 1;
   fi;
-  
+
   # Check whether SID is alphanumeric
   # Github issue #246: Cannot start OracleDB image
   if [[ "$ORACLE_SID" =~ [^a-zA-Z0-9] ]]; then
@@ -137,6 +141,10 @@ fi;
 
 # Default for ORACLE PDB
 export ORACLE_PDB=${ORACLE_PDB:-ORCLPDB1}
+
+# Make ORACLE_PDB upper case
+# Github issue # 984
+export ORACLE_PDB=${ORACLE_PDB^^}
 
 # Default for ORACLE CHARACTERSET
 export ORACLE_CHARACTERSET=${ORACLE_CHARACTERSET:-AL32UTF8}

--- a/OracleDatabase/SingleInstance/tests/runContainerTests121.sh
+++ b/OracleDatabase/SingleInstance/tests/runContainerTests121.sh
@@ -26,3 +26,7 @@ runContainerTest "12.1.0.2 EE default database" "12.1.0.2-EE-default" "oracle/da
 
 # Run 12.1.0.2 SE2 default container
 runContainerTest "12.1.0.2 SE2 default database" "12.1.0.2-SE2-default" "oracle/database:12.1.0.2-se2"
+
+###################### TEST 12.1.0.2 EE lowercase ORACLE_SID ###########################
+
+runContainerTest "12.1.0.2 EE lowercase ORACLE_SID" "12.1.0.2-EE-lowercase_ORACLE_SID" "oracle/database:12.1.0.2-ee" "orcltest" "PDB1"

--- a/OracleDatabase/SingleInstance/tests/runContainerTests122.sh
+++ b/OracleDatabase/SingleInstance/tests/runContainerTests122.sh
@@ -31,3 +31,7 @@ runContainerTest "12.2.0.1-EE-custom database" "12.2.0.1-EE-custom" "oracle/data
 
 # Run 12.2.0.1 SE2 default container
 runContainerTest "12.2.0.1 SE2 default database" "12.2.0.1-SE2-default" "oracle/database:12.2.0.1-se2"
+
+###################### TEST 12.2.0.1 EE lowercase ORACLE_SID ###########################
+
+runContainerTest "12.2.0.1 EE lowercase ORACLE_SID" "12.2.0.1-EE-lowercase_ORACLE_SID" "oracle/database:12.2.0.1-ee" "orcltest" "PDB1"

--- a/OracleDatabase/SingleInstance/tests/runContainerTests183.sh
+++ b/OracleDatabase/SingleInstance/tests/runContainerTests183.sh
@@ -39,3 +39,11 @@ runContainerTest "18.3.0 EE JA16SJISTILDE character set" "18.3.0-EE-JA16SJISTILD
 ###################### TEST 18.3.0 EE KO16KSC5601 character set ###########################
 
 runContainerTest "18.3.0 EE KO16KSC5601 character set" "18.3.0-EE-KO16KSC5601-character-set" "oracle/database:18.3.0-ee" "ORCLTEST" "PDB1" "KO16KSC5601"
+
+###################### TEST 18.3.0 EE lowercase ORACLE_SID ###########################
+
+runContainerTest "18.3.0 EE lowercase ORACLE_SID" "18.3.0-EE-lowercase_ORACLE_SID" "oracle/database:18.3.0-ee" "orcltest" "PDB1"
+
+###################### TEST 18.3.0 EE lowercase ORACLE_PDB ###########################
+
+runContainerTest "18.3.0 EE lowercase ORACLE_PDB" "18.3.0-EE-lowercase_ORACLE_PDB" "oracle/database:18.3.0-ee" "ORCLTEST" "pdb1"


### PR DESCRIPTION
Fix for issue #984.

Signed-off-by: Gerald Venzl <gerald.venzl@gmail.com>