### PR TITLE
Correct checkDBStatus during configuration

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/18.4.0/checkDBStatus.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/18.4.0/checkDBStatus.sh
@@ -10,12 +10,14 @@
 #               1 = PDB is not open
 #               2 = Sql Plus execution failed
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-# 
+#
 
 ORACLE_SID="`grep $ORACLE_HOME /etc/oratab | cut -d: -f1`"
 OPEN_MODE="READ WRITE"
 ORAENV_ASK=NO
 source oraenv
+
+[ -f "$ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/oratab" ] || exit 1;
 
 # Check Oracle at least one PDB has open_mode "READ WRITE" and store it in status
 status=`su -p oracle -c "sqlplus -s / as sysdba" << EOF


### PR DESCRIPTION
The checkDBStatus is returning a 0 at the start of the initial configuration of the database 18.4.0-xe. Because of this, the docker healthcheck parameter '--start-period' has no effect.

I added a check for the file "oratab" in the data volume. This file is created at the end of the configuration. So during the configuration, the check always returns a 1 and after the configuration, the sqlplus command does the real health check.

This pull request only changed the check for the database version 18.4.0. In case this change is also valid for other versions, then copy it there too.

Regards,
Vincent