### PR TITLE
Issue#174 download a specific release of WDT

### DIFF
--- a/OracleWebLogic/samples/12213-domain-home-in-image-wdt/build.sh
+++ b/OracleWebLogic/samples/12213-domain-home-in-image-wdt/build.sh
@@ -52,10 +52,9 @@
 #  to the properties/docker-build directory and change the model to reference the files in /u01/oracle/properties.
 #
 # WDT_VERSION           - If the weblogic deploy install image does not exist in the script location, 
-#                         the WDT install image is downloaded from the github repository. The downloaded release
-#                         is the current supported version for WebLogic Operator. (see the script constaant 
-#                         WDT_SUPPORTED_RELEASE) To select a different release, set this environment variable to 
-#                         the desired release tag or to 'LATEST' to get the lastest release.
+#                         the latest release of the WDT install image is downloaded from the github 
+#                         repository. To select a different release, set this environment variable to 
+#                         the desired release tag (i.e. 0.20).
 #
 # CURL                  - If the "curl" command is not on the shell PATH, use this argument
 #                         as <location>/curl. The curl is performed if the weblogic-deploy.zip install
@@ -95,8 +94,6 @@
 #                         the build args needed by this Dockerfile, or provide the build args in the 
 #                         CUSTOM_BUILD_ARG.
 #
-
-WDT_SUPPORTED_RELEASE=0.17
 
 if [ -z "${JAVA_HOME}" ] || [ ! -e "${JAVA_HOME}/bin/jar" ]; then 
    echo "JAVA_HOME must be set to version of a java JDK 1.8 or greater"
