### PR TITLE
1201 fixes

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/Checksum.ee
+++ b/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/Checksum.ee
@@ -1,0 +1,1 @@
+99a7c4a088a8a502c261e741a8339ae8  LINUX.X64_180000_db_home.zip

--- a/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/Checksum.se2
+++ b/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/Checksum.se2
@@ -1,0 +1,1 @@
+99a7c4a088a8a502c261e741a8339ae8  LINUX.X64_180000_db_home.zip

--- a/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/Dockerfile
+++ b/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/Dockerfile
@@ -8,15 +8,15 @@
 # 
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
-# (1) db_home.zip
-#     Download Oracle Database 18c Enterprise Edition or Standard Edition 2 for Linux x64
+# (1) goldimage of particular base release
+#     Download Oracle Database 18c (or higher edition) Enterprise Edition or Standard Edition 2 for Linux x64
 #     from http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html
 #
 # HOW TO BUILD THIS IMAGE
 # -----------------------
 # Put all downloaded files in the same directory as this Dockerfile
-# Run: 
-#      $ docker build -t oracle/database:18.3.0-${EDITION} . 
+# Run:
+#      $ docker build -t oracle/database:${VERSION}-${EDITION} .
 #
 # Pull base image
 # ---------------
@@ -26,12 +26,15 @@ FROM oraclelinux:7-slim as base
 # ----------
 MAINTAINER Gerald Venzl <gerald.venzl@oracle.com>
 
+ARG MAJOR_VERSION
+ARG GOLDIMAGE_NAME
+
 # Environment variables required for this build (do NOT change)
 # -------------------------------------------------------------
 ENV ORACLE_BASE=/opt/oracle \
-    ORACLE_HOME=/opt/oracle/product/18c/dbhome_1 \
+    ORACLE_HOME=/opt/oracle/product/$MAJOR_VERSION.0.0/dbhome_1 \
     INSTALL_DIR=/opt/install \
-    INSTALL_FILE_1="LINUX.X64_180000_db_home.zip" \
+    INSTALL_FILE_1=$GOLDIMAGE_NAME \
     INSTALL_RSP="db_inst.rsp" \
     CONFIG_RSP="dbca.rsp.tmpl" \
     PWD_FILE="setPassword.sh" \

