### PR TITLE
[OracleRestDataServices] Use custom context-root if specified by CONTEXT_ROOT env variable

### DIFF
--- a/OracleRestDataServices/README.md
+++ b/OracleRestDataServices/README.md
@@ -62,6 +62,7 @@ To run your ORDS Docker image use the **docker run** command as follows:
     -e ORACLE_SERVICE=<your Oracle DB Service name (default: ORCLPDB1)> \
     -e ORACLE_PWD=<your database SYS password> \
     -e ORDS_PWD=<your ORDS password> \
+    -e CONTEXT_ROOT=<http context-root to use (default: ords)> \
     -v [<host mount point>:]/opt/oracle/ords/config/ords \
     oracle/restdataservices:3.0.12
     
@@ -76,6 +77,7 @@ To run your ORDS Docker image use the **docker run** command as follows:
        -e ORACLE_SERVICE: The Oracle Database Service name that ORDS should use (default: ORCLPDB1)
        -e ORACLE_PWD:     The Oracle Database SYS password
        -e ORDS_PWD:       The ORDS_PUBLIC_USER password
+       -e CONTEXT_ROOT:   (optional) The http context-root that ORDS should use (default: ords)
        -v /opt/oracle/ords/config/ords
                           The data volume to use for the ORDS configuration files.
                           Has to be writable by the Unix "oracle" (uid: 54321) user inside the container!

--- a/OracleRestDataServices/dockerfiles/runOrds.sh
+++ b/OracleRestDataServices/dockerfiles/runOrds.sh
@@ -9,6 +9,17 @@
 # Copyright (c) 2014-2017 Oracle and/or its affiliates. All rights reserved.
 # 
 
+CONTEXT_ROOT=${CONTEXT_ROOT:-"ords"}
+CONTEXT_ROOT=$(echo "${CONTEXT_ROOT}" | sed 's/\///g')
+if [ "$CONTEXT_ROOT" != "ords" ]; then
+  if mv $ORDS_HOME/ords.war $ORDS_HOME/$CONTEXT_ROOT.war; then
+    echo "INFO: Renamed ords.war to $CONTEXT_ROOT.war"
+  else
+    echo "ERROR: Failed renaming ords.war to $CONTEXT_ROOT.war. Exiting..."
+    exit 1
+  fi
+fi
+
 function setupOrds() {
 
   # Check whether the Oracle DB password has been specified
@@ -26,11 +37,11 @@ function setupOrds() {
   APEXI=${APEXI:-"$ORDS_HOME/doc_root/i"}
   
   # Make standalone dir
-  mkdir -p $ORDS_HOME/config/ords/standalone
+  mkdir -p $ORDS_HOME/config/$CONTEXT_ROOT/standalone
   
   # Copy template files
   cp $ORDS_HOME/$CONFIG_PROPS $ORDS_HOME/params/ords_params.properties
-  cp $ORDS_HOME/$STANDALONE_PROPS $ORDS_HOME/config/ords/standalone/standalone.properties
+  cp $ORDS_HOME/$STANDALONE_PROPS $ORDS_HOME/config/$CONTEXT_ROOT/standalone/standalone.properties
 
   # Replace DB related variables (ords_params.properties)
   sed -i -e "s|###ORACLE_SERVICE###|$ORACLE_SERVICE|g" $ORDS_HOME/params/ords_params.properties
@@ -40,19 +51,20 @@ function setupOrds() {
   sed -i -e "s|###ORACLE_PWD###|$ORACLE_PWD|g" $ORDS_HOME/params/ords_params.properties
   
   # Replace standalone runtime variables (standalone.properties)
-  sed -i -e "s|###PORT###|8888|g" $ORDS_HOME/config/ords/standalone/standalone.properties
-  sed -i -e "s|###DOC_ROOT###|$ORDS_HOME/doc_root|g" $ORDS_HOME/config/ords/standalone/standalone.properties
-  sed -i -e "s|###APEXI###|$APEXI|g" $ORDS_HOME/config/ords/standalone/standalone.properties
+  sed -i -e "s|###PORT###|8888|g" $ORDS_HOME/config/$CONTEXT_ROOT/standalone/standalone.properties
+  sed -i -e "s|###CONTEXT_ROOT###|$CONTEXT_ROOT|g" $ORDS_HOME/config/$CONTEXT_ROOT/standalone/standalone.properties
+  sed -i -e "s|###DOC_ROOT###|$ORDS_HOME/doc_root|g" $ORDS_HOME/config/$CONTEXT_ROOT/standalone/standalone.properties
+  sed -i -e "s|###APEXI###|$APEXI|g" $ORDS_HOME/config/$CONTEXT_ROOT/standalone/standalone.properties
    
    # Start ODRDS setup
-   java -jar $ORDS_HOME/ords.war install simple
+   java -jar $ORDS_HOME/$CONTEXT_ROOT.war install simple
 }
 
 ############# MAIN ################
 
 # Check whether ords is already setup
-if [ ! -f $ORDS_HOME/config/ords/standalone/standalone.properties ]; then
+if [ ! -f $ORDS_HOME/config/$CONTEXT_ROOT/standalone/standalone.properties ]; then
    setupOrds;
 fi;
 
-java -jar $ORDS_HOME/ords.war standalone
+java -jar $ORDS_HOME/$CONTEXT_ROOT.war standalone

--- a/OracleRestDataServices/dockerfiles/standalone.properties.tmpl
+++ b/OracleRestDataServices/dockerfiles/standalone.properties.tmpl
@@ -1,6 +1,6 @@
 jetty.port=###PORT###
 standalone.access.log=/tmp/ords_log
-standalone.context.path=/ords
+standalone.context.path=/###CONTEXT_ROOT###
 standalone.doc.root=###DOC_ROOT###
 standalone.scheme.do.not.prompt=true
 standalone.static.context.path=/i


### PR DESCRIPTION
Add option to specify a different context-root using `CONTEXT_ROOT` env variable (default remains `/ords`)

Signed-off-by: Fabio Caseri