### PR TITLE
fixes Oracle XE README.md volume params doc (#1001)

### DIFF
--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -124,11 +124,11 @@ To run your Oracle Database Express Edition Docker image use the **docker run** 
 	                  The data volume to use for the database.
 	                  Has to be writable by the Unix "oracle" (uid: 54321) user inside the container!
 	                  If omitted the database will not be persisted over container recreation.
-	   -v /u01/app/oracle/scripts/startup | /docker-entrypoint-initdb.d
+	   -v /u01/app/oracle/scripts/startup | /docker-entrypoint-initdb.d/startup
 	                  Optional: A volume with custom scripts to be run after database startup.
 	                  For further details see the "Running scripts after setup and on startup" section below.
-	   -v /u01/app/oracle/scripts/setup | /docker-entrypoint-initdb.d
-	                  Optional: A volume with custom scripts to be run after database startup.
+	   -v /u01/app/oracle/scripts/setup | /docker-entrypoint-initdb.d/setup
+	                  Optional: A volume with custom scripts to be run after database setup.
 	                  For further details see the "Running scripts after setup and on startup" section below.
 
 There are two ports that are exposed in this image:


### PR DESCRIPTION
The volume params for custom scripts shown in the docker run command needed clarification.

Signed-off-by: Alexis Lopez <aalopez@gmail.com>