### PR TITLE
Update WLS patch for k8s to have correct patches

### DIFF
--- a/OracleWebLogic/samples/12213-patch-wls-for-k8s/Dockerfile
+++ b/OracleWebLogic/samples/12213-patch-wls-for-k8s/Dockerfile
@@ -9,9 +9,8 @@
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
 # (1) p28186730_139400_Generic.zip
-# (2) p27117282_122130_Generic.zip
+# (2) p28298734_122130_Generic.zip
 # (3) p28076014_122130_Generic.zip
-# (4) p28298734_122130_Generic.zip
 #     Download the patches from http://support.oracle.com
 #
 # HOW TO BUILD THIS IMAGE
@@ -32,13 +31,12 @@ MAINTAINER Monica Riccelli <monica.riccelli@oracle.com>
 # Environment variables required for this build (do NOT change)
 # -------------------------------------------------------------
 ENV PATCH_PKG0="p28186730_139400_Generic.zip"
-ENV PATCH_PKG1="p27117282_122130_Generic.zip"
+ENV PATCH_PKG1="p28298734_122130_Generic.zip"
 ENV PATCH_PKG2="p28076014_122130_Generic.zip"
-ENV PATCH_PKG3="p28298734_122130_Generic.zip"
 
 # Copy supplemental package and scripts
 # --------------------------------
-COPY $PATCH_PKG0 $PATCH_PKG1 $PATCH_PKG2 $PATCH_PKG3 /u01/
+COPY $PATCH_PKG0 $PATCH_PKG1 $PATCH_PKG2 /u01/
 
 # Installation of Supplemental Quick Installer
 # --------------------------------------------
@@ -49,15 +47,13 @@ RUN cd /u01 && $JAVA_HOME/bin/jar xf /u01/$PATCH_PKG0 && \
     java -jar /u01/6880880/opatch_generic.jar -silent oracle_home=/u01/oracle -ignoreSysPrereqs && \
     echo "opatch updated" && sleep 5 && \
     cd /u01 && $JAVA_HOME/bin/jar xf /u01/$PATCH_PKG1 && \
-    cd /u01/27117282 && $ORACLE_HOME/OPatch/opatch apply -silent && \
-    cd /u01 && $JAVA_HOME/bin/jar xf /u01/$PATCH_PKG3 && \
     cd /u01/28298734 && $ORACLE_HOME/OPatch/opatch apply -silent && \
     cd /u01 && $JAVA_HOME/bin/jar xf /u01/$PATCH_PKG2 && \
     cd /u01/28076014 && $ORACLE_HOME/OPatch/opatch apply -silent && \
     $ORACLE_HOME/OPatch/opatch util cleanup -silent && \
     rm /u01/$PATCH_PKG0 && rm /u01/$PATCH_PKG1 && rm /u01/$PATCH_PKG2 && \