--- a/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/Dockerfile
+++ b/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/Dockerfile
@@ -1,0 +1,113 @@
+# LICENSE UPL 1.0
+#
+# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+#
+# ORACLE DOCKERFILES PROJECT
+# --------------------------
+# This is the Dockerfile for Oracle Database 18c
+# 
+# REQUIRED FILES TO BUILD THIS IMAGE
+# ----------------------------------
+# (1) db_home.zip
+#     Download Oracle Database 18c Enterprise Edition or Standard Edition 2 for Linux x64
+#     from http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html
+#
+# HOW TO BUILD THIS IMAGE
+# -----------------------
+# Put all downloaded files in the same directory as this Dockerfile
+# Run: 
+#      $ docker build -t oracle/database:18.3.0-${EDITION} . 
+#
+# Pull base image
+# ---------------
+FROM oraclelinux:7-slim as base
+
+# Maintainer
+# ----------
+MAINTAINER Gerald Venzl <gerald.venzl@oracle.com>
+
+# Environment variables required for this build (do NOT change)
+# -------------------------------------------------------------
+ENV ORACLE_BASE=/opt/oracle \
+    ORACLE_HOME=/opt/oracle/product/18c/dbhome_1 \
+    INSTALL_DIR=/opt/install \
+    INSTALL_FILE_1="LINUX.X64_180000_db_home.zip" \
+    INSTALL_RSP="db_inst.rsp" \
+    CONFIG_RSP="dbca.rsp.tmpl" \
+    PWD_FILE="setPassword.sh" \
+    RUN_FILE="runOracle.sh" \
+    START_FILE="startDB.sh" \
+    CREATE_DB_FILE="createDB.sh" \
+    SETUP_LINUX_FILE="setupLinuxEnv.sh" \
+    CHECK_SPACE_FILE="checkSpace.sh" \
+    CHECK_DB_FILE="checkDBStatus.sh" \
+    USER_SCRIPTS_FILE="runUserScripts.sh" \
+    INSTALL_DB_BINARIES_FILE="installDBBinaries.sh"
+
+# Use second ENV so that variable get substituted
+ENV PATH=$ORACLE_HOME/bin:$ORACLE_HOME/OPatch/:/usr/sbin:$PATH \
+    LD_LIBRARY_PATH=$ORACLE_HOME/lib:/usr/lib \
+    CLASSPATH=$ORACLE_HOME/jlib:$ORACLE_HOME/rdbms/jlib
+
+# Copy files needed during both installation and runtime
+# -------------
+COPY $SETUP_LINUX_FILE $CHECK_SPACE_FILE $INSTALL_DIR/
+COPY $RUN_FILE $START_FILE $CREATE_DB_FILE $CONFIG_RSP $PWD_FILE $CHECK_DB_FILE $USER_SCRIPTS_FILE $ORACLE_BASE/
+
+RUN chmod ug+x $INSTALL_DIR/*.sh && \
+    sync && \
+    $INSTALL_DIR/$CHECK_SPACE_FILE && \
+    $INSTALL_DIR/$SETUP_LINUX_FILE && \
+    rm -rf $INSTALL_DIR
+
+
+
+#############################################
+# -------------------------------------------
+# Start new stage for installing the database
+# -------------------------------------------
+#############################################
+
+FROM base AS builder
+
+ARG DB_EDITION
+
+# Install unzip for unzip operation
+RUN yum -y install unzip
+
+# Copy DB install file
+COPY --chown=oracle:dba $INSTALL_FILE_1 $INSTALL_RSP $INSTALL_DB_BINARIES_FILE $INSTALL_DIR/
+
+# Install DB software binaries
+USER oracle
+RUN chmod ug+x $INSTALL_DIR/*.sh && \
+    sync && \
+    $INSTALL_DIR/$INSTALL_DB_BINARIES_FILE $DB_EDITION
+
+
+
+#############################################
+# -------------------------------------------
+# Start new layer for database runtime
+# -------------------------------------------
+#############################################
+
+FROM base
+
+USER oracle
+COPY --chown=oracle:dba --from=builder $ORACLE_BASE $ORACLE_BASE
+
+USER root
+RUN $ORACLE_BASE/oraInventory/orainstRoot.sh && \
+    $ORACLE_HOME/root.sh
+
+USER oracle
+WORKDIR /home/oracle
+
+VOLUME ["$ORACLE_BASE/oradata"]
+EXPOSE 1521 5500
+HEALTHCHECK --interval=1m --start-period=5m \
+   CMD "$ORACLE_BASE/$CHECK_DB_FILE" >/dev/null || exit 1
+
+# Define default command to start Oracle Database. 
+CMD exec $ORACLE_BASE/$RUN_FILE

--- a/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/checkDBStatus.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/checkDBStatus.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# LICENSE UPL 1.0
+#
+# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+#
+# Since: May, 2017
+# Author: gerald.venzl@oracle.com
+# Description: Checks the status of Oracle Database.
+# Return codes: 0 = PDB is open and ready to use
+#               1 = PDB is not open
+#               2 = Sql Plus execution failed
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# 
+
+ORACLE_SID="`grep $ORACLE_HOME /etc/oratab | cut -d: -f1`"
+OPEN_MODE="READ WRITE"
+ORAENV_ASK=NO
+source oraenv
+
+# Check Oracle at least one PDB has open_mode "READ WRITE" and store it in status
+status=`sqlplus -s / as sysdba << EOF
+   set heading off;
+   set pagesize 0;
+   SELECT DISTINCT open_mode FROM v\\$pdbs WHERE open_mode = '$OPEN_MODE';
+   exit;
+EOF`
+
+# Store return code from SQL*Plus
+ret=$?
+
+# SQL Plus execution was successful and PDB is open
+if [ $ret -eq 0 ] && [ "$status" = "$OPEN_MODE" ]; then
+   exit 0;
+# PDB is not open
+elif [ "$status" != "$OPEN_MODE" ]; then
+   exit 1;
+# SQL Plus execution failed
+else
+   exit 2;
+fi;

--- a/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/checkSpace.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/checkSpace.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# LICENSE UPL 1.0
+#
+# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+#
+# Since: January, 2017
+# Author: gerald.venzl@oracle.com
+# Description: Checks the available space of the system.
+# 
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# 
+
+REQUIRED_SPACE_GB=18
+AVAILABLE_SPACE_GB=`df -PB 1G / | tail -n 1 | awk '{ print $4 }'`
+
+if [ $AVAILABLE_SPACE_GB -lt $REQUIRED_SPACE_GB ]; then
+  script_name=`basename "$0"`
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  echo "$script_name: ERROR - There is not enough space available in the docker container."
+  echo "$script_name: The container needs at least $REQUIRED_SPACE_GB GB, but only $AVAILABLE_SPACE_GB GB are available."
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  exit 1;
+fi;

--- a/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/createDB.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# LICENSE UPL 1.0
+#
+# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+# 
+# Since: November, 2016
+# Author: gerald.venzl@oracle.com
+# Description: Creates an Oracle Database based on following parameters:
+#              $ORACLE_SID: The Oracle SID and CDB name
+#              $ORACLE_PDB: The PDB name
+#              $ORACLE_PWD: The Oracle password
+# 
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# 
+
+set -e
+
+# Check whether ORACLE_SID is passed on
+export ORACLE_SID=${1:-ORCLCDB}
+
+# Check whether ORACLE_PDB is passed on
+export ORACLE_PDB=${2:-ORCLPDB1}
+
+# Auto generate ORACLE PWD if not passed on
+export ORACLE_PWD=${3:-"`openssl rand -base64 8`1"}
+echo "ORACLE PASSWORD FOR SYS, SYSTEM AND PDBADMIN: $ORACLE_PWD";
+
+# Replace place holders in response file
+cp $ORACLE_BASE/$CONFIG_RSP $ORACLE_BASE/dbca.rsp
+sed -i -e "s|###ORACLE_SID###|$ORACLE_SID|g" $ORACLE_BASE/dbca.rsp
+sed -i -e "s|###ORACLE_PDB###|$ORACLE_PDB|g" $ORACLE_BASE/dbca.rsp
+sed -i -e "s|###ORACLE_PWD###|$ORACLE_PWD|g" $ORACLE_BASE/dbca.rsp
+sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" $ORACLE_BASE/dbca.rsp
+
+# If there is greater than 8 CPUs default back to dbca memory calculations
+# dbca will automatically pick 40% of available memory for Oracle DB
+# The minimum of 2G is for small environments to guarantee that Oracle has enough memory to function
+# However, bigger environment can and should use more of the available memory
+# This is due to Github Issue #307
+if [ `nproc` -gt 8 ]; then
+   sed -i -e "s|totalMemory=2048||g" $ORACLE_BASE/dbca.rsp
+fi;
+
+# Create network related config files (sqlnet.ora, tnsnames.ora, listener.ora)
+mkdir -p $ORACLE_HOME/network/admin
+echo "NAME.DIRECTORY_PATH= (TNSNAMES, EZCONNECT, HOSTNAME)" > $ORACLE_HOME/network/admin/sqlnet.ora
+
+# Listener.ora
+echo "LISTENER = 
+(DESCRIPTION_LIST = 
+  (DESCRIPTION = 
+    (ADDRESS = (PROTOCOL = IPC)(KEY = EXTPROC1)) 
+    (ADDRESS = (PROTOCOL = TCP)(HOST = 0.0.0.0)(PORT = 1521)) 
+  ) 
+) 
+
+DEDICATED_THROUGH_BROKER_LISTENER=ON
+DIAG_ADR_ENABLED = off
+" > $ORACLE_HOME/network/admin/listener.ora
+
+# Start LISTENER and run DBCA
+lsnrctl start &&
+dbca -silent -createDatabase -responseFile $ORACLE_BASE/dbca.rsp ||
+ cat /opt/oracle/cfgtoollogs/dbca/$ORACLE_SID/$ORACLE_SID.log ||
+ cat /opt/oracle/cfgtoollogs/dbca/$ORACLE_SID.log
+
+echo "$ORACLE_SID=localhost:1521/$ORACLE_SID" > $ORACLE_HOME/network/admin/tnsnames.ora
+echo "$ORACLE_PDB= 
+(DESCRIPTION = 
+  (ADDRESS = (PROTOCOL = TCP)(HOST = 0.0.0.0)(PORT = 1521))
+  (CONNECT_DATA =
+    (SERVER = DEDICATED)
+    (SERVICE_NAME = $ORACLE_PDB)
+  )
+)" >> $ORACLE_HOME/network/admin/tnsnames.ora
+
+# Remove second control file, fix local_listener, make PDB auto open
+sqlplus / as sysdba << EOF
+   ALTER SYSTEM SET control_files='$ORACLE_BASE/oradata/$ORACLE_SID/control01.ctl' scope=spfile;
+   ALTER SYSTEM SET local_listener='';
+   ALTER PLUGGABLE DATABASE $ORACLE_PDB SAVE STATE;
+   exit;
+EOF
+
+# Remove temporary response file
+rm $ORACLE_BASE/dbca.rsp

--- a/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/db_inst.rsp
+++ b/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/db_inst.rsp
@@ -1,0 +1,125 @@
+####################################################################
+## Copyright(c) Oracle Corporation 1998,2017. All rights reserved.##
+##                                                                ##
+## Specify values for the variables listed below to customize     ##
+## your installation.                                             ##
+##                                                                ##
+## Each variable is associated with a comment. The comment        ##
+## can help to populate the variables with the appropriate        ##
+## values.                                                        ##
+##                                                                ##
+## IMPORTANT NOTE: This file contains plain text passwords and    ##
+## should be secured to have read permission only by oracle user  ##
+## or db administrator who owns this installation.                ##
+##                                                                ##
+####################################################################
+
+
+#-------------------------------------------------------------------------------
+# Do not change the following system generated value. 
+#-------------------------------------------------------------------------------
+oracle.install.responseFileVersion=/oracle/install/rspfmt_dbinstall_response_schema_v18.0.0
+
+#-------------------------------------------------------------------------------
+# Specify the installation option.
+# It can be one of the following:
+#   - INSTALL_DB_SWONLY
+#   - INSTALL_DB_AND_CONFIG
+#   - UPGRADE_DB
+#-------------------------------------------------------------------------------
+oracle.install.option=INSTALL_DB_SWONLY
+
+#-------------------------------------------------------------------------------
+# Specify the Unix group to be set for the inventory directory.  
+#-------------------------------------------------------------------------------
+UNIX_GROUP_NAME=dba
+
+#-------------------------------------------------------------------------------
+# Specify the location which holds the inventory files.
+# This is an optional parameter if installing on
+# Windows based Operating System.
+#-------------------------------------------------------------------------------
+INVENTORY_LOCATION=###ORACLE_BASE###/oraInventory
+#-------------------------------------------------------------------------------
+# Specify the complete path of the Oracle Home. 
+#-------------------------------------------------------------------------------
+ORACLE_HOME=###ORACLE_HOME###
+
+#-------------------------------------------------------------------------------
+# Specify the complete path of the Oracle Base. 
+#-------------------------------------------------------------------------------
+ORACLE_BASE=###ORACLE_BASE###
+
+#-------------------------------------------------------------------------------
+# Specify the installation edition of the component.                     
+#                                                             
+# The value should contain only one of these choices.  
+#   - EE     : Enterprise Edition 
+#   - SE2    : Standard Edition 2
+#-------------------------------------------------------------------------------
+oracle.install.db.InstallEdition=###ORACLE_EDITION###
+
+###############################################################################
+#                                                                             #
+# PRIVILEGED OPERATING SYSTEM GROUPS                                          #
+# ------------------------------------------                                  #
+# Provide values for the OS groups to which SYSDBA and SYSOPER privileges     #
+# needs to be granted. If the install is being performed as a member of the   #
+# group "dba", then that will be used unless specified otherwise below.       #
+#                                                                             #
+# The value to be specified for OSDBA and OSOPER group is only for UNIX based #
+# Operating System.                                                           #
+#                                                                             #
+###############################################################################
+
+#------------------------------------------------------------------------------
+# The OSDBA_GROUP is the OS group which is to be granted SYSDBA privileges.
+#-------------------------------------------------------------------------------
+oracle.install.db.OSDBA_GROUP=dba
+
+#------------------------------------------------------------------------------
+# The OSOPER_GROUP is the OS group which is to be granted SYSOPER privileges.
+# The value to be specified for OSOPER group is optional.
+#------------------------------------------------------------------------------
+oracle.install.db.OSOPER_GROUP=dba
+
+#------------------------------------------------------------------------------
+# The OSBACKUPDBA_GROUP is the OS group which is to be granted SYSBACKUP privileges.
+#------------------------------------------------------------------------------
+oracle.install.db.OSBACKUPDBA_GROUP=dba
+
+#------------------------------------------------------------------------------
+# The OSDGDBA_GROUP is the OS group which is to be granted SYSDG privileges.
+#------------------------------------------------------------------------------
+oracle.install.db.OSDGDBA_GROUP=dba
+
+#------------------------------------------------------------------------------
+# The OSKMDBA_GROUP is the OS group which is to be granted SYSKM privileges.
+#------------------------------------------------------------------------------
+oracle.install.db.OSKMDBA_GROUP=dba
+
+#------------------------------------------------------------------------------
+# The OSRACDBA_GROUP is the OS group which is to be granted SYSRAC privileges.
+#------------------------------------------------------------------------------
+oracle.install.db.OSRACDBA_GROUP=dba
+
+#------------------------------------------------------------------------------
+# Specify whether to enable the user to set the password for
+# My Oracle Support credentials. The value can be either true or false.
+# If left blank it will be assumed to be false.
+#
+# Example    : SECURITY_UPDATES_VIA_MYORACLESUPPORT=true
+#------------------------------------------------------------------------------
+SECURITY_UPDATES_VIA_MYORACLESUPPORT=false
+
+#------------------------------------------------------------------------------
+# Specify whether user doesn't want to configure Security Updates.
+# The value for this variable should be true if you don't want to configure
+# Security Updates, false otherwise.
+#
+# The value can be either true or false. If left blank it will be assumed
+# to be true.
+#
+# Example    : DECLINE_SECURITY_UPDATES=false
+#------------------------------------------------------------------------------
+DECLINE_SECURITY_UPDATES=true

--- a/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/dbca.rsp.tmpl
+++ b/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/dbca.rsp.tmpl
@@ -1,0 +1,204 @@
+##############################################################################
+##                                                                          ##
+##                            DBCA response file                            ##
+##                            ------------------                            ##
+## Copyright(c) Oracle Corporation 1998,2017. All rights reserved.          ##
+##                                                                          ##
+## Specify values for the variables listed below to customize 			    ##
+## your installation.                                         			    ##
+##                                                            			    ##
+## Each variable is associated with a comment. The comment    			    ##
+## can help to populate the variables with the appropriate   			    ##
+## values.                                                  			    ##
+##                                                               			##
+## IMPORTANT NOTE: This file contains plain text passwords and   			##
+## should be secured to have read permission only by oracle user 			##
+## or db administrator who owns this installation.               			##
+##############################################################################
+#-------------------------------------------------------------------------------
+# Do not change the following system generated value. 
+#-------------------------------------------------------------------------------
+responseFileVersion=/oracle/assistants/rspfmt_dbca_response_schema_v18.0.0
+
+#-----------------------------------------------------------------------------
+# Name          : gdbName
+# Datatype      : String
+# Description   : Global database name of the database
+# Valid values  : <db_name>.<db_domain> - when database domain isn't NULL
+#                 <db_name>             - when database domain is NULL
+# Default value : None
+# Mandatory     : Yes
+#-----------------------------------------------------------------------------
+gdbName=###ORACLE_SID###
+
+#-----------------------------------------------------------------------------
+# Name          : sid
+# Datatype      : String
+# Description   : System identifier (SID) of the database
+# Valid values  : Check Oracle12c Administrator's Guide
+# Default value : <db_name> specified in GDBNAME
+# Mandatory     : No
+#-----------------------------------------------------------------------------
+sid=###ORACLE_SID###
+
+#-----------------------------------------------------------------------------
+# Name          : createAsContainerDatabase 
+# Datatype      : boolean
+# Description   : flag to create database as container database 
+# Valid values  : Check Oracle12c Administrator's Guide
+# Default value : false
+# Mandatory     : No
+#-----------------------------------------------------------------------------
+createAsContainerDatabase=true
+
+#-----------------------------------------------------------------------------
+# Name          : numberOfPDBs
+# Datatype      : Number
+# Description   : Specify the number of pdb to be created
+# Valid values  : 0 to 4094
+# Default value : 0
+# Mandatory     : No
+#-----------------------------------------------------------------------------
+numberOfPDBs=1
+
+#-----------------------------------------------------------------------------
+# Name          : pdbName 
+# Datatype      : String
+# Description   : Specify the pdbname/pdbanme prefix if one or more pdb need to be created
+# Valid values  : Check Oracle12c Administrator's Guide
+# Default value : None
+# Mandatory     : No
+#-----------------------------------------------------------------------------
+pdbName=###ORACLE_PDB###
+
+#-----------------------------------------------------------------------------
+# Name          : pdbAdminPassword
+# Datatype      : String
+# Description   : PDB Administrator user password
+# Valid values  : Check Oracle12c Administrator's Guide
+# Default value : None
+# Mandatory     : No
+#-----------------------------------------------------------------------------
+pdbAdminPassword=###ORACLE_PWD###
+
+#-----------------------------------------------------------------------------
+# Name          : templateName
+# Datatype      : String
+# Description   : Name of the template
+# Valid values  : Template file name
+# Default value : None
+# Mandatory     : Yes
+#-----------------------------------------------------------------------------
+templateName=General_Purpose.dbc
+
+#-----------------------------------------------------------------------------
+# Name          : sysPassword
+# Datatype      : String
+# Description   : Password for SYS user
+# Valid values  : Check Oracle12c Administrator's Guide
+# Default value : None
+# Mandatory     : Yes
+#-----------------------------------------------------------------------------
+sysPassword=###ORACLE_PWD###
+
+#-----------------------------------------------------------------------------
+# Name          : systemPassword
+# Datatype      : String
+# Description   : Password for SYSTEM user
+# Valid values  : Check Oracle12c Administrator's Guide
+# Default value : None
+# Mandatory     : Yes
+#-----------------------------------------------------------------------------
+systemPassword=###ORACLE_PWD###
+
+#-----------------------------------------------------------------------------
+# Name          : emConfiguration
+# Datatype      : String
+# Description   : Enterprise Manager Configuration Type
+# Valid values  : CENTRAL|DBEXPRESS|BOTH|NONE
+# Default value : NONE
+# Mandatory     : No
+#-----------------------------------------------------------------------------
+emConfiguration=DBEXPRESS
+
+#-----------------------------------------------------------------------------
+# Name          : emExpressPort
+# Datatype      : Number
+# Description   : Enterprise Manager Configuration Type
+# Valid values  : Check Oracle12c Administrator's Guide
+# Default value : NONE
+# Mandatory     : No, will be picked up from DBEXPRESS_HTTPS_PORT env variable
+#                 or auto generates a free port between 5500 and 5599
+#-----------------------------------------------------------------------------
+emExpressPort=5500
+
+#-----------------------------------------------------------------------------
+# Name          : dbsnmpPassword
+# Datatype      : String
+# Description   : Password for DBSNMP user
+# Valid values  : Check Oracle12c Administrator's Guide
+# Default value : None
+# Mandatory     : Yes, if emConfiguration is specified or
+#                 the value of runCVUChecks is TRUE
+#-----------------------------------------------------------------------------
+dbsnmpPassword=###ORACLE_PWD###
+
+#-----------------------------------------------------------------------------
+# Name          : characterSet
+# Datatype      : String
+# Description   : Character set of the database
+# Valid values  : Check Oracle12c National Language Support Guide
+# Default value : "US7ASCII"
+# Mandatory     : NO
+#-----------------------------------------------------------------------------
+characterSet=###ORACLE_CHARACTERSET###
+
+#-----------------------------------------------------------------------------
+# Name          : nationalCharacterSet
+# Datatype      : String
+# Description   : National Character set of the database
+# Valid values  : "UTF8" or "AL16UTF16". For details, check Oracle12c National Language Support Guide
+# Default value : "AL16UTF16"
+# Mandatory     : No
+#-----------------------------------------------------------------------------
+nationalCharacterSet=AL16UTF16
+
+#-----------------------------------------------------------------------------
+# Name          : initParams
+# Datatype      : String
+# Description   : comma separated list of name=value pairs. Overrides initialization parameters defined in templates
+# Default value : None
+# Mandatory     : NO
+#-----------------------------------------------------------------------------
+initParams=audit_trail=none,audit_sys_operations=false
+
+#-----------------------------------------------------------------------------
+# Name          : listeners
+# Datatype      : String
+# Description   : Specifies list of listeners to register the database with.
+#		  By default the database is configured for all the listeners specified in the 
+#		  $ORACLE_HOME/network/admin/listener.ora 	
+# Valid values  : The list should be comma separated like "listener1,listener2".
+# Mandatory     : NO
+#-----------------------------------------------------------------------------
+#listeners=LISTENER
+
+#-----------------------------------------------------------------------------
+# Name          : automaticMemoryManagement
+# Datatype      : Boolean
+# Description   : flag to indicate Automatic Memory Management is used
+# Valid values  : TRUE/FALSE
+# Default value : TRUE
+# Mandatory     : NO
+#-----------------------------------------------------------------------------
+automaticMemoryManagement=FALSE
+
+#-----------------------------------------------------------------------------
+# Name          : totalMemory
+# Datatype      : String
+# Description   : total memory in MB to allocate to Oracle
+# Valid values  : 
+# Default value : 
+# Mandatory     : NO
+#-----------------------------------------------------------------------------
+totalMemory=2048

--- a/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/installDBBinaries.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/installDBBinaries.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# LICENSE UPL 1.0
+#
+# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+#
+# Since: December, 2016
+# Author: gerald.venzl@oracle.com
+# Description: Sets up the unix environment for DB installation.
+# 
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# 
+
+# Convert $1 into upper case via "^^" (bash version 4 onwards)
+EDITION=${1^^}
+
+# Check whether edition has been passed on
+if [ "$EDITION" == "" ]; then
+   echo "ERROR: No edition has been passed on!"
+   echo "Please specify the correct edition!"
+   exit 1;
+fi;
+
+# Check whether correct edition has been passed on
+if [ "$EDITION" != "EE" -a "$EDITION" != "SE2" ]; then
+   echo "ERROR: Wrong edition has been passed on!"
+   echo "Edition $EDITION is no a valid edition!"
+   exit 1;
+fi;
+
+# Check whether ORACLE_BASE is set
+if [ "$ORACLE_BASE" == "" ]; then
+   echo "ERROR: ORACLE_BASE has not been set!"
+   echo "You have to have the ORACLE_BASE environment variable set to a valid value!"
+   exit 1;
+fi;
+
+# Check whether ORACLE_HOME is set
+if [ "$ORACLE_HOME" == "" ]; then
+   echo "ERROR: ORACLE_HOME has not been set!"
+   echo "You have to have the ORACLE_HOME environment variable set to a valid value!"
+   exit 1;
+fi;
+
+
+# Replace place holders
+# ---------------------
+sed -i -e "s|###ORACLE_EDITION###|$EDITION|g" $INSTALL_DIR/$INSTALL_RSP && \
+sed -i -e "s|###ORACLE_BASE###|$ORACLE_BASE|g" $INSTALL_DIR/$INSTALL_RSP && \
+sed -i -e "s|###ORACLE_HOME###|$ORACLE_HOME|g" $INSTALL_DIR/$INSTALL_RSP
+
+# Install Oracle binaries
+cd $ORACLE_HOME       && \
+mv $INSTALL_DIR/$INSTALL_FILE_1 $ORACLE_HOME/ && \
+unzip $INSTALL_FILE_1 && \
+rm $INSTALL_FILE_1    && \
+$ORACLE_HOME/runInstaller -silent -force -waitforcompletion -responsefile $INSTALL_DIR/$INSTALL_RSP -ignorePrereqFailure && \
+cd $HOME
+
+# Remove not needed components
+# APEX
+rm -rf $ORACLE_HOME/apex && \
+# ORDS
+rm -rf $ORACLE_HOME/ords && \
+# SQL Developer
+rm -rf $ORACLE_HOME/sqldeveloper && \
+# UCP connection pool
+rm -rf $ORACLE_HOME/ucp && \
+# All installer files
+rm -rf $ORACLE_HOME/lib/*.zip && \
+# OUI backup
+rm -rf $ORACLE_HOME/inventory/backup/* && \
+# Network tools help
+rm -rf $ORACLE_HOME/network/tools/help && \
+# Database upgrade assistant
+rm -rf $ORACLE_HOME/assistants/dbua && \
+# Database migration assistant
+rm -rf $ORACLE_HOME/dmu && \
+# Remove pilot workflow installer
+rm -rf $ORACLE_HOME/install/pilot && \
+# Support tools
+rm -rf $ORACLE_HOME/suptools && \
+# Temp location
+rm -rf /tmp/* && \
+# Database files directory
+rm -rf $INSTALL_DIR/database

--- a/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/runOracle.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+# LICENSE UPL 1.0
+#
+# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+# 
+# Since: November, 2016
+# Author: gerald.venzl@oracle.com
+# Description: Runs the Oracle Database inside the container
+# 
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# 
+
+########### Move DB files ############
+function moveFiles {
+
+   if [ ! -d $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID ]; then
+      mkdir -p $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/
+   fi;
+
+   mv $ORACLE_HOME/dbs/spfile$ORACLE_SID.ora $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/
+   mv $ORACLE_HOME/dbs/orapw$ORACLE_SID $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/
+   mv $ORACLE_HOME/network/admin/sqlnet.ora $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/
+   mv $ORACLE_HOME/network/admin/listener.ora $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/
+   mv $ORACLE_HOME/network/admin/tnsnames.ora $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/
+
+   # oracle user does not have permissions in /etc, hence cp and not mv
+   cp /etc/oratab $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/
+   
+   symLinkFiles;
+}
+
+########### Symbolic link DB files ############
+function symLinkFiles {
+
+   if [ ! -L $ORACLE_HOME/dbs/spfile$ORACLE_SID.ora ]; then
+      ln -s $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/spfile$ORACLE_SID.ora $ORACLE_HOME/dbs/spfile$ORACLE_SID.ora
+   fi;
+   
+   if [ ! -L $ORACLE_HOME/dbs/orapw$ORACLE_SID ]; then
+      ln -s $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/orapw$ORACLE_SID $ORACLE_HOME/dbs/orapw$ORACLE_SID
+   fi;
+   
+   if [ ! -L $ORACLE_HOME/network/admin/sqlnet.ora ]; then
+      ln -s $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/sqlnet.ora $ORACLE_HOME/network/admin/sqlnet.ora
+   fi;
+
+   if [ ! -L $ORACLE_HOME/network/admin/listener.ora ]; then
+      ln -s $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/listener.ora $ORACLE_HOME/network/admin/listener.ora
+   fi;
+
+   if [ ! -L $ORACLE_HOME/network/admin/tnsnames.ora ]; then
+      ln -s $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/tnsnames.ora $ORACLE_HOME/network/admin/tnsnames.ora
+   fi;
+
+   # oracle user does not have permissions in /etc, hence cp and not ln 
+   cp $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/oratab /etc/oratab
+
+}
+
+########### SIGINT handler ############
+function _int() {
+   echo "Stopping container."
+   echo "SIGINT received, shutting down database!"
+   sqlplus / as sysdba <<EOF
+   shutdown immediate;
+   exit;
+EOF
+   lsnrctl stop
+}
+
+########### SIGTERM handler ############
+function _term() {
+   echo "Stopping container."
+   echo "SIGTERM received, shutting down database!"
+   sqlplus / as sysdba <<EOF
+   shutdown immediate;
+   exit;
+EOF
+   lsnrctl stop
+}
+
+########### SIGKILL handler ############
+function _kill() {
+   echo "SIGKILL received, shutting down database!"
+   sqlplus / as sysdba <<EOF
+   shutdown abort;
+   exit;
+EOF
+   lsnrctl stop
+}
+
+###################################
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! #
+############# MAIN ################
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! #
+###################################
+
+# Check whether container has enough memory
+# Github issue #219: Prevent integer overflow,
+# only check if memory digits are less than 11 (single GB range and below) 
+if [ `cat /sys/fs/cgroup/memory/memory.limit_in_bytes | wc -c` -lt 11 ]; then
+   if [ `cat /sys/fs/cgroup/memory/memory.limit_in_bytes` -lt 2147483648 ]; then
+      echo "Error: The container doesn't have enough memory allocated."
+      echo "A database container needs at least 2 GB of memory."
+      echo "You currently only have $((`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`/1024/1024/1024)) GB allocated to the container."
+      exit 1;
+   fi;
+fi;
+
+# Check that hostname doesn't container any "_"
+# Github issue #711
+if hostname | grep -q "_"; then
+   echo "Error: The hostname must not container any '_'".
+   echo "Your current hostname is '$(hostname)'"
+fi;
+
+# Set SIGINT handler
+trap _int SIGINT
+
+# Set SIGTERM handler
+trap _term SIGTERM
+
+# Set SIGKILL handler
+trap _kill SIGKILL
+
+# Default for ORACLE SID
+if [ "$ORACLE_SID" == "" ]; then
+   export ORACLE_SID=ORCLCDB
+else
+  # Make ORACLE_SID upper case
+  # Github issue # 984
+  export ORACLE_SID=${ORACLE_SID^^}
+
+  # Check whether SID is no longer than 12 bytes
+  # Github issue #246: Cannot start OracleDB image
+  if [ "${#ORACLE_SID}" -gt 12 ]; then
+     echo "Error: The ORACLE_SID must only be up to 12 characters long."
+     exit 1;
+  fi;
+
+  # Check whether SID is alphanumeric
+  # Github issue #246: Cannot start OracleDB image
+  if [[ "$ORACLE_SID" =~ [^a-zA-Z0-9] ]]; then
+     echo "Error: The ORACLE_SID must be alphanumeric."
+     exit 1;
+   fi;
+fi;
+
+# Default for ORACLE PDB
+export ORACLE_PDB=${ORACLE_PDB:-ORCLPDB1}
+
+# Make ORACLE_PDB upper case
+# Github issue # 984
+export ORACLE_PDB=${ORACLE_PDB^^}
+
+# Default for ORACLE CHARACTERSET
+export ORACLE_CHARACTERSET=${ORACLE_CHARACTERSET:-AL32UTF8}
+
+# Check whether database already exists
+if [ -d $ORACLE_BASE/oradata/$ORACLE_SID ]; then
+   symLinkFiles;
+   
+   # Make sure audit file destination exists
+   if [ ! -d $ORACLE_BASE/admin/$ORACLE_SID/adump ]; then
+      mkdir -p $ORACLE_BASE/admin/$ORACLE_SID/adump
+   fi;
+   
+   # Start database
+   $ORACLE_BASE/$START_FILE;
+   
+else
+  # Remove database config files, if they exist
+  rm -f $ORACLE_HOME/dbs/spfile$ORACLE_SID.ora
+  rm -f $ORACLE_HOME/dbs/orapw$ORACLE_SID
+  rm -f $ORACLE_HOME/network/admin/sqlnet.ora
+  rm -f $ORACLE_HOME/network/admin/listener.ora
+  rm -f $ORACLE_HOME/network/admin/tnsnames.ora
+   
+  # Create database
+  $ORACLE_BASE/$CREATE_DB_FILE $ORACLE_SID $ORACLE_PDB $ORACLE_PWD;
+   
+  # Move database operational files to oradata
+  moveFiles;
+   
+  # Execute custom provided setup scripts
+  $ORACLE_BASE/$USER_SCRIPTS_FILE $ORACLE_BASE/scripts/setup
+fi;
+
+# Check whether database is up and running
+$ORACLE_BASE/$CHECK_DB_FILE
+if [ $? -eq 0 ]; then
+  echo "#########################"
+  echo "DATABASE IS READY TO USE!"
+  echo "#########################"
+  
+  # Execute custom provided startup scripts
+  $ORACLE_BASE/$USER_SCRIPTS_FILE $ORACLE_BASE/scripts/startup
+  
+else
+  echo "#####################################"
+  echo "########### E R R O R ###############"
+  echo "DATABASE SETUP WAS NOT SUCCESSFUL!"
+  echo "Please check output for further info!"
+  echo "########### E R R O R ###############" 
+  echo "#####################################"
+fi;
+
+# Tail on alert log and wait (otherwise container will exit)
+echo "The following output is now a tail of the alert.log:"
+tail -f $ORACLE_BASE/diag/rdbms/*/*/trace/alert*.log &
+childPID=$!
+wait $childPID

