### PR TITLE
Create new sample for WebLogic Domain in image

### DIFF
--- a/OracleWebLogic/samples/12213-domain-home-in-image/Dockerfile
+++ b/OracleWebLogic/samples/12213-domain-home-in-image/Dockerfile
@@ -1,0 +1,89 @@
+#Copyright (c) 2014-2018 Oracle and/or its affiliates. All rights reserved.
+#
+#Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+#
+# ORACLE DOCKERFILES PROJECT
+# --------------------------
+# This Dockerfile extends the Oracle WebLogic image by creating a sample domain.
+#
+# Util scripts are copied into the image enabling users to plug NodeManager
+# automatically into the AdminServer running on another container.
+#
+# HOW TO BUILD THIS IMAGE
+# -----------------------
+# Put all downloaded files in the same directory as this Dockerfile
+# Run:
+#      $ sudo docker build -t 12213-domain-home-image
+#
+# Pull base image
+# ---------------
+FROM oracle/weblogic:12.2.1.3-developer
+
+# Maintainer
+# ----------
+MAINTAINER Monica Riccelli <monica.riccelli@oracle.com>
+
+ARG CUSTOM_DOMAIN_NAME="${CUSTOM_DOMAIN_NAME:-base_domain}"
+
+ARG DOM_ADMIN_PORT="${DOM_ADMIN_PORT:-7001}"  
+ARG DOM_ADMIN_NAME="${DOM_ADMIN_NAME:-AdminServer}" 
+ARG MANAGED_SERVER_NAME_BASE="${MANAGED_SERVER_NAME_BASE:-MS}"
+ARG MANAGED_SERVER_PORT="${MANAGED_SERVER_PORT:-8001}"
+ARG DOM_CLUSTER_NAME="${DOM_CLUSTER_NAME:-DockerCluster}" 
+ARG DOM_DEBUG_FLAG="${DOM_DEBUG_FLAG:-true}" 
+ARG PRODUCTION_MODE_ENABLED="${DOM_PRODUCTION_MODE_ENABLED:-false}"
+ARG CLUSTER_TYPE="${CLUSTER_TYPE:-DYNAMIC}"
+ARG CONFIGURED_MANAGED_SERVER_COUNT="${CONFIGURED_MANAGED_SERVER_COUNT:-2}" 
+
+# WLS Configuration
+# ---------------------------
+ENV DOMAIN_NAME="${CUSTOM_DOMAIN_NAME}" \
+    PRE_DOMAIN_HOME=/u01/oracle/user_projects \
+    ADMIN_HOST="wlsadmin" \
+    NM_PORT="5556" \
+    DEBUG_PORT="8453" \
+    ORACLE_HOME=/u01/oracle \
+    CONFIG_JVM_ARGS="-Dweblogic.security.SSL.ignoreHostnameVerification=true"  \
+    DOMAIN_HOME="/u01/oracle/user_projects/domains/${DOMAIN_NAME}" \
+    PATH=$PATH:/u01/oracle/oracle_common/common/bin:/u01/oracle/wlserver/common/bin:${DOMAIN_HOME}:${DOMAIN_HOME}/bin:/u01/oracle
+
+# Domain and Server environment variables
+# ------------------------------------------------------------
+ENV ADMIN_PORT="${DOM_ADMIN_PORT}"  \
+    ADMIN_SERVER_NAME="${DOM_ADMIN_NAME}" \
+    MANAGED_SERVER_NAME_BASE="${MANAGED_SERVER_NAME_BASE}" \
+    MANAGE_S_NAME="${MANAGE_S_NAME}" \
+    MANAGED_SERVER_PORT="${MANAGED_SERVER_PORT}" \
+    CLUSTER_NAME="${DOM_CLUSTER_NAME}" \
+    DEBUG_FLAG="$(DOM_DEBUG_FLAG}" \
+    CONFIGURED_MANAGED_SERVER_COUNT="${CONFIGURED_MANAGED_SERVER_COUNT}" \
+    PROPERTIES_FILE_DIR="/u01/oracle/properties" \
+    PRODUCTION_MODE_ENABLED="${PRODUCTION_MODE_ENABLED}"
+
+# Add files required to build this image
+COPY container-scripts/* /u01/oracle/
+
+#Create directory where domain will be written to
+USER root
+RUN chmod +xw /u01/oracle/*.sh && \
+    chmod +xw /u01/oracle/*.py && \
+    mkdir +xwr ${PROPERTIES_FILE_DIR} && \
+    chown -R oracle:oracle ${PROPERTIES_FILE_DIR} && \
+    mkdir -p $DOMAIN_HOME && \
+    chown -R oracle:oracle $DOMAIN_HOME && \
+    chmod -R a+xwr $DOMAIN_HOME
+
+COPY properties/domain.properties ${PROPERTIES_FILE_DIR}
+# Configuration of WLS Domain
+RUN /u01/oracle/createWLSDomain.sh && \
+    echo ". $DOMAIN_HOME/bin/setDomainEnv.sh" >> /u01/oracle/.bashrc && \
+    chmod -R a+x $DOMAIN_HOME/bin/*.sh  && \
+    rm ${PROPERTIES_FILE_DIR}/domain.properties
+
+# Expose Node Manager default port, and also default for admin and managed server
+EXPOSE $ADMIN_PORT $MANAGED_SERVER_PORT $DEBUG_PORT
+
+WORKDIR $DOMAIN_HOME
+
+# Define default command to start bash.
+CMD ["startAdminServer.sh"]

--- a/OracleWebLogic/samples/12213-domain-home-in-image/README.md
+++ b/OracleWebLogic/samples/12213-domain-home-in-image/README.md
@@ -1,0 +1,63 @@
+Example Image with a  WebLogic Server Domain
+=============================================
+This Dockerfile extends the Oracle WebLogic image by creating a sample WebLogic Server  12.2.1.3 domain and cluster into a Docker image.
+
+A domain is created inside the image and Utility scripts are copied into the image, enabling users to start an Administration Server and a Managed Servers each running in separate containers.
+
+### Providing the Administration Server user name and password
+
+**During Docker Build:** The user name, password, and data source parameters must be supplied in the domain.properties file located in a `docker-images/OracleWebLogic/samples/12213-domain-home-in-image/properties` in the HOST. This properties file gets copied into the image directory `/u01/oracle/properties`.
+
+**During Docker Run:** The user name and password must be supplied in a security.properties file located in a `docker-images/OracleWebLogic/samples/12213-domain-home-in-image/properties` in the HOST. In the Docker run command line add the -v option maps the properties file into the image directory /u01/oracle/properties. The properties file enables the scripts to configure the correct authentication for the WebLogic Administration Server and Managed Servers.
+
+The format of the domain.properties and security.properties files are key=value pairs, for example:
+
+username=myadminusername
+password=myadminpassword
+
+Note: Oracle recommends that the domain.properties and security.properties files be deleted or secured after the container and the WebLogic Server are started so that the user name and password are not inadvertently exposed.
+
+### How to Build and Run
+
+**NOTE:** First make sure you have built `oracle/weblogic:12.2.1.3-developer`.  If you want to set your own Domain Name it is an ARG parameter and must be set at build timei with the --build-arg deirective. 
+
+* Domain Name:     `DOMAIN_NAME`      (default: `base_domain`)  
+
+To build this sample, run:
+
+	$ docker build --build-arg DOMAIN_NAME=myDomain -t 12213-domain-home-in-image .
+
+**NOTE:** The DOMAIN_HOME will be persisted in the image directory `/u01/oracle/user-projects/domains/$DOMAIN_NAME`.
+
+You can define the following environment variables at Docker build time  using the `--build-arg` option  on the command line. These environmental variables need to be set for the domain. 
+
+* Admin Name:                               `ADMIN_NAME`                      (default: `AdminServer`)  
+* Admin Port:                               `DOM_ADMIN_PORT`                  (default: `7001`)          
+* Managed Server Name Prefix:               `MANAGED_SERVER_NAME_BASE`        (default: `MS`)    
+* Number of Managed Servers in the Cluster: `CONFIGURED_MANAGED_SERVER_COUNT` (default: `2`)
+* Managed Server Port:                      `MANAGED_SERVER_PORT`             (default: `8001`)          
+* Cluster Name:                             `DOM_CLUSTER_NAME`                (default: `DockerCluster`)
+* Debug Flag:                               `DOM_DEBUG_FLAG`                  (default: `true`)         
+* Production Mode:                          `PRODUCTION_MODE_ENABLED`         (default: `false`)            
+* Cluster Type:                             `CLUSTER_TYPE`                    (default: `DYNAMIC`)
+
+
+To start the containerized Administration Server, run:
+
+	$ docker run -d --name wlsadmin --hostname wlsadmin -p 7001:7001 -v <HOST DIRECTORY TO PROPERTIES FILE>/properties:/u01/oracle/properties 12213-domain-home-in-image
+
+To start a containerized Managed Server (MS1) to self-register with the Administration Server above, run:
+
+	$ docker run -d --name MS1 --link wlsadmin:wlsadmin -p 8001:8001 -v <HOST DIRECTORY TO PROPERTIES FILE>/properties:/u01/oracle/properties -e MANAGE_S_NAME=MS1 12213-domain-home-in-image startManagedServer.sh
+
+
+To start a second Managed Server (MS2), run:
+
+	$ docker run -d --name MS2 --link wlsadmin:wlsadmin -p 8002:8001 -v <HOST DIRECTORY TO PROPERTIES FILE>/properties:/u01/oracle/properties -e MANAGE_S_NAME=MS2 12213-domain-home-in-image startManagedServer.sh
+
+The above scenario from this sample will give you a WebLogic domain with a cluster set up on a single host environment.
+
+You may create more containerized Managed Servers by calling the `docker` command above
+
+# Copyright
+Copyright (c) 2014-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleWebLogic/samples/12213-domain-home-in-image/build.sh
+++ b/OracleWebLogic/samples/12213-domain-home-in-image/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+#
+#Copyright (c) 2014-2018 Oracle and/or its affiliates. All rights reserved.
+#
+#Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+#
+docker build -t 12213-domain-home-in-image .

--- a/OracleWebLogic/samples/12213-domain-home-in-image/container-scripts/create-wls-domain.py
+++ b/OracleWebLogic/samples/12213-domain-home-in-image/container-scripts/create-wls-domain.py
@@ -1,0 +1,226 @@
+#Copyright (c) 2014-2018 Oracle and/or its affiliates. All rights reserved.
+#
+#Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+#
+# WebLogic on Docker Default Domain
+#
+# Domain, as defined in DOMAIN_NAME, will be created in this script. Name defaults to 'base_domain'.
+#
+# Since : November, 2018
+# Author: monica.riccelli@oracle.com
+# ==============================================
+
+import os
+import socket
+
+def getEnvVar(var):
+  val=os.environ.get(var)
+  if val==None:
+    print "ERROR: Env var ",var, " not set."
+    sys.exit(1)
+  return val
+
+# This python script is used to create a WebLogic domain
+
+#domain_uid                   = os.environ.get("DOMAIN_UID")
+hostname                      = socket.gethostname()
+server_port                   = int(os.environ.get("MANAGED_SERVER_PORT"))
+domain_path                   = os.environ.get("DOMAIN_HOME")
+cluster_name                  = os.environ.get("CLUSTER_NAME")
+admin_server_name             = os.environ.get("ADMIN_SERVER_NAME")
+#admin_server_name_svc        = os.environ.get("ADMIN_SERVER_NAME_SVC")
+admin_port                    = int(os.environ.get("ADMIN_PORT"))
+domain_name                   = os.environ.get("DOMAIN_NAME")
+#t3_channel_port              = int(os.environ.get("T3_CHANNEL_PORT"))
+#t3_public_address            = os.environ.get("T3_PUBLIC_ADDRESS")
+number_of_ms                  = int(os.environ.get("CONFIGURED_MANAGED_SERVER_COUNT"))
+cluster_type                  = os.environ.get("CLUSTER_TYPE")
+managed_server_name_base      = os.environ.get("MANAGED_SERVER_NAME_BASE")
+#managed_server_name_base_svc = os.environ.get("MANAGED_SERVER_NAME_BASE_SVC")
+#domain_logs                   = os.environ.get("DOMAIN_LOGS_DIR")
+#script_dir                    = os.environ.get("CREATE_DOMAIN_SCRIPT_DIR")
+production_mode_enabled       = os.environ.get("PRODUCTION_MODE_ENABLED")
+
+# Read the domain secrets from the common python file
+#execfile('%s/read-domain-secret.py' % script_dir)
+
+print('domain_path              : [%s]' % domain_path);
+print('domain_name              : [%s]' % domain_name);
+print('admin_server_name        : [%s]' % admin_server_name);
+print('admin_port               : [%s]' % admin_port);
+print('cluster_name             : [%s]' % cluster_name);
+print('server_port              : [%s]' % server_port);
+print('hostname                 : [%s]' % hostname);
+print('number_of_ms             : [%s]' % number_of_ms);
+print('cluster_type             : [%s]' % cluster_type);
+print('managed_server_name_base : [%s]' % managed_server_name_base);
+print('production_mode_enabled  : [%s]' % production_mode_enabled);
+print('dsname                   : [%s]' % dsname);
+
+# Open default domain template
+# ============================
+readTemplate("/u01/oracle/wlserver/common/templates/wls/wls.jar")
+
+set('Name', domain_name)
+setOption('DomainName', domain_name)
+create(domain_name,'Log')
+cd('/Log/%s' % domain_name);
+set('FileName', '%s.log' % (domain_name))
+
+# Configure the Administration Server
+# ===================================
+cd('/Servers/AdminServer')
+#set('ListenAddress', '%s-%s' % (domain_uid, admin_server_name_svc))
+set('ListenPort', admin_port)
+set('Name', admin_server_name)
+
+
+#create('T3Channel', 'NetworkAccessPoint')
+#cd('/Servers/%s/NetworkAccessPoints/T3Channel' % admin_server_name)
+#set('PublicPort', t3_channel_port)
+#set('PublicAddress', t3_public_address)
+#set('ListenAddress', '%s-%s' % (domain_uid, admin_server_name_svc))
+#set('ListenPort', t3_channel_port)
+
+#cd('/Servers/%s' % admin_server_name)
+#create(admin_server_name, 'Log')
+#cd('/Servers/%s/Log/%s' % (admin_server_name, admin_server_name))
+#set('FileName', '%s.log' % (admin_server_name))
+
+# Set the admin user's username and password
+# ==========================================
+cd('/Security/%s/User/weblogic' % domain_name)
+cmo.setName(username)
+cmo.setPassword(password)
+
+# Write the domain and close the domain template
+# ==============================================
+setOption('OverwriteDomain', 'true')
+
+
+# Create a cluster
+# ======================
+cd('/')
+cl=create(cluster_name, 'Cluster')
+
+if cluster_type == "CONFIGURED":
+
+  # Create managed servers
+  for index in range(0, number_of_ms):
+    cd('/')
+    msIndex = index+1
+
+    cd('/')
+    name = '%s%s' % (managed_server_name_base, msIndex)
+#   name_svc = '%s%s' % (managed_server_name_base_svc, msIndex)
+
+    create(name, 'Server')
+    cd('/Servers/%s/' % name )
+    print('managed server name is %s' % name);
+#   set('ListenAddress', '%s-%s' % (domain_uid, name_svc))
+    set('ListenPort', server_port)
+    set('NumOfRetriesBeforeMSIMode', 0)
+    set('RetryIntervalBeforeMSIMode', 1)
+    set('Cluster', cluster_name)
+
+#    create(name,'Log')
+#    cd('/Servers/%s/Log/%s' % (name, name))
+#    set('FileName', '%s.log' % (name))
+
+else:
+  print('Configuring Dynamic Cluster %s' % cluster_name)
+
+  templateName = cluster_name + "-template"
+  print('Creating Server Template: %s' % templateName)
+  st1=create(templateName, 'ServerTemplate')
+  print('Done creating Server Template: %s' % templateName)
+  cd('/ServerTemplates/%s' % templateName)
+  cmo.setListenPort(server_port)
+#  cmo.setListenAddress('%s-%s${id}' % (domain_uid, managed_server_name_base_svc))
+  cmo.setCluster(cl)
+#  create(templateName,'Log')
+#  cd('Log/%s' % templateName)
+#  set('FileName', '%s${id}.log' % (managed_server_name_base))
+#  print('Done setting attributes for Server Template: %s' % templateName);
+
+
+  cd('/Clusters/%s' % cluster_name)
+  create(cluster_name, 'DynamicServers')
+  cd('DynamicServers/%s' % cluster_name)
+  set('ServerTemplate', st1)
+  set('ServerNamePrefix', managed_server_name_base)
+  set('DynamicClusterSize', number_of_ms)
+  set('MaxDynamicClusterSize', number_of_ms)
+  set('CalculatedListenPorts', false)
+  set('Id', 1)
+
+  print('Done setting attributes for Dynamic Cluster: %s' % cluster_name);
+
+# Create a Data Source
+# ======================
+cd('/')
+print('Configuring a Data Source: %s' % dsname);
+create(dsname, 'JDBCSystemResource')
+cd('/JDBCSystemResource/' + dsname + '/JdbcResource/' + dsname)
+cmo.setName(dsname)
+
+cd('/JDBCSystemResource/' + dsname + '/JdbcResource/' + dsname)
+create('myJdbcDataSourceParams','JDBCDataSourceParams')
+cd('JDBCDataSourceParams/NO_NAME_0')
+set('JNDIName', java.lang.String(dsjndiname))
+set('GlobalTransactionsProtocol', java.lang.String('None'))
+
+cd('/JDBCSystemResource/' + dsname + '/JdbcResource/' + dsname)
+create('myJdbcDriverParams','JDBCDriverParams')
+cd('JDBCDriverParams/NO_NAME_0')
+set('DriverName', dsdriver)
+set('URL', dsurl)
+set('PasswordEncrypted', dspassword)
+set('UseXADataSourceInterface', 'false')
+
+print 'create JDBCDriverParams Properties'
+create('myProperties','Properties')
+cd('Properties/NO_NAME_0')
+create('user','Property')
+cd('Property/user')
+set('Value', dsusername)
+
+cd('../../')
+create('databaseName','Property')
+cd('Property/databaseName')
+set('Value', dsdbname)
+
+print 'create JDBCConnectionPoolParams'
+cd('/JDBCSystemResource/' + dsname + '/JdbcResource/' + dsname)
+create('myJdbcConnectionPoolParams','JDBCConnectionPoolParams')
+cd('JDBCConnectionPoolParams/NO_NAME_0')
+set('TestTableName','SQL SELECT 1 FROM DUAL')
+set('InitialCapacity',int(dsinitalcapacity))
+
+print('Done setting attributes for Data Source: %s' % dsname);
+
+# Assign
+# ======
+assign('JDBCSystemResource', dsname, 'Target', cluster_name)
+
+# Write Domain
+# ============
+writeDomain(domain_path)
+closeTemplate()
+print 'Domain Created'
+
+# Update Domain
+readDomain(domain_path)
+cd('/')
+if production_mode_enabled == "true":
+  cmo.setProductionModeEnabled(true)
+else: 
+  cmo.setProductionModeEnabled(false)
+updateDomain()
+closeDomain()
+print 'Domain Updated'
+print 'Done'
+
+# Exit WLST
+# =========
+exit()

--- a/OracleWebLogic/samples/12213-domain-home-in-image/container-scripts/createWLSDomain.sh
+++ b/OracleWebLogic/samples/12213-domain-home-in-image/container-scripts/createWLSDomain.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+#Copyright (c) 2014-2018 Oracle and/or its affiliates. All rights reserved.
+#
+#Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+
+#Define DOMAIN_HOME
+echo "Domain Home is: " $DOMAIN_HOME
+
+# If AdminServer.log does not exists, container is starting for 1st time
+# So it should start NM and also associate with AdminServer
+# Otherwise, only start NM (container restarted)
+########### SIGTERM handler ############
+function _term() {
+   echo "Stopping container."
+   echo "SIGTERM received, shutting down the server!"
+   ${DOMAIN_HOME}/bin/stopWebLogic.sh
+}
+
+########### SIGKILL handler ############
+function _kill() {
+   echo "SIGKILL received, shutting down the server!"
+   kill -9 $childPID
+}
+
+# Set SIGTERM handler
+trap _term SIGTERM
+
+# Set SIGKILL handler
+trap _kill SIGKILL
+
+#Loop determining state of WLS
+function check_wls {
+    action=$1
+    host=$2
+    port=$3
+    sleeptime=$4
+    while true
+    do
+        sleep $sleeptime
+        if [ "$action" == "started" ]; then
+            started_url="http://$host:$port/weblogic/ready"
+            echo -e "Waiting for WebLogic server to get $action, checking $started_url"
+            status=`/usr/bin/curl -s -i $started_url | grep "200 OK"`
+            echo "Status:" $status
+            if [ ! -z "$status" ]; then
+              break
+            fi
+        elif [ "$action" == "shutdown" ]; then
+            shutdown_url="http://$host:$port"
+            echo -e "Waiting for WebLogic server to get $action, checking $shutdown_url"
+            status=`/usr/bin/curl -s -i $shutdown_url | grep "500 Can't connect"`
+            if [ ! -z "$status" ]; then
+              break
+            fi
+        fi
+    done
+    echo -e "WebLogic Server has $action"
+}
+
+ADD_DOMAIN=1
+if [  -f ${DOMAIN_HOME}/servers/AdminServer/logs/AdminServer.log ]; then
+    exit
+fi
+
+# Create Domain only if 1st execution
+PROPERTIES_FILE=${PROPERTIES_FILE_DIR}/domain.properties
+if [ ! -e "${PROPERTIES_FILE}" ]; then
+   echo "A properties file with the username and password needs to be supplied."
+   exit
+fi
+
+# Get Username
+USER=`awk '{print $1}' ${PROPERTIES_FILE} | grep username | cut -d "=" -f2`
+if [ -z "${USER}" ]; then
+   echo "The domain username is blank.  The Admin username must be set in the properties file."
+   exit
+fi
+# Get Password
+PASS=`awk '{print $1}' ${PROPERTIES_FILE} | grep password | cut -d "=" -f2`
+if [ -z "${PASS}" ]; then
+   echo "The domain password is blank.  The Admin password must be set in the properties file."
+   exit
+fi
+
+# Create domain
+wlst.sh -skipWLSModuleScanning -loadProperties ${PROPERTIES_FILE}  /u01/oracle/create-wls-domain.py

--- a/OracleWebLogic/samples/12213-domain-home-in-image/container-scripts/shutdown-servers.py
+++ b/OracleWebLogic/samples/12213-domain-home-in-image/container-scripts/shutdown-servers.py
@@ -1,0 +1,15 @@
+host = sys.argv[1]
+port = sys.argv[2]
+user_name = sys.argv[3]
+password = sys.argv[4]
+name = sys.argv[5]
+
+print('host     : [%s]' % host);
+print('port      : [%s]' % port);
+print('user_name     : [%s]' % user_name);
+print('password     : ********');
+print('name     : [%s]' % name);
+
+connect(user_name, password, 't3://' + host + ':' + port)
+shutdown(name, 'Server', ignoreSessions='true')
+exit()

--- a/OracleWebLogic/samples/12213-domain-home-in-image/container-scripts/startAdminServer.sh
+++ b/OracleWebLogic/samples/12213-domain-home-in-image/container-scripts/startAdminServer.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+#
+#Copyright (c) 2014-2018 Oracle and/or its affiliates. All rights reserved.
+#
+#Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+
+#Define DOMAIN_HOME
+echo "Domain Home is: " $DOMAIN_HOME
+
+# If AdminServer.log does not exists, container is starting for 1st time
+# So it should start NM and also associate with AdminServer
+# Otherwise, only start NM (container restarted)
+########### SIGTERM handler ############
+function _term() {
+   echo "Stopping container."
+   echo "SIGTERM received, shutting down the server!"
+   ${DOMAIN_HOME}/bin/stopWebLogic.sh
+}
+
+########### SIGKILL handler ############
+function _kill() {
+   echo "SIGKILL received, shutting down the server!"
+   kill -9 $childPID
+}
+
+# Set SIGTERM handler
+trap _term SIGTERM
+
+# Set SIGKILL handler
+trap _kill SIGKILL
+
+#Loop determining state of WLS
+function check_wls {
+    action=$1
+    host=$2
+    port=$3
+    sleeptime=$4
+    while true
+    do
+        sleep $sleeptime
+        if [ "$action" == "started" ]; then
+            started_url="http://$host:$port/weblogic/ready"
+            echo -e "Waiting for WebLogic server to get $action, checking $started_url"
+            status=`/usr/bin/curl -s -i $started_url | grep "200 OK"`
+            echo "Status:" $status
+            if [ ! -z "$status" ]; then
+              break
+            fi
+        elif [ "$action" == "shutdown" ]; then
+            shutdown_url="http://$host:$port"
+            echo -e "Waiting for WebLogic server to get $action, checking $shutdown_url"
+            status=`/usr/bin/curl -s -i $shutdown_url | grep "500 Can't connect"`
+            if [ ! -z "$status" ]; then
+              break
+            fi
+        fi
+    done
+    echo -e "WebLogic Server has $action"
+}
+
+
+export AS_HOME="${DOMAIN_HOME}/servers/${ADMIN_SERVER_NAME}"
+export AS_SECURITY="${AS_HOME}/security"
+
+if [  -f ${AS_HOME}/logs/${ADMIN_SERVER_NAME}.log ]; then
+    exit
+fi
+
+echo "Admin Server Name: ${ADMIN_SERVER_NAME}"
+echo "Admin Server Home: ${AS_HOME}"
+echo "Admin Server Security: ${AS_SECURITY}"
+
+# Create Domain only if 1st execution
+PROPERTIES_FILE=${PROPERTIES_FILE_DIR}/security.properties
+if [ ! -e "${PROPERTIES_FILE}" ]; then
+   echo "A properties file with the username and password needs to be supplied."
+   exit
+fi
+
+# Get Username
+USER=`awk '{print $1}' ${PROPERTIES_FILE} | grep username | cut -d "=" -f2`
+if [ -z "${USER}" ]; then
+   echo "The domain username is blank.  The Admin username must be set in the properties file."
+   exit
+fi
+# Get Password
+PASS=`awk '{print $1}' ${PROPERTIES_FILE} | grep password | cut -d "=" -f2`
+if [ -z "${PASS}" ]; then
+   echo "The domain password is blank.  The Admin password must be set in the properties file."
+   exit
+fi
+
+# Create domain
+mkdir -p ${AS_SECURITY}
+echo "username=${USER}" >> ${AS_SECURITY}/boot.properties
+echo "password=${PASS}" >> ${AS_SECURITY}/boot.properties
+${DOMAIN_HOME}/bin/setDomainEnv.sh
+
+#echo 'Running Admin Server in background'
+${DOMAIN_HOME}/bin/startWebLogic.sh &
+
+#echo 'Waiting for Admin Server to reach RUNNING state'
+check_wls "started" localhost ${ADMIN_PORT} 2
+
+# tail the Admin Server Logs
+tail -f ${AS_HOME}/logs/${ADMIN_SERVER_NAME}.log &
+
+childPID=$!
+wait $childPID

--- a/OracleWebLogic/samples/12213-domain-home-in-image/container-scripts/startManagedServer.sh
+++ b/OracleWebLogic/samples/12213-domain-home-in-image/container-scripts/startManagedServer.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# Copyright (c) 2014-2018 Oracle and/or its affiliates. All rights reserved.
+#
+# If log.nm does not exists, container is starting for 1st time
+# So it should start NM and also associate with AdminServer, as well Managed Server
+# Otherwise, only start NM (container is being restarted)o
+export MS_HOME="${DOMAIN_HOME}/servers/${MANAGE_S_NAME}"
+export MS_SECURITY="${MS_HOME}/security"
+
+if [ -f ${MS_HOME}/logs/${MANAGE_S_NAME}.log ]; then
+   exit
+fi
+
+# Wait for AdminServer to become available for any subsequent operation
+/u01/oracle/waitForAdminServer.sh
+
+echo "Managed Server Name: ${MANAGE_S_NAME}"
+echo "Managed Server Home: ${MS_HOME}"
+echo "Managed Server Security: ${MS_SECURITY}"
+
+PROPERTIES_FILE=${PROPERTIES_FILE_DIR}/security.properties
+if [ ! -e "${PROPERTIES_FILE}" ]; then
+   echo "A properties file with the username and password needs to be supplied."
+   exit
+fi
+# Get Username
+USER=`awk '{print $1}' ${PROPERTIES_FILE} | grep username | cut -d "=" -f2`
+if [ -z "${USER}" ]; then
+   echo "The domain username is blank.  The Admin username must be set in the properties file."
+   exit
+fi
+# Get Password
+PASS=`awk '{print $1}' ${PROPERTIES_FILE} | grep password | cut -d "=" -f2`
+if [ -z "${PASS}" ]; then
+   echo "The domain password is blank.  The Admin password must be set in the properties file."
+   exit
+fi
+
+# Create Managed Server
+mkdir -p ${MS_SECURITY}
+echo "username=${USER}" >> ${MS_SECURITY}/boot.properties
+echo "password=${PASS}" >> ${MS_SECURITY}/boot.properties
+${DOMAIN_HOME}/bin/setDomainEnv.sh
+
+# Start 'ManagedServer'
+echo "Start Managed Server"
+${DOMAIN_HOME}/bin/startManagedWebLogic.sh ${MANAGE_S_NAME} http://${ADMIN_HOST}:${ADMIN_PORT}
+
+# tail Managed Server log
+tail -f ${MS_HOME}/logs/${MANAGE_S_NAME}.log &
+
+childPID=$!
+wait $childPID

--- a/OracleWebLogic/samples/12213-domain-home-in-image/container-scripts/waitForAdminServer.sh
+++ b/OracleWebLogic/samples/12213-domain-home-in-image/container-scripts/waitForAdminServer.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+#Copyright (c) 2014-2018 Oracle and/or its affiliates. All rights reserved.
+#
+#Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+#
+# This script will wait until Admin Server is available.
+# There is no timeout!
+#
+echo "Waiting for WebLogic Admin Server on $ADMIN_HOST:$ADMIN_PORT to become available..."
+while :
+do
+  (echo > /dev/tcp/$ADMIN_HOST/$ADMIN_PORT) >/dev/null 2>&1
+  available=$?
+  if [[ $available -eq 0 ]]; then
+    echo "WebLogic Admin Server is now available. Proceeding..."
+    break
+  fi
+  sleep 1
+done

--- a/OracleWebLogic/samples/12213-domain-home-in-image/container-scripts/wlst
+++ b/OracleWebLogic/samples/12213-domain-home-in-image/container-scripts/wlst
@@ -1,0 +1,6 @@
+#!/bin/sh
+#
+# This script will be in PATH and it will skip module scanning by default, making WLST calls much faster
+# If you know what you are doing, call actual wlst.sh
+#
+wlst.sh -skipWLSModuleScanning $@

--- a/OracleWebLogic/samples/12213-domain-home-in-image/properties/domain.properties
+++ b/OracleWebLogic/samples/12213-domain-home-in-image/properties/domain.properties
@@ -1,0 +1,22 @@
+username=myuser
+password=mypassword1
+dsname=DockerDS
+dsdbname=default;create=true
+dsjndiname=jdbc/DockerDS
+dsdriver=org.apache.derby.jdbc.ClientDataSource
+dsurl=jdbc:derby://localhost:1527/default;ServerName=localhost;databaseName=default;create=true
+dsusername=dbuser
+dspassword=dbpassword
+dstestquery=SQL SELECT 1 FROM SYS.SYSTABLES
+dsinitalcapacity=0
+dsmaxcapacity=1
+#Oracle database settings
+#dsname=DockerDS2
+#dsdbname=default;create=true
+#dsintitalcapacity=0
+#dsjndiname=jdbc/DockerDS2
+#dsdriver=oracle.jdbc.OracleDriver
+#dsurl=jdbc:oracle:thin:@//xxx.xxx.x.xxx:1521/ORCLCDB
+#dsusername=system
+#dspassword=LetsDocker
+#dstestquery=SQL ISVALID

--- a/OracleWebLogic/samples/12213-domain-home-in-image/properties/security.properties
+++ b/OracleWebLogic/samples/12213-domain-home-in-image/properties/security.properties
@@ -1,0 +1,2 @@
+username=myuser
+password=mypassword1


### PR DESCRIPTION
Create new sample, a WebLogic Server 12.2.1.3 domain with the DOMAIN_HOME inside of the Docker image.
Cluster can be Configured or Dynamic, and with a DataSource.