@@ -322,7 +319,7 @@ curl_failed() {
 
 function wdturl {
   githubRepo=oracle/weblogic-deploy-tooling
-  githubRelease=$(if [ -n "$WDT_VERSION" ]; then echo ${WDT_VERSION}; else echo ${WDT_SUPPORTED_RELEASE}; fi)
+  githubRelease=$(if [ -n "$WDT_VERSION" ]; then echo ${WDT_VERSION}; else echo LATEST; fi)
   if [ "LATEST" != "${githubRelease}" ]; then githubRelease=weblogic-deploy-tooling-${githubRelease#weblogic-deploy-tooling-}; fi
   url=$(github_url $githubRepo $githubRelease)
   rc=$?

--- a/OracleWebLogic/samples/12213-domain-home-in-image-wdt/build.sh
+++ b/OracleWebLogic/samples/12213-domain-home-in-image-wdt/build.sh
@@ -16,18 +16,18 @@
 #
 #  The steps run by this script are as follows:
 #
-#   set_up                - prepare the script for the build. This includes copying the 
-#                           model, variable and archive file to a temporary directory in
+#   set_up                - prepare the script for the build. call container-scripts/setEnv.sh to create a 
+#                           string of build arguments and source variables into the build.sh environment.
+#                           The values in the build args string are required for exposing ports and container
+#                           ENV variables in the sample Dockerfile.
+#
+#                           Copy the model, variable and archive file to a temporary directory in
 #                           the sample directory. The sample directory is used as the docker
 #                           build context. This step builds the sample archive file if the 
 #                           sample files are used.
 #
 #   download_tool         - download the latest weblogic-deploy.zip install if the archive
 #                           does not exist in the current location. 
-#
-#   prepare_build_args    - call container-scripts/setEnv.sh to create a string of build arguments
-#                           from the properties in the variable file. These arguments are required
-#                           for exposing ports and container ENV variables in the sample Dockerfile.
 #
 #   build_domain_image    - run the docker build with the sample Dockerfile in the context location.
 #
@@ -51,24 +51,39 @@
 #  so that the files are accessible in the build context. If your model uses file tokens, copy the files 
 #  to the properties/docker-build directory and change the model to reference the files in /u01/oracle/properties.
 #
+# There are three ways that you can set the environment variables before running build.sh to build the docker image.
+#
+#  1. Manually set the environment variable:
+#     WDT_VERSION=LATEST
+#     export WDT_VERSION  
+#
+#  2. Add the variable directly to the build.sh script. It is suggested you put them under the SCRIPT ENVIRONMENT VARIABLES
+#     section below so they are highly visible.
+#
+#  3. Add the environment variable to the domain.properties or the file in the CUSTOM_WDT_VARIABLE (set by method 1 or 2). 
+#     The setEnv.sh will inspect the properties file for known variables and export each one to the environment.
+#
+# Variables set by method 2 will override variables set by method 1. Variables set by method 3 will override variables set
+#  by methods 1 and 2. 
+# 
 # WDT_VERSION           - If the weblogic deploy install image does not exist in the script location, 
 #                         the latest release of the WDT install image is downloaded from the github 
-#                         repository. To select a different release, set this environment variable to 
-#                         the desired release tag (i.e. 0.20).
+#                         repository. To select a specific release instead, set this environment variable to 
+#                         the desired release tag (i.e. 0.20 or weblogic-deploy-tooling-0.20).
 #
 # CURL                  - If the "curl" command is not on the shell PATH, use this argument
 #                         as <location>/curl. The curl is performed if the weblogic-deploy.zip install
 #                         has not been downloaded into the sample directory.
 #
-# TAG_NAME              - Tag the docker image with this name. This overrides the default of 
+# CUSTOM_TAG_NAME       - Tag the docker image with this name. This overrides the default of 
 #                         12213-domain-home-in-image-wdt:latest. 
 #
 #                         There are four ways to tag the domain home image using this build script.
 #
-#                           . Do nothing and the image will be tagged with the default name. 
-#                           . Add an IMAGE_TAG variable to the variable file and allow the
-#                             setEnv.sh to manage the tag. Overrides the default tag.
-#                           . Set the TAG_NAME environment variable. Overrides the default tag.
+#                           . Do nothing and the image will be tagged with the default name.
+#                           . Add an IMAGE_TAG variable to the properties file (maintains backward compatibility). Overrides 
+#                             the default tag.
+#                           . Set the CUSTOM_TAG_NAME environment variable. Overrides both the default tag and IMAGE_TAG.        
 #                           . Set the ADDITIONAL_BUILD_ARGS to include a tag argument 
 #                             (i.e. -t sample-tag). Adds an additional tag to the image.
 #
@@ -77,7 +92,7 @@
 #
 # CUSTOM_BUILD_ARG      - Use this variable's value to add build arguments to the image build. If this
 #                         variable is set, its value is used to set the BUILD_ARG variable instead
-#                         of calling the setEnv.sh script. The BUILD_ARG is used on the docker build  
+#                         overriding the setEnv.sh script. The BUILD_ARG is used on the docker build  
 #                         command in the build_domain_image step. 
 #
 # CUSTOM_WDT_MODEL      - Override the default model simple-topology.yaml in the build_domain_image step.
@@ -94,19 +109,44 @@
 #                         the build args needed by this Dockerfile, or provide the build args in the 
 #                         CUSTOM_BUILD_ARG.
 #
+# CUSTOM_DOCKERFILE     - Alternative Dockerfile
+#
 
-if [ -z "${JAVA_HOME}" ] || [ ! -e "${JAVA_HOME}/bin/jar" ]; then 
-   echo "JAVA_HOME must be set to version of a java JDK 1.8 or greater"
-   exit 1
-fi
-echo "JAVA_HOME=${JAVA_HOME}"
+# SCRIPT ENVIRONMENT VARIABLES
+###################
 
-# Perform any clean up and exit with the return code in variable rc.
+
+###################
+
+
+# DEFAULTS
+WDT_SUPPORTED_RELEASE=LATEST
+WDT_GITHUB_REPO=oracle/weblogic-deploy-tooling
+
+  
+# Perform any clean up and exit with the return code 
 clean_and_exit() {
-   return_code=${rc:-1}
+   if [ $#  -eq 0 ]; then return_code=1; else return_code=$1; fi
    rm -rf ${tempLocation}
-   echo "Build exiting with return code $return_code"
+   echo "*** build.sh exiting with return code $return_code"
    exit $return_code
+}
+
+# Call the setEnv.sh to create the BUILD_ARG from the properties file and source any variables into the 
+# script run environment
+set_args() {  
+   if [ ! -f ${WDT_VARIABLE} ] ; then
+	  echo "Cannot set the docker build argument string from the variable file ${WDT_VARIABLE} using the script ${scriptDir}/container-scripts/setEnv.sh"
+	  clean_and_exit
+  fi
+  . ${scriptDir}/container-scripts/setEnv.sh ${WDT_VARIABLE}
+  rc=$?
+  if [ $rc != 0 ]; then
+	 echo "Failure deriving the docker build-argument string from the variable file ${WDT_VARIABLE}"
+	 echo "   BUILD_ARG=${BUILD_ARG}"
+	 echo "   setEnv.sh return_code=${rc}"
+	 clean_and_exit $rc
+  fi 
 }
 
 # Perform some simple setup to prime the rest of the build shell. This includes setting the model,
@@ -126,21 +166,52 @@ set_up() {
 	  chmod -R u+rwx ${tempLocation}
    fi
    
-   # if the custom wdt archive is NOT set (file or empty string) then build the sample archive
-   if [ "${CUSTOM_WDT_ARCHIVE+true}" != "true" ]; then  
+    # Source the environment variables from the environment file and properties file.
+    # If the CUSTOM_WDT_VARIABLE is sourced in the environment, use this value to locate the properties files.
+	# If the properties file contains the 
+    WDT_VARIABLE=${CUSTOM_WDT_VARIABLE:-${scriptDir}/properties/docker-build/domain.properties}
+	set_args
+	WDT_VARIABLE=${CUSTOM_WDT_VARIABLE:-$WDT_VARIABLE}
+
+	if [ -n "${JAVA_HOME}" ]; then
+	    if [ -d ${JAVA_HOME} ]; then 
+	      if [ -f ${JAVA_HOME}/bin/java ]; then 
+		     JAVA=${JAVA_HOME}/bin/java
+		  elif	[ -f ${JAVA_HOME}/java ]; then
+		     JAVA=${JAVA_HOME}/java
+		  fi
+		elif [ -f ${JAVA_HOME} ]; then 
+           JAVA=${JAVA_HOME} 		
+	    fi 
+	else
+	  JAVA=`which java`
+	fi
+    JAVA_BIN=${JAVA%/*}
+	
+	if [ ! -f $JAVA ] || [[ "`${JAVA} -version 2>&1 | grep ' version ' | sed -E 's/.*"([^"]+)".*/\1/'`" < "1.8" ]] || [ ! -f ${JAVA_BIN}/jar ]; then
+	   echo "JAVA_HOME must be set to valid location of a java JDK version 1.8 or greater"
+	   if [ -n "$JAVA" ]; then echo "$JAVA is version \"`$JAVA -version`\" and jdk jar must exist at location ${JAVA_BIN}"; fi
+	   clean_and_exit
+    fi
+
+	# if the custom wdt archive is NOT set (file or empty string) then build the sample archive
+    if [ "${CUSTOM_WDT_ARCHIVE+true}" != "true" ]; then  
       echo "Build the sample archive file"
       WDT_ARCHIVE=${scriptDir}/archive.zip
       build_archive
-	    rc=$?
-	    if [ $rc -ne 0 ]; then return_code=$rc; clean_and_exit; fi
+	  rc=$?
+	  if [ $rc -ne 0 ]; then clean_and_exit $rc; fi
    fi
    
    # prime the model and variable file variables. Then copy the files to the temporary 
    # location to ensure the files are within the context
-   WDT_MODEL=${CUSTOM_WDT_MODEL-"${scriptDir}/simple-topology.yaml"}
-   WDT_VARIABLE=${CUSTOM_WDT_VARIABLE-"${scriptDir}/properties/docker-build/domain.properties"}
-   WDT_ARCHIVE=${CUSTOM_WDT_ARCHIVE-"${scriptDir}/archive.zip"}
-   echo "WDT_MODEL=[${WDT_MODEL}] WDT_VARIABLE=[$WDT_VARIABLE] WDT_ARCHIVE=[$WDT_ARCHIVE]"
+   WDT_MODEL=${CUSTOM_WDT_MODEL:-${scriptDir}/simple-topology.yaml}
+   WDT_ARCHIVE=${CUSTOM_WDT_ARCHIVE:-${scriptDir}/archive.zip}
+   
+   WDT_MODEL=`eval echo $WDT_MODEL`
+   WDT_ARCHIVE=`eval echo $WDT_ARCHIVE`
+   WDT_VARIABLE=`eval echo $WDT_VARIABLE`
+
 
    # model is required. If it does not exist then exit
    if [ ! -f ${WDT_MODEL} ]; then
@@ -165,14 +236,24 @@ set_up() {
       WDT_ARCHIVE=${tempDir}/${WDT_ARCHIVE##*/}
    fi   
    
-   dockerFile=${CUSTOM_DOCKERFILE-"${scriptDir}/Dockerfile"}
+   if [ -n "${CUSTOM_BUILD_ARG}" ]; then
+     echo "Using custom build argument string instead of the properties file build arg string"
+     BUILD_ARG=${CUSTOM_BUILD_ARG}
+   fi    		
+		
+   MODEL_ARGS="--build-arg WDT_MODEL=${WDT_MODEL}"
+   if [ -n "${WDT_VARIABLE}" ]; then MODEL_ARGS="${MODEL_ARGS} --build-arg WDT_VARIABLE=${WDT_VARIABLE}"; fi
+   if [ -n "${WDT_ARCHIVE}" ]; then MODEL_ARGS="${MODEL_ARGS} --build-arg WDT_ARCHIVE=${WDT_ARCHIVE}"; fi
+   
+   dockerFile=${CUSTOM_DOCKERFILE:-${scriptDir}/Dockerfile}
    if [ -z "${dockerFile}" ] || [ ! -f $dockerFile ]; then
-      echo "Invalid Dockerfile (${dockerFile}). Dockerfile required"
-	    clean_and_exit
+      echo "Invalid Dockerfile ${dockerFile}. Dockerfile required"
+      clean_and_exit
    fi
    cp ${dockerFile} ${tempLocation}
    dockerFile=${tempLocation}/${dockerFile##*/}
- 
+     
+   tag_name	 
 }
 
 # Run the docker build using the arguments from both the BUILD_ARG (created by the setEnv.sh) and
@@ -191,7 +272,7 @@ build_domain_image() {
        -t ${tagName} \
        ${scriptDir}"
    echo " "
-    
+ 
    # Expand the tagName variable before exec the docker build.
    eval docker build \
        $BUILD_ARG \
@@ -250,19 +331,26 @@ download_tool() {
     if [ ! -s "${scriptDir}/weblogic-deploy.zip" ]; then
 
       # Find the curl command or use the command from the CURL variable
-      if [ -z "$CURL" ]; then CURL=`which curl`; fi 
-	    if [ -z "$CURL" ] || [ ! -e ${CURL} ]; then curl_failed; fi 
-      
-      download_url=$(wdturl)
-      if [ -z "${download_url}" ]; then curl_failed; fi
-      
+      if [ -n "$CURL" ]; then CURL=`eval echo ${CURL}`; else CURL=`which curl`; fi
+	  if [ -x $CURL ]; then 
+	     download_url=$(wdturl)
+	  else 
+	     echo '$CURL is not a valid curl executable'
+		 curl_failed
+      fi
+	  if [ -z "$download_url" ]; then 
+	    echo 'Unable to determine the weblogic-deploy download url'
+	    curl_failed
+	  fi
+  
       echo "Downloading the weblogic deploy tool install: ${download_url}/weblogic-deploy.zip"      
-      ${CURL} -m 60 -Lo ${scriptDir}/weblogic-deploy.zip ${download_url}/weblogic-deploy.zip
+      ${CURL} -m 120 -Lo ${scriptDir}/weblogic-deploy.zip ${download_url}/weblogic-deploy.zip
       rc=$?
       if [ $rc != 0 ]; then echo "${CURL} failed with return code=${rc}"; return_code=$rc; curl_failed; fi
-      ${JAVA_HOME}/bin/jar tf ${scriptDir}/weblogic-deploy.zip &> /dev/null
+      ${JAVA_BIN}/jar tf ${scriptDir}/weblogic-deploy.zip &> /dev/null
       rc=$?
       if [ $rc != 0 ]; then 
+	     echo "Downloaded an invalid or corrupted WDT install image : `ls -l ${scriptDir}/weblogic-deploy.zip`"
          if [ -f ${scriptDir}/weblogic-deploy.zip ]; then rm ${scriptDir}/weblogic-deploy.zip; fi
          curl_failed
       fi
@@ -271,44 +359,13 @@ download_tool() {
     fi  
     echo WDT Tool: `ls -l ${scriptDir}/weblogic-deploy.zip`	
 }
-
-# This calls the setEnv.sh in container-scripts to parse the ADMIN_HOST, ADMIN_PORT,
-# MS_PORT, and DOMAIN_NAME from the sample properties file and pass
-# as a string of --build-arg in the variable BUILD_ARG
-# If the CUSTOM_BUILD_ARG variable is set, use its value in place of the setEnv.sh
-prepare_build_args() {
-   BUILD_ARG=
-   if [ -n "${CUSTOM_BUILD_ARG}" ]; then
-      echo "Using custom build argument string instead of parsing the sample properties file"
-      BUILD_ARG=${CUSTOM_BUILD_ARG}
-   else
-      echo "Create the BUILD_ARG string from the variable file ${WDT_VARIABLE}"
-       if [ ! -f ${scriptDir}/${WDT_VARIABLE} ] || \
-          [ ! -f ${scriptDir}/container-scripts/setEnv.sh ]; then
-          echo "Cannot set the docker build argument string from the variable file ${WDT_VARIABLE}"
-          clean_and_exit
-      fi
-      . ${scriptDir}/container-scripts/setEnv.sh ${scriptDir}/${WDT_VARIABLE}
-      rc=$?
-      if [ $rc != 0 ]; then
-         echo "Failure deriving the docker build-argument string from the variable file ${WDT_VARIABLE}"
-         echo "   BUILD_ARG=${BUILD_ARG}"
-         echo "   setEnv.sh return_code=${rc}"
-         return_code=${rc}
-         clean_and_exit
-      fi 
-   fi
-   MODEL_ARGS="--build-arg WDT_MODEL=${WDT_MODEL}"
-   if [ -n "${WDT_VARIABLE}" ]; then MODEL_ARGS="${MODEL_ARGS} --build-arg WDT_VARIABLE=${WDT_VARIABLE}"; fi
-   if [ -n "${WDT_ARCHIVE}" ]; then MODEL_ARGS="${MODEL_ARGS} --build-arg WDT_ARCHIVE=${WDT_ARCHIVE}"; fi
-}
-
+ 
 # Determine the tag name for the resulting image using the value in the TAG_NAME.
 # The setEnv.sh will set the TAG_NAME variable if the property is found in the
 # properties file. This function should be called after the setEnv.sh is run
 tag_name() {
-   tagName=${TAG_NAME:-"12213-domain-home-in-image-wdt:latest"}
-   #echo ${TAG_NAME} and ${tagName}
+   tagName=${CUSTOM_TAG_NAME:-12213-domain-home-in-image-wdt}
+   #echo ${CUSTOM_TAG_NAME} and ${tagName}
 }
 
 curl_failed() {
@@ -317,37 +374,30 @@ curl_failed() {
       clean_and_exit
 }
 
-function wdturl {
-  githubRepo=oracle/weblogic-deploy-tooling
-  githubRelease=$(if [ -n "$WDT_VERSION" ]; then echo ${WDT_VERSION}; else echo LATEST; fi)
+wdturl() {
+  githubRepo=${WDT_GITHUB_REPO}
+  githubRelease=${WDT_VERSION:-$WDT_SUPPORTED_RELEASE}
   if [ "LATEST" != "${githubRelease}" ]; then githubRelease=weblogic-deploy-tooling-${githubRelease#weblogic-deploy-tooling-}; fi
-  url=$(github_url $githubRepo $githubRelease)
-  rc=$?
-  echo $url
-  return $rc
+  echo $(github_url)
 }
 
-function github_url {
-  if [ $# -eq 2 ]; then 
-    var1=$1
-    var2=$2
-    if [ "$var2" == "LATEST" ]; then release=$(latest_release $var1); else release=$var2; fi
-    if [ -n "${release}" ]; then echo "https://github.com/${var1}/releases/download/${release}"; return 0; fi
-  fi
-  echo ""
-  return 1
+github_url() {
+    if [ "$githubRelease" == "LATEST" ]; then 
+	   githubRelease=$(latest_release)
+	   if [ "$?" -ne "0"]; then return $?; fi
+	fi
+	if [ -z "$githubRelease" ]; then return 1; fi
+	echo https://github.com/${githubRepo}/releases/download/${githubRelease}
 }
-  
-function latest_release {
-    ${CURL} -m 20 --silent "https://api.github.com/repos/${1}/releases/latest" | # Get latest release from GitHub api
+
+latest_release() {
+  ${CURL} --silent "https://api.github.com/repos/${githubRepo}/releases/latest" | # Get latest release from GitHub api
     grep '"tag_name":' |                                            # Get tag line
     sed -E 's/.*"([^"]+)".*/\1/'                                    # Pluck JSON value
 }
 
 set_up
 download_tool
-prepare_build_args
-tag_name
 build_domain_image
-return_code=$?
-clean_and_exit
+rc=$?
+clean_and_exit $rc

--- a/OracleWebLogic/samples/12213-domain-home-in-image-wdt/container-scripts/setEnv.sh
+++ b/OracleWebLogic/samples/12213-domain-home-in-image-wdt/container-scripts/setEnv.sh
@@ -14,8 +14,84 @@ if [ "$#" -eq  "0" ]; then
     exit 1
  else
     PROPERTIES_FILE=$1
-    echo Export environment variables from the ${PROPERTIES_FILE} properties file
+    echo Source environment variables from ${PROPERTIES_FILE} 
 fi
+
+# Export any variables that are used by the build.sh into the environment
+# If the CUSTOM_VARIABLE_FILE is in the properties file, then the build arg string 
+# will be built from this file instead of the file on this script command line
+CUSTOM_WDT_VARIABLE=`awk '{print $1}' $PROPERTIES_FILE | grep ^CUSTOM_WDT_VARIABLE= | cut -d "=" -f2`
+if [ -n "$CUSTOM_WDT_VARIABLE" ]; then
+    export CUSTOM_WDT_VARIABLE
+    echo "CUSTOM_WDT_VARIABLE=$CUSTOM_WDT_VARIABLE"
+fi
+
+JAVA_HOME=`awk '{print $1}' $PROPERTIES_FILE | grep ^JAVA_HOME= | cut -d "=" -f2`
+if [ -n "$JAVA_HOME" ]; then
+    export JAVA_HOME
+    echo "JAVA_HOME=$JAVA_HOME"
+fi
+
+WDT_VERSION=`awk '{print $1}' $PROPERTIES_FILE | grep ^WDT_VERSION= | cut -d "=" -f2`
+if [ -n "$WDT_VERSION" ]; then
+    export WDT_VERSION
+    echo "WDT_VERSION=$WDT_VERSION"
+fi
+
+
+CUSTOM_TAG_NAME=`awk '{print $1}' $PROPERTIES_FILE | grep ^CUSTOM_TAG_NAME= | cut -d "=" -f2`
+if [ -z "$CUSTOM_TAG_NAME" ]; then 
+   CUSTOM_TAG_NAME=`awk '{print $1}' $PROPERTIES_FILE | grep ^IMAGE_TAG= | cut -d "=" -f2`
+fi 
+if [ -n "$CUSTOM_TAG_NAME" ]; then
+    export CUSTOM_TAG_NAME
+    echo "CUSTOM_TAG_NAME=$CUSTOM_TAG_NAME"
+fi
+
+CUSTOM_WDT_MODEL=`awk '{print $1}' $PROPERTIES_FILE | grep ^CUSTOM_WDT_MODEL= | cut -d "=" -f2`
+if [ -n "$CUSTOM_WDT_MODEL" ]; then
+    export CUSTOM_WDT_MODEL
+    echo "CUSTOM_WDT_MODEL=$CUSTOM_WDT_MODEL"
+fi
+
+CUSTOM_WDT_ARCHIVE=`awk '{print $1}' $PROPERTIES_FILE | grep ^CUSTOM_WDT_ARCHIVE= | cut -d "=" -f2`
+if [ -n "$CUSTOM_WDT_ARCHIVE" ]; then
+    export CUSTOM_WDT_ARCHIVE
+    echo "CUSTOM_WDT_ARCHIVE=$CUSTOM_WDT_ARCHIVE"
+fi
+
+ADDITIONAL_BUILD_ARGS=`cat $PROPERTIES_FILE | grep -P "((?<=ADDITIONAL_BUILD_ARGS=[']).*[^']|(?<=ADDITIONAL_BUILD_ARGS=)[^'].*)" -o`
+if [ -n "$ADDITIONAL_BUILD_ARGS" ]; then
+    export ADDITIONAL_BUILD_ARGS
+    echo "ADDITIONAL_BUILD_ARGS=$ADDITIONAL_BUILD_ARGS" 
+fi
+
+CURL=`awk '{print $1}' $PROPERTIES_FILE | grep ^CURL= | cut -d "=" -f2`
+if [ -n "$CURL" ]; then
+    export CURL
+    echo "CURL=$CURL"
+fi
+
+CUSTOM_DOCKERFILE=`awk '{print $1}' $PROPERTIES_FILE | grep ^CUSTOM_DOCKERFILE= | cut -d "=" -f2`
+if [ -n "$CUSTOM_DOCKERFILE" ]; then
+    export CUSTOM_DOCKERFILE
+    echo "NOTICE: Replacing the sample Dockerfile name with $CUSTOM_DOCKERFILE"
+fi
+
+CUSTOM_BUILD_ARG=`cat $PROPERTIES_FILE | grep -P "((?<=CUSTOM_BUILD_ARG=[']).*[^']|(?<=CUSTOM_BUILD_ARG=)[^'].*)" -o`
+if [ -n "$CUSTOM_BUILD_ARG" ]; then
+    export CUSTOM_BUILD_ARG
+    echo "CUSTOM_BUILD_ARG=$CUSTOM_BUILD_ARG"
+    exit 0
+fi
+
+# Now build the BUILD_ARG string from the properties file
+
+if [ -n "$CUSTOM_WDT_VARIABLE" ]; then
+   echo "The BUILD_ARG will built from $CUSTOM_WDT_VARIABLE instead of $PROPERTIES_FILE"
+   PROPERTIES_FILE=$CUSTOM_WDT_VARIABLE
+fi
+echo "Build the BUILD_ARGS string from $PROPERTIES_FILE"
 
 DOMAIN_DIR=`awk '{print $1}' $PROPERTIES_FILE | grep ^DOMAIN_NAME= | cut -d "=" -f2`
 if [ ! -n "$DOMAIN_DIR" ]; then  
@@ -23,6 +99,7 @@ if [ ! -n "$DOMAIN_DIR" ]; then
       DOMAIN_DIR=$DOMAIN_NAME
    fi
 fi
+
 if [ -n "$DOMAIN_DIR" ]; then
      DOMAIN_NAME=$DOMAIN_DIR
      export DOMAIN_NAME
@@ -64,12 +141,4 @@ if [ -n "$DEBUG_PORT" ]; then
     echo DEBUG_PORT=$DEBUG_PORT
     BUILD_ARG="$BUILD_ARG --build-arg CUSTOM_DEBUG_PORT=$DEBUG_PORT"
 fi
-
-CUSTOM_TAG_NAME=`awk '{print $1}' $PROPERTIES_FILE | grep ^IMAGE_TAG= | cut -d "=" -f2`
-if [ -n "$CUSTOM_TAG_NAME" ]; then
-    TAG_NAME=${CUSTOM_TAG_NAME}
-    export TAG_NAME
-    echo "Set the image tag name to $TAG_NAME"
-fi
-
 echo BUILD_ARG=$BUILD_ARG

--- a/OracleWebLogic/samples/12213-domain-home-in-image-wdt/properties/docker-build/domain.properties
+++ b/OracleWebLogic/samples/12213-domain-home-in-image-wdt/properties/docker-build/domain.properties
@@ -16,3 +16,27 @@ JAVA_OPTIONS=-Dweblogic.StdoutDebugEnabled=false
 T3_CHANNEL_PORT=30012
 T3_PUBLIC_ADDRESS=kubernetes
 CLUSTER_ADMIN=cluster-1,admin-server
+
+#
+# Set environment variables to customize the domain creation
+# with variables used by the build.sh. The setEnv.sh will look for
+# the build.sh environment variables in the domain.properties and
+# export to the environment. Please see the build.sh for information about each
+# of these environment variables:
+#
+# You can also set the build.sh environment variables manually before
+# running the build.sh:
+#
+#  WDT_VERSION=0.20
+#  export WDT_VERSION
+#
+#JAVA_HOME=
+#WDT_VERSION=
+#CUSTOM_TAG_NAME=
+#CUSTOM_WDT_MODEL=
+#CUSTOM_WDT_ARCHIVE=
+#CUSTOM_WDT_VARIABLE=
+#CUSTOM_BUILD_ARG=
+#CUSTOM_DOCKERFILE=
+#ADDITIONAL_BUILD_ARGS=
+#CURL=


### PR DESCRIPTION
1. Add an environment variable WDT_VERSION to allow the user to download a specific release of weblogic deploy tooling. By default, the latest release is downloaded.

2. Add additional tests to insure a good image was downloaded from the git repository for Jira OWLS-72698