--- a/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/runUserScripts.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/runUserScripts.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# LICENSE UPL 1.0
+#
+# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+#
+# Since: July, 2017
+# Author: gerald.venzl@oracle.com
+# Description: Runs user shell and SQL scripts
+# 
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# 
+
+SCRIPTS_ROOT="$1";
+
+# Check whether parameter has been passed on
+if [ -z "$SCRIPTS_ROOT" ]; then
+   echo "$0: No SCRIPTS_ROOT passed on, no scripts will be run";
+   exit 1;
+fi;
+
+# Execute custom provided files (only if directory exists and has files in it)
+if [ -d "$SCRIPTS_ROOT" ] && [ -n "$(ls -A $SCRIPTS_ROOT)" ]; then
+
+  echo "";
+  echo "Executing user defined scripts"
+
+  for f in $SCRIPTS_ROOT/*; do
+      case "$f" in
+          *.sh)     echo "$0: running $f"; . "$f" ;;
+          *.sql)    echo "$0: running $f"; echo "exit" | $ORACLE_HOME/bin/sqlplus -s "/ as sysdba" @"$f"; echo ;;
+          *)        echo "$0: ignoring $f" ;;
+      esac
+      echo "";
+  done
+  
+  echo "DONE: Executing user defined scripts"
+  echo "";
+
+fi;

--- a/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/setPassword.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/setPassword.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# LICENSE UPL 1.0
+#
+# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+# 
+# Since: November, 2016
+# Author: gerald.venzl@oracle.com
+# Description: Sets the password for sys, system and pdb_admin
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# 
+
+ORACLE_PWD=$1
+ORACLE_SID="`grep $ORACLE_HOME /etc/oratab | cut -d: -f1`"
+ORACLE_PDB="`ls -dl $ORACLE_BASE/oradata/$ORACLE_SID/*/ | grep -v pdbseed | awk '{print $9}' | cut -d/ -f6`"
+ORAENV_ASK=NO
+source oraenv
+
+sqlplus / as sysdba << EOF
+      ALTER USER SYS IDENTIFIED BY "$ORACLE_PWD";
+      ALTER USER SYSTEM IDENTIFIED BY "$ORACLE_PWD";
+      ALTER SESSION SET CONTAINER=$ORACLE_PDB;
+      ALTER USER PDBADMIN IDENTIFIED BY "$ORACLE_PWD";
+      exit;
+EOF
+

--- a/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/setupLinuxEnv.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/setupLinuxEnv.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# LICENSE UPL 1.0
+#
+# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+#
+# Since: December, 2016
+# Author: gerald.venzl@oracle.com
+# Description: Sets up the unix environment for DB installation.
+# 
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# 
+
+# Setup filesystem and oracle user
+# Adjust file permissions, go to /opt/oracle as user 'oracle' to proceed with Oracle installation
+# ------------------------------------------------------------
+mkdir -p $ORACLE_BASE/scripts/setup && \
+mkdir $ORACLE_BASE/scripts/startup && \
+ln -s $ORACLE_BASE/scripts /docker-entrypoint-initdb.d && \
+mkdir $ORACLE_BASE/oradata && \
+mkdir -p $ORACLE_HOME && \
+chmod ug+x $ORACLE_BASE/*.sh && \
+yum -y install oracle-database-preinstall-18c openssl && \
+rm -rf /var/cache/yum && \
+ln -s $ORACLE_BASE/$PWD_FILE /home/oracle/ && \
+echo oracle:oracle | chpasswd && \
+chown -R oracle:dba $ORACLE_BASE

--- a/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/startDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/goldimage_based_docker/startDB.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# LICENSE UPL 1.0
+#
+# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+#
+# Since: November, 2016
+# Author: gerald.venzl@oracle.com
+# Description: Starts the Listener and Oracle Database.
+#              The ORACLE_HOME and the PATH has to be set.
+# 
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# 
+
+# Check that ORACLE_HOME is set
+if [ "$ORACLE_HOME" == "" ]; then
+  script_name=`basename "$0"`
+  echo "$script_name: ERROR - ORACLE_HOME is not set. Please set ORACLE_HOME and PATH before invoking this script."
+  exit 1;
+fi;
+
+# Start Listener
+lsnrctl start
+
+# Start database
+sqlplus / as sysdba << EOF
+   STARTUP;
+   exit;
+EOF


### PR DESCRIPTION
The following things have been done as part of this issue:

1. Modified buildDockerImage.sh to accept a new parameter for goldimage name. This provides the user to provide a custom goldimage (which is useful for internal teams at Oracle) instead of being restricted to the one present on OTN.

2. Created a folder goldimage_based_docker which has all files copied from folder 18.3.0 under dockerfiles.

3. Modified the Dockerfile in this newly created folder to accept 2 arguments: major base release version and goldimage name.

4. Modified buildDockerImage.sh to change directory to 'goldimage_based_docker' for versions starting from 18c.