### PR TITLE
Updating the 18.3 Instant Client 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,7 +14,7 @@
 /OracleFMWInfrastructure/ @mriccell
 /OracleGoldenGate/        @sbalousek
 /OracleHTTPServer/        @Prabhat-Kishore
-/OracleInstantClient/     @gvenzl
+/OracleInstantClient/     @cjbj
 /OracleJava/              @aureliogrb
 /OracleRestDataServices/  @gvenzl
 /OracleSOASuite/          @prashanthnagaraja

--- a/OracleInstantClient/README.md
+++ b/OracleInstantClient/README.md
@@ -8,13 +8,13 @@ The SQL*Plus command-line query tool is also included, allowing quick ad-hoc SQL
 
 The [Oracle Instant Client](http://www.oracle.com/technetwork/database/features/instant-client/) is a repackaging of Oracle Database libraries, tools and header files usable to create and run applications that connect to a remote (or local) Oracle Database.
 
-Oracle client-server version interopability is detailed in [Doc ID 207303.1](https://support.oracle.com/epmos/faces/DocumentDisplay?id=207303.1).  Applications using Oracle Call Interface (OCI) 18.3 and 12.2 can connect to Oracle Database 11.2 or later.  Some tools may have other restrictions.
+Oracle client-server version interoperability is detailed in [Doc ID 207303.1](https://support.oracle.com/epmos/faces/DocumentDisplay?id=207303.1).  Applications using Oracle Call Interface (OCI) 18.3 and 12.2 can connect to Oracle Database 11.2 or later.  Some tools may have other restrictions.
 
 From release 18.3, the Oracle Instant Client RPMs for Oracle Linux are available for direct download from the [Oracle Linux yum server](https://yum.oracle.com) without requiring manual license acceptance.
 
 ## Building the Oracle Instant Client 18.3 Image
 
-Change directory to [`dockerfiles/18.3.0`](dockerfiles/18.3.0) and simply run:
+Change directory to [`dockerfiles/18.3.0`](dockerfiles/18.3.0) and run:
 
 ```
 docker build -t oracle/instantclient:18.3.0

--- a/OracleInstantClient/README.md
+++ b/OracleInstantClient/README.md
@@ -1,40 +1,39 @@
 # About this Docker Image
 
-This Docker image contains the Oracle Instant Client 'Basic', 'SDK' and 'SQL*Plus' packages.  It can be extended to run OCI, OCCI, and JDBC applications.  It can also be extended to build and run scripting language drivers that use OCI such as Python's cx_Oracle, Node.js's node-oracledb, PHP's OCI8, and Ruby's ruby-oci8.  
+These Docker images contain the Oracle Instant Client 'Basic', 'SDK' and 'SQL*Plus' packages.  They can be extended to run OCI, OCCI, and JDBC applications.  They can also be extended to build and run scripting language drivers that use OCI such as Python's cx_Oracle, Node.js's node-oracledb, PHP's OCI8, and Ruby's ruby-oci8.  
 
 The SQL*Plus command-line query tool is also included, allowing quick ad-hoc SQL and PL/SQL execution.
 
-## About Oracle Instant Client
+## About the Oracle Instant Client
 
-[Oracle Instant Client](http://www.oracle.com/technetwork/database/features/instant-client/) is a repackaging of Oracle Database libraries, tools and header files usable to create and run applications that connect to a remote (or local) Oracle Database.
+The [Oracle Instant Client](http://www.oracle.com/technetwork/database/features/instant-client/) is a repackaging of Oracle Database libraries, tools and header files usable to create and run applications that connect to a remote (or local) Oracle Database.
 
-## Required files
+From release 18.3, the Oracle Instant Client RPMs for Oracle Linux are also available on the [Oracle Linux yum server](https://yum.oracle.com). 
 
-Download the Oracle Instant Client RPMs from OTN:
+## Building the Oracle Instant Client 18.3 Image
 
-http://www.oracle.com/technetwork/topics/linuxx86-64soft-092277.html
+Change directory to [`dockerfiles/18.3.0`](dockerfiles/18.3.0) and simply run:
 
-The following three RPMs are required:
+```
+docker build -t oracle/instantclient:18.3.0
+```
 
-- `oracle-instantclient<version>-basic-<version>-1.x86_64.rpm`
-- `oracle-instantclient<version>-devel-<version>-1.x86_64.rpm`
-- `oracle-instantclient<version>-sqlplus-<version>-1.x86_64.rpm`
+The build process will automatically install the Instant Client using RPMs sourced directly from the [Oracle Instant Client repository](http://yum.oracle.com/repo/OracleLinux/OL7/oracle/instantclient/x86_64/index.html) on the [Oracle Linux yum server](https://yum.oracle.com).
 
-## Building
+## Building the Oracle Instant Client 12.2.0.1 Image
+
+Download the following three RPMs from the [Instant Client download page](http://www.oracle.com/technetwork/topics/linuxx86-64soft-092277.html) on the Oracle Technology Network:
+
+- `oracle-instantclient12.2-basic-12.2.0.1.0-1.x86_64.rpm`
+- `oracle-instantclient12.2-devel-12.2.0.1.0-1.x86_64.rpm`
+- `oracle-instantclient12.2-sqlplus-12.2.0.1.0-1.x86_64.rpm`
 
 Place the downloaded Oracle Instant Client RPMs (from the previous step) in the
-same directory as the `Dockerfile` and run:
+[`dockerfiles/12.2.0.1`](dockerfiles/12.2.0.1) directory, then switch to that directory and run:
 
 ```
-docker build -t oracle/instantclient:<version> .
+docker build -t oracle/instantclient:12.2.0.1 .
 ```
-
-For example, to build an 18.3 Instant Client Docker Image, run:
-
-```
-docker build -t oracle/instantclient:18.3.0 .
-```
-
 
 ## Usage
 

--- a/OracleInstantClient/README.md
+++ b/OracleInstantClient/README.md
@@ -1,14 +1,16 @@
 # About this Docker Image
 
-These Docker images contain the Oracle Instant Client 'Basic', 'SDK' and 'SQL*Plus' packages.  They can be extended to run OCI, OCCI, and JDBC applications.  They can also be extended to build and run scripting language drivers that use OCI such as Python's cx_Oracle, Node.js's node-oracledb, PHP's OCI8, and Ruby's ruby-oci8.  
+These Docker images contain the Oracle Instant Client 'Basic', 'SDK' and 'SQL*Plus' packages.  They can be extended to run Oracle Call Interface (OCI), Oracle C++ Call Interface (OCCI) and JDBC applications.  They can also be extended to build and run scripting language drivers that use OCI such as Python's cx_Oracle, Node.js's node-oracledb, PHP's OCI8, and Ruby's ruby-oci8.  
 
 The SQL*Plus command-line query tool is also included, allowing quick ad-hoc SQL and PL/SQL execution.
 
-## About the Oracle Instant Client
+## About Oracle Instant Client
 
 The [Oracle Instant Client](http://www.oracle.com/technetwork/database/features/instant-client/) is a repackaging of Oracle Database libraries, tools and header files usable to create and run applications that connect to a remote (or local) Oracle Database.
 
-From release 18.3, the Oracle Instant Client RPMs for Oracle Linux are also available on the [Oracle Linux yum server](https://yum.oracle.com). 
+Oracle client-server version interopability is detailed in [Doc ID 207303.1](https://support.oracle.com/epmos/faces/DocumentDisplay?id=207303.1).  Applications using Oracle Call Interface (OCI) 18.3 and 12.2 can connect to Oracle Database 11.2 or later.  Some tools may have other restrictions.
+
+From release 18.3, the Oracle Instant Client RPMs for Oracle Linux are available for direct download from the [Oracle Linux yum server](https://yum.oracle.com) without requiring manual license acceptance.
 
 ## Building the Oracle Instant Client 18.3 Image
 
@@ -20,7 +22,7 @@ docker build -t oracle/instantclient:18.3.0
 
 The build process will automatically install the Instant Client using RPMs sourced directly from the [Oracle Instant Client repository](http://yum.oracle.com/repo/OracleLinux/OL7/oracle/instantclient/x86_64/index.html) on the [Oracle Linux yum server](https://yum.oracle.com).
 
-## Building the Oracle Instant Client 12.2.0.1 Image
+## Building the Oracle Instant Client 12.2 Image
 
 Download the following three RPMs from the [Instant Client download page](http://www.oracle.com/technetwork/topics/linuxx86-64soft-092277.html) on the Oracle Technology Network:
 

--- a/OracleInstantClient/dockerfiles/18.3.0/Dockerfile
+++ b/OracleInstantClient/dockerfiles/18.3.0/Dockerfile
@@ -7,15 +7,6 @@
 #
 # Dockerfile template for Oracle Instant Client
 #
-# REQUIRED FILES TO BUILD THIS IMAGE
-# ==================================
-# 
-# From http://www.oracle.com/technetwork/topics/linuxx86-64soft-092277.html
-#  Download the following three RPMs:
-#    - oracle-instantclient18.3-basic-18.3.0.0.0-1.x86_64.rpm
-#    - oracle-instantclient18.3-devel-18.3.0.0.0-1.x86_64.rpm
-#    - oracle-instantclient18.3-sqlplus-18.3.0.0.0-1.x86_64.rpm 
-#
 # HOW TO BUILD THIS IMAGE
 # -----------------------
 # Put all downloaded files in the same directory as this Dockerfile
@@ -25,11 +16,10 @@
 #
 FROM oraclelinux:7-slim
 
-ADD oracle-instantclient*.rpm /tmp/
-
-RUN  yum -y install /tmp/oracle-instantclient*.rpm && \
+RUN  curl -o /etc/yum.repos.d/public-yum-ol7.repo https://yum.oracle.com/public-yum-ol7.repo && \
+     yum-config-manager --enable ol7_oracle_instantclient && \
+     yum -y install oracle-instantclient18.3-basic oracle-instantclient18.3-devel oracle-instantclient18.3-sqlplus && \
      rm -rf /var/cache/yum && \
-     rm -f /tmp/oracle-instantclient*.rpm && \
      echo /usr/lib/oracle/18.3/client64/lib > /etc/ld.so.conf.d/oracle-instantclient18.3.conf && \
      ldconfig
 


### PR DESCRIPTION
I updated the `Dockerfile` to automatically configure the `ol7_oracle_instantclient` repo and then install RPMs directly from the [Oracle Linux yum server](https://yum.oracle.com). I also updated the `README.md` file accordingly.

Signed-off-by: Avi Miller <avi.miller@oracle.com>