-    rm -rf /u01/6880880 && rm -rf /u01/27117282 && rm -rf /u01/28076014 && \
-    rm -rf /u01/28298734 && rm -rf /u01/oracle/cfgtoollogs/opatch/* 
+    rm -rf /u01/6880880 && rm -rf /u01/28076014 && rm -rf /u01/28298734 && \
+    rm -rf /u01/oracle/cfgtoollogs/opatch/* 
 
 WORKDIR ${ORACLE_HOME}
 

--- a/OracleWebLogic/samples/12213-patch-wls-for-k8s/Dockerfile
+++ b/OracleWebLogic/samples/12213-patch-wls-for-k8s/Dockerfile
@@ -11,6 +11,7 @@
 # (1) p28186730_139400_Generic.zip
 # (2) p27117282_122130_Generic.zip
 # (3) p28076014_122130_Generic.zip
+# (4) p28298734_122130_Generic.zip
 #     Download the patches from http://support.oracle.com
 #
 # HOW TO BUILD THIS IMAGE
@@ -22,7 +23,7 @@
 
 # Pull base image
 # ---------------
-FROM oracle/weblogic:12.2.1.3-developer
+FROM oracle/weblogic:12.2.1.3-generic
 
 # Maintainer
 # ----------
@@ -33,10 +34,11 @@ MAINTAINER Monica Riccelli <monica.riccelli@oracle.com>
 ENV PATCH_PKG0="p28186730_139400_Generic.zip"
 ENV PATCH_PKG1="p27117282_122130_Generic.zip"
 ENV PATCH_PKG2="p28076014_122130_Generic.zip"
+ENV PATCH_PKG3="p28298734_122130_Generic.zip"
 
 # Copy supplemental package and scripts
 # --------------------------------
-COPY $PATCH_PKG0 $PATCH_PKG1 $PATCH_PKG2 /u01/
+COPY $PATCH_PKG0 $PATCH_PKG1 $PATCH_PKG2 $PATCH_PKG3 /u01/
 
 # Installation of Supplemental Quick Installer
 # --------------------------------------------
@@ -48,12 +50,14 @@ RUN cd /u01 && $JAVA_HOME/bin/jar xf /u01/$PATCH_PKG0 && \
     echo "opatch updated" && sleep 5 && \
     cd /u01 && $JAVA_HOME/bin/jar xf /u01/$PATCH_PKG1 && \
     cd /u01/27117282 && $ORACLE_HOME/OPatch/opatch apply -silent && \
+    cd /u01 && $JAVA_HOME/bin/jar xf /u01/$PATCH_PKG3 && \
+    cd /u01/28298734 && $ORACLE_HOME/OPatch/opatch apply -silent && \
     cd /u01 && $JAVA_HOME/bin/jar xf /u01/$PATCH_PKG2 && \
     cd /u01/28076014 && $ORACLE_HOME/OPatch/opatch apply -silent && \
     $ORACLE_HOME/OPatch/opatch util cleanup -silent && \
     rm /u01/$PATCH_PKG0 && rm /u01/$PATCH_PKG1 && rm /u01/$PATCH_PKG2 && \
     rm -rf /u01/6880880 && rm -rf /u01/27117282 && rm -rf /u01/28076014 && \
-    rm -rf /u01/oracle/cfgtoollogs/opatch/* 
+    rm -rf /u01/28298734 && rm -rf /u01/oracle/cfgtoollogs/opatch/* 
 
 WORKDIR ${ORACLE_HOME}
 

--- a/OracleWebLogic/samples/12213-patch-wls-for-k8s/Dockerfile
+++ b/OracleWebLogic/samples/12213-patch-wls-for-k8s/Dockerfile
@@ -22,7 +22,7 @@
 
 # Pull base image
 # ---------------
-FROM oracle/weblogic:12.2.1.3-generic
+FROM oracle/weblogic:12.2.1.3-developer
 
 # Maintainer
 # ----------

--- a/OracleWebLogic/samples/12213-patch-wls-for-k8s/README.md
+++ b/OracleWebLogic/samples/12213-patch-wls-for-k8s/README.md
@@ -10,7 +10,7 @@ We are applying patch 'p28076014_12213_Generic.zip' which is required for the We
 First make sure you have built **oracle/weblogic:12.2.1.3-developer**.
 
 	Then download file [p28186730_139400_Generic.zip](http://support.oracle.com) and place it in the same directory as this README.
-	Then download file [p27117282_122130_Generic.zip](http://support.oracle.com) and place it in the same directory as this README.
+	Then download file [p28298734_122130_Generic.zip](http://support.oracle.com) and place it in the same directory as this README.
 	Then download file [p28076014_122130_Generic.zip](http://support.oracle.com) and place it in the same directory as this README.
 
 To build, run:

--- a/OracleWebLogic/samples/12213-patch-wls-for-k8s/p28076014_122130_Generic.download
+++ b/OracleWebLogic/samples/12213-patch-wls-for-k8s/p28076014_122130_Generic.download
@@ -1,0 +1,8 @@
+# Download this file from the following address:
+#
+# https://support.oracle.com
+#
+# 1)  Download the ZIP file "Patch" for WebLogic 12.2.1.3
+# 2) Put the ZIP file in the same location as this .download file
+# 
+b57a9b37a0828575e2931a3da88f821e p28076014_122130_Generic.zip

--- a/OracleWebLogic/samples/12213-patch-wls-for-k8s/p28298734_122130_Generic.download
+++ b/OracleWebLogic/samples/12213-patch-wls-for-k8s/p28298734_122130_Generic.download
@@ -1,0 +1,8 @@
+# Download this file from the following address:
+#
+# https://support.oracle.com
+#
+# 1)  Download the ZIP file "Patch" for WebLogic 12.2.1.3
+# 2) Put the ZIP file in the same location as this .download file
+# 
+84e32ca7c83cc4bad6eba8c4497ee6e5  p28298734_122130_Generic.zip


### PR DESCRIPTION
Removed patch p27117282_122130_Generic.zip which is not required
Added patch p28298734_122130_Generic.zip which is required (it is a prereq for p28076014_122130_Generic.zip and it supersedes p27117282_122130_Generic.zip)