### PR TITLE
Adding configuration for the Work-In-Progress Probot

### DIFF
--- a/.github/wip.yml
+++ b/.github/wip.yml
@@ -1,0 +1,8 @@
+locations:
+  - title
+  - label_name
+  - commit_subject
+terms:
+  - wip
+  - do not merge
+  - work in progress


### PR DESCRIPTION
Enables the WIP Probot that prevents merges for PRs that have "WIP" in their title.

Signed-off-by: Avi Miller <avi.miller@oracle.com>