### PR TITLE
fix startManagedServer.sh hard-coded domain name

### DIFF
--- a/OracleFMWInfrastructure/dockerfiles/12.2.1.3/container-scripts/startManagedServer.sh
+++ b/OracleFMWInfrastructure/dockerfiles/12.2.1.3/container-scripts/startManagedServer.sh
@@ -9,12 +9,12 @@
 
 export adminhostname=$adminhostname
 export adminport=$adminport
-
+export DOMAIN_NAME=$DOMAIN_NAME
 
 # First Update the server in the domain
 export server="infra_server1"
 export DOMAIN_ROOT="/u01/oracle/user_projects/domains"
-export DOMAIN_HOME="/u01/oracle/user_projects/domains/InfraDomain"
+export DOMAIN_HOME="/u01/oracle/user_projects/domains/$DOMAIN_NAME"
 
 echo $adminhostname
 echo $adminport


### PR DESCRIPTION
in docker-images/OracleFMWInfrastructure/dockerfiles/12.2.1.3/container-scripts/startManagedServer.sh, the domain name was hard-coded to 'InfraDomain'. When running the managed server container using:
`docker run -d -p 9801:8001 --network=InfraNET --volumes-from InfraAdminContainer --name InfraManagedContainer --env-file ./infraServer.env.list oracle/fmw-infrastructure:12.2.1.3 startManagedServer.sh`

If the domain name set in 'infraServer.env.list' is different than 'InfraDomain', the managed server fails to start. 