### PR TITLE
Update for Instant Client 18.5 release

### DIFF
--- a/OracleInstantClient/dockerfiles/18/Dockerfile
+++ b/OracleInstantClient/dockerfiles/18/Dockerfile
@@ -16,13 +16,12 @@
 #
 FROM oraclelinux:7-slim
 
-RUN  curl -o /etc/yum.repos.d/public-yum-ol7.repo https://yum.oracle.com/public-yum-ol7.repo && \
-     yum-config-manager --enable ol7_oracle_instantclient && \
-     yum -y install oracle-instantclient18.3-basic oracle-instantclient18.3-devel oracle-instantclient18.3-sqlplus && \
+RUN  yum-config-manager --enable ol7_oracle_instantclient && \
+     yum -y install oracle-instantclient18.5-basic oracle-instantclient18.5-devel oracle-instantclient18.5-sqlplus && \
      rm -rf /var/cache/yum && \
-     echo /usr/lib/oracle/18.3/client64/lib > /etc/ld.so.conf.d/oracle-instantclient18.3.conf && \
+     echo /usr/lib/oracle/18.5/client64/lib > /etc/ld.so.conf.d/oracle-instantclient18.5.conf && \
      ldconfig
 
-ENV PATH=$PATH:/usr/lib/oracle/18.3/client64/bin
+ENV PATH=$PATH:/usr/lib/oracle/18.5/client64/bin
 
 CMD ["sqlplus", "-v"]

--- a/OracleInstantClient/dockerfiles/18/Dockerfile
+++ b/OracleInstantClient/dockerfiles/18/Dockerfile
@@ -1,6 +1,6 @@
 # LICENSE UPL 1.0
 #
-# Copyright (c) 2014-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
 #
 # ORACLE DOCKERFILES PROJECT
 # --------------------------
@@ -11,7 +11,7 @@
 # -----------------------
 #
 # Run:
-#      $ docker build -t oracle/instantclient:18.3.0 .
+#      $ docker build -t oracle/instantclient:18 .
 #
 #
 FROM oraclelinux:7-slim

--- a/OracleInstantClient/dockerfiles/18/Dockerfile
+++ b/OracleInstantClient/dockerfiles/18/Dockerfile
@@ -16,12 +16,15 @@
 #
 FROM oraclelinux:7-slim
 
+ARG release=18
+ARG update=5
+
 RUN  yum-config-manager --enable ol7_oracle_instantclient && \
-     yum -y install oracle-instantclient18.5-basic oracle-instantclient18.5-devel oracle-instantclient18.5-sqlplus && \
+     yum -y install oracle-instantclient${release}.${update}-basic oracle-instantclient${release}.${update}-devel oracle-instantclient${release}.${update}-sqlplus && \
      rm -rf /var/cache/yum && \
-     echo /usr/lib/oracle/18.5/client64/lib > /etc/ld.so.conf.d/oracle-instantclient18.5.conf && \
+     echo /usr/lib/oracle/${release}.${update}/client64/lib > /etc/ld.so.conf.d/oracle-instantclient${release}.${update}.conf && \
      ldconfig
 
-ENV PATH=$PATH:/usr/lib/oracle/18.5/client64/bin
+ENV PATH=$PATH:/usr/lib/oracle/${release}.${update}/client64/bin
 
 CMD ["sqlplus", "-v"]


### PR DESCRIPTION
- Update for Instant Client 18.5 release

- Use just the major version to make future upgrades easier.

- Parameterize the version number