### PR TITLE
Apr 2019 Java SE CPU

### DIFF
--- a/OracleJava/README.md
+++ b/OracleJava/README.md
@@ -2,7 +2,7 @@ Oracle Java on Docker
 =====
 This repository contains a sample Docker configuration to facilitate installation and environment setup for DevOps users. This project includes a Dockerfile for Server JRE 8 based on Oracle Linux.
 
-Oracle Java Server JRE provides the features from Oracle Java JDK commonly required for Server-side Applications (i.e. Java EE application servers). For more information about Server JRE, visit the [Understanding the Server JRE](https://blogs.oracle.com/java-platform-group/understanding-the-server-jre) blog entry from the Java Product Management team.
+Oracle Java Server JRE provides the features from Oracle Java JDK commonly required for server-side applications (i.e. Running a Java EE application server). For more information about Server JRE, visit the [Understanding the Server JRE blog entry](https://blogs.oracle.com/java-platform-group/understanding-the-server-jre) from the Java Product Management team.
 
 ## Building the Java 8 (Server JRE) base image
 [Download Server JRE 8](http://www.oracle.com/technetwork/java/javase/downloads/server-jre8-downloads-2133154.html) `.tar.gz` file and drop it inside the folder `../OracleJava/java-8`.

--- a/OracleJava/README.md
+++ b/OracleJava/README.md
@@ -17,7 +17,7 @@ $ docker build -t oracle/serverjre:8 .
 ## License
 To download and run the Oracle JDK, regardless of inside or outside a Docker container, you must download the binary from the Oracle website and accept the license indicated on that page.
 
-All scripts and files hosted in this project and GitHub [`docker/OracleWebLogic`](./) repository, required to build the Docker images are, unless otherwise noted, released under the [UPL 1.0](https://oss.oracle.com/licenses/upl/) license.
+All scripts and files hosted in this project and GitHub [`docker/OracleJava`](./) repository, required to build the Docker images are, unless otherwise noted, released under the [UPL 1.0](https://oss.oracle.com/licenses/upl/) license.
 
 ## Customer Support
 We support JDK 8 (Server JRE) in certified Docker container. For additional details on the JDK 8 Certified System Configurations, please refer to the [Oracle Java SE Certified System Configuration Pages](https://www.oracle.com/technetwork/java/javaseproducts/documentation/index.html#sysconfig).

--- a/OracleJava/README.md
+++ b/OracleJava/README.md
@@ -20,4 +20,4 @@ To download and run the Oracle JDK, regardless of inside or outside a Docker con
 All scripts and files hosted in this project and GitHub [`docker/OracleJava`](./) repository, required to build the Docker images are, unless otherwise noted, released under the [UPL 1.0](https://oss.oracle.com/licenses/upl/) license.
 
 ## Customer Support
-We support JDK 8 (Server JRE) in certified Docker container. For additional details on the JDK 8 Certified System Configurations, please refer to the [Oracle Java SE Certified System Configuration Pages](https://www.oracle.com/technetwork/java/javaseproducts/documentation/index.html#sysconfig).
+We support JDK 8 (Server JRE) when running on certified operating systems in a Docker container. For additional details on the JDK 8 Certified System Configurations, please refer to the [Oracle Java SE Certified System Configuration Pages](https://www.oracle.com/technetwork/java/javaseproducts/documentation/index.html#sysconfig).

--- a/OracleJava/README.md
+++ b/OracleJava/README.md
@@ -1,14 +1,23 @@
 Oracle Java on Docker
 =====
-Build a Docker image containing Oracle Java (Server JRE specifically).
+This repository contains a sample Docker configuration to facilitate installation and environment setup for DevOps users. This project includes a Dockerfile for Server JRE 8 based on Oracle Linux.
 
-The Oracle Java Server JRE provides the same features as Oracle Java JDK commonly required for Server-side Applications (i.e. Java EE application servers). For more information about Server JRE, visit the [Understanding the Server JRE](https://blogs.oracle.com/java-platform-group/understanding-the-server-jre) blog entry from the Java Product Management team.
+Oracle Java Server JRE provides the features from Oracle Java JDK commonly required for Server-side Applications (i.e. Java EE application servers). For more information about Server JRE, visit the [Understanding the Server JRE](https://blogs.oracle.com/java-platform-group/understanding-the-server-jre) blog entry from the Java Product Management team.
 
-## Java 8
-[Download Server JRE 8](http://www.oracle.com/technetwork/java/javase/downloads/server-jre8-downloads-2133154.html) `.tar.gz` file and drop it inside folder `java-8`. 
-Build it:
+## Building the Java 8 (Server JRE) base image
+[Download Server JRE 8](http://www.oracle.com/technetwork/java/javase/downloads/server-jre8-downloads-2133154.html) `.tar.gz` file and drop it inside the folder `../OracleJava/java-8`.
+
+Build it using:
 
 ```
-$ cd java-8
+$ cd ../OracleJava/java-8
 $ docker build -t oracle/serverjre:8 .
 ```
+
+## License
+To download and run the Oracle JDK, regardless of inside or outside a Docker container, you must download the binary from the Oracle website and accept the license indicated on that page.
+
+All scripts and files hosted in this project and GitHub [`docker/OracleWebLogic`](./) repository, required to build the Docker images are, unless otherwise noted, released under the [UPL 1.0](https://oss.oracle.com/licenses/upl/) license.
+
+## Customer Support
+We support JDK 8 (Server JRE) in certified Docker container. For additional details on the JDK 8 Certified System Configurations, please refer to the [Oracle Java SE Certified System Configuration Pages](https://www.oracle.com/technetwork/java/javaseproducts/documentation/index.html#sysconfig).

--- a/OracleJava/java-8/server-jre-8u211-linux-x64.tar.gz.download
+++ b/OracleJava/java-8/server-jre-8u211-linux-x64.tar.gz.download
@@ -2,4 +2,4 @@
 #
 #  - http://www.oracle.com/technetwork/java/javase/downloads/server-jre8-downloads-2133154.html
 #
-0da7f9cfe63daf41e84783825efee26d0e4e7c2130e2d7a651002d3c94078b8d  server-jre-8u201-linux-x64.tar.gz
+97a5c3f10678d309a60ab0b17be0d637adb9fa4131050da0736bf2214d521d2d  server-jre-8u211-linux-x64.tar.gz


### PR DESCRIPTION
Updated the files to point to the Apr 2019 CPU so 8u201->8u211

Added some text to the directories README file clarifying the licenses (the JDK has its own licenses on Oracle's download sites, the dockerfiles on this project under UPL), and clarified what a supported image is. 