### PR TITLE
LF for *.conf files that are used inside of unix vm

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.sh eol=lf
+*.conf eol=lf


### PR DESCRIPTION
If a configuration file is checked out by a windows machine the new line is changed to CRLF. 
The changed configuration file can corrupt the target unix image it will be used with.

Signed-off-by: Christian Louis <c.louis@mail.de>