### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,10 +6,10 @@
 /NoSQL/                   @anandchandak
 /OpenJDK/                 @aureliogrb
 /OracleBI/                @sjvp
-/OracleCloudInfrastructure/ @Djelibeybi @gvenzl @mriccell
 /OracleCoherence/         @thegridman
 /OracleDataIntegrator/    @mavaishn
 /OracleDatabase/SingleInstance/          @gvenzl
+/OracleDatabase/RAC/      @psaini79
 /OracleEDQ/               @subhashsutrave
 /OracleFMWInfrastructure/ @mriccell
 /OracleGoldenGate/        @sbalousek


### PR DESCRIPTION
This removes a redundant entry and sets @psaini79 as the owner of the RAC content.

Signed-off-by: Avi Miller <avi.miller@oracle.com>