### PR TITLE
Adding wrapper for graal-updater

### DIFF
--- a/GraalVM/CE/1.0.0-rc7/Dockerfile
+++ b/GraalVM/CE/1.0.0-rc7/Dockerfile
@@ -28,6 +28,8 @@ RUN curl -o /etc/yum.repos.d/public-yum-ol7.repo http://yum.oracle.com/public-yu
     && yum install -y libcxx libcxx-devel llvm-toolset-7 \
     && rm -rf /var/cache/yum
 
+ADD gu-wrapper.sh /usr/local/bin/gu
+
 RUN set -eux \
     && curl --fail --silent --location --retry 3 ${GRAALVM_PKG} \
     | gunzip | tar x -C /opt/ \
@@ -40,6 +42,8 @@ RUN set -eux \
         base="$(basename "$bin")"; \
         [ ! -e "/usr/bin/$base" ]; \
         alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
-    done;
+    done \
+
+    && chmod +x /usr/local/bin/gu
 
 CMD java -version

--- a/GraalVM/CE/1.0.0-rc7/gu-wrapper.sh
+++ b/GraalVM/CE/1.0.0-rc7/gu-wrapper.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# LICENSE UPL 1.0
+#
+# Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+#
+
+$JAVA_HOME/bin/gu "${@}"
+RT=$?
+if [ $RT -ne 0 ]; then
+  exit $RT
+fi
+
+# Only run on *install operations
+if [[ "$@" == *"install"* ]]; then
+
+  # Add new links for newly installed components
+  for bin in "$JAVA_HOME/bin/"*; do
+    base="$(basename "$bin")";
+    if [[ ! -e "/usr/bin/$base" ]]; then
+      alternatives --install "/usr/bin/$base" "$base" "$bin" 20000;
+    fi
+  done;
+
+  # Remove dead links from uninstalled components
+  find /usr/bin -xtype l -delete
+
+  echo "Refreshed alternative links in /usr/bin/"
+fi
+


### PR DESCRIPTION
The wrapper takes care that alternative links in /usr/bin are updated when new components are installed or uninstalled.

This simplifies derived Docker images.