### PR TITLE
Correct typo in FMWInfrastructure README.md, correct createRCU.sh pro…

### DIFF
--- a/OracleFMWInfrastructure/dockerfiles/12.2.1.3/README.md
+++ b/OracleFMWInfrastructure/dockerfiles/12.2.1.3/README.md
@@ -42,7 +42,7 @@ You can also pull the Oracle Server JRE 8 image from the [Oracle Container Regis
 #### Providing the Administration Server user name and password and Database username and password
 The user name and password must be supplied in a `./dockerfiles/12.2.1.3/properties/domain_security.properties` file located in a HOST directory that you will map at Docker runtime with the `-v` option to the image directory `/u01/oracle/properties`. The properties file enables the scripts to configure the correct authentication for the WebLogic Administration Server and Database.
 
-The format of the `domain.properties` file is key=value pair:
+The format of the `domain_security.properties` file is key=value pair:
 
         username=myusername
         password=welcome1

--- a/OracleFMWInfrastructure/samples/12213-domain-in-volume/container-scripts/createRCU.sh
+++ b/OracleFMWInfrastructure/samples/12213-domain-in-volume/container-scripts/createRCU.sh
@@ -53,7 +53,7 @@ if [ -z "$RCUPREFIX" ]; then
 fi
 # echo "RCU Prefix: $RCUPREFIX"
 # Get Database Connection String 
-CONNECTION_STRING_=`awk '{print $1}' $PROPERTIES_FILE | grep CONNECTION_STRING | cut -d "=" -f2`
+CONNECTION_STRING=`awk '{print $1}' $PROPERTIES_FILE | grep CONNECTION_STRING | cut -d "=" -f2`
 if [ -z "$CONNECTION_STRING" ]; then
    echo "The Connection String is blank.  The Connection String must be set in the properties file."
    exit

--- a/OracleWebLogic/samples/1213-domain/container-scripts/createServer.sh
+++ b/OracleWebLogic/samples/1213-domain/container-scripts/createServer.sh
@@ -15,7 +15,7 @@ fi
 
 # Start Node Manager
 echo "Starting NodeManager in background..."
-nohup startNodeManager.sh > log.nm 2>&1 &
+nohup /u01/oracle/user_projects/domains/base_domain/bin/startNodeManager.sh > log.nm 2>&1 &
 echo "NodeManager started."
 
 # Add this 'Machine' and 'ManagedServer' to the AdminServer only if 1st execution


### PR DESCRIPTION
1) Correct  CONNECTION_STRING property n OracleFMWInfra sample 12213-domain-in-volume #1268 2) Correct OracleWebLogic 1213-domain sample to fix issue #1113
3) Correct name of property file in OracleFMWInfrastructure/dockerfile/12.2.1.3 README