### PR TITLE
Updating CODEOWNERS 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,12 +1,12 @@
 # The last matching pattern has the most precedence.
-*                         @Djelibeybi
+*                         @Djelibeybi @gvenzl @mriccell
 /ContainerCloud/          @mikeraab
 /GlassFish/               @arindam-bandyopadhyay
 /GraalVM/                 @mzachh
 /NoSQL/                   @anandchandak
 /OpenJDK/                 @aureliogrb
 /OracleBI/                @sjvp
-/OracleCloudInfrastructure/ @Djelibeybi
+/OracleCloudInfrastructure/ @Djelibeybi @gvenzl @mriccell
 /OracleCoherence/         @thegridman
 /OracleDataIntegrator/    @mavaishn
 /OracleDatabase/SingleInstance/          @gvenzl


### PR DESCRIPTION
I'm about to head off on honeymoon/mini-sabbatical, so this change ensures there is review coverage by the entire admin team, not just me. 

Signed-off-by: Avi Miller <avi.miller@oracle.com>