### PR TITLE
Ensure the channel is available

### DIFF
--- a/OracleInstantClient/dockerfiles/18/Dockerfile
+++ b/OracleInstantClient/dockerfiles/18/Dockerfile
@@ -19,7 +19,7 @@ FROM oraclelinux:7-slim
 ARG release=18
 ARG update=5
 
-RUN  yum-config-manager --enable ol7_oracle_instantclient && \
+RUN  yum -y install oracle-release-el7 && yum-config-manager --enable ol7_oracle_instantclient && \
      yum -y install oracle-instantclient${release}.${update}-basic oracle-instantclient${release}.${update}-devel oracle-instantclient${release}.${update}-sqlplus && \
      rm -rf /var/cache/yum && \
      echo /usr/lib/oracle/${release}.${update}/client64/lib > /etc/ld.so.conf.d/oracle-instantclient${release}.${update}.conf && \

--- a/OracleInstantClient/dockerfiles/19/Dockerfile
+++ b/OracleInstantClient/dockerfiles/19/Dockerfile
@@ -21,7 +21,7 @@ FROM oraclelinux:7-slim
 ARG release=19
 ARG update=3
 
-RUN  yum-config-manager --enable ol7_oracle_instantclient && \
+RUN  yum -y install oracle-release-el7 && yum-config-manager --enable ol7_oracle_instantclient && \
      yum -y install oracle-instantclient${release}.${update}-basic oracle-instantclient${release}.${update}-devel oracle-instantclient${release}.${update}-sqlplus && \
      rm -rf /var/cache/yum
 


### PR DESCRIPTION
Fix for modular repo files.

Note although the IC channel is enabled by default with oracle-release-el7, the explicit `--enable` is retained to help users without modular repo files.