### PR TITLE
12.1.0.1 changed to 12.1.0.2 in README.md

### DIFF
--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -5,7 +5,7 @@ Sample Docker build files to facilitate installation, configuration, and environ
 This project offers sample Dockerfiles for:
  * Oracle Database 18c (18.3.0) Enterprise Edition and Standard Edition 2
  * Oracle Database 12c Release 2 (12.2.0.2) Enterprise Edition and Standard Edition 2
- * Oracle Database 12c Release 1 (12.1.0.1) Enterprise Edition and Standard Edition 2
+ * Oracle Database 12c Release 1 (12.1.0.2) Enterprise Edition and Standard Edition 2
  * Oracle Database 11g Release 2 (11.2.0.2) Express Edition.
 
 To assist in building the images, you can use the [buildDockerImage.sh](dockerfiles/buildDockerImage.sh) script. See below for instructions and usage.


### PR DESCRIPTION
- Updated Oracle Database version 12c Release 1 from **12.1.0.1** to **12.1.0.2**  in OracleDatabase/SingleInstance/README.md 

Signed-off-by: Yann Toqué <toqueyann@gmail.com>