### PR TITLE
OWLS-72196 set the worker module as the default MPM module

### DIFF
--- a/OracleWebLogic/samples/12213-webtier-apache/Dockerfile
+++ b/OracleWebLogic/samples/12213-webtier-apache/Dockerfile
@@ -1,6 +1,6 @@
 # Example of Apache HTTP Server with WebLogic plugin for load balancing WebLogic on Docker Containers
 #
-# Copyright (c) 2016-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016-2019 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 #
@@ -40,6 +40,8 @@ COPY weblogic.conf /etc/httpd/conf.d/
 COPY custom_mod_wl_apache.conf.sample /config/custom_mod_wl_apache.conf
 COPY custom_mod_wl_apache.conf.sample /configtmp/custom_mod_wl_apache.conf
 COPY custom_mod_ssl_apache.conf.sample /configtmp/custom_mod_ssl_apache.conf
+COPY custom_mod_mpm.conf.sample /etc/httpd/conf.modules.d/00-mpm.conf
+COPY custom_mod_cgi.conf.sample /etc/httpd/conf.modules.d/01-cgi.conf
 COPY container-scripts/* /u01/oracle/container-scripts/
 
 # Use unzip because the base image does not contain a JDK

--- a/OracleWebLogic/samples/12213-webtier-apache/custom_mod_cgi.conf.sample
+++ b/OracleWebLogic/samples/12213-webtier-apache/custom_mod_cgi.conf.sample
@@ -1,0 +1,28 @@
+# This configuration file loads a CGI module appropriate to the MPM
+# which has been configured in 00-mpm.conf.  mod_cgid should be used
+# with a threaded MPM; mod_cgi with the prefork MPM.
+
+<IfModule mpm_worker_module>
+   StartServers 2
+   MaxClients 5000
+   MinSpareThreads 100
+   MaxSpareThreads 400
+   ServerLimit 200
+   ThreadsPerChild 27
+   MaxRequestsPerChild 0
+   LoadModule cgid_module modules/mod_cgid.so
+</IfModule>
+<IfModule mpm_event_module>
+   StartServers 2
+   MaxClients 5000
+   MinSpareThreads 100
+   MaxSpareThreads 400
+   ServerLimit 200
+   ThreadsPerChild 27
+   MaxRequestsPerChild 0
+   LoadModule cgid_module modules/mod_cgid.so
+</IfModule>
+<IfModule mpm_prefork_module>
+   LoadModule cgi_module modules/mod_cgi.so
+</IfModule>
+

--- a/OracleWebLogic/samples/12213-webtier-apache/custom_mod_mpm.conf.sample
+++ b/OracleWebLogic/samples/12213-webtier-apache/custom_mod_mpm.conf.sample
@@ -1,0 +1,19 @@
+# Select the MPM module which should be used by uncommenting exactly
+# one of the following LoadModule lines:
+
+# prefork MPM: Implements a non-threaded, pre-forking web server
+# See: http://httpd.apache.org/docs/2.4/mod/prefork.html
+#LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
+
+# worker MPM: Multi-Processing Module implementing a hybrid
+# multi-threaded multi-process web server
+# See: http://httpd.apache.org/docs/2.4/mod/worker.html
+#
+LoadModule mpm_worker_module modules/mod_mpm_worker.so
+
+# event MPM: A variant of the worker MPM with the goal of consuming
+# threads only for connections with active processing
+# See: http://httpd.apache.org/docs/2.4/mod/event.html
+#
+#LoadModule mpm_event_module modules/mod_mpm_event.so
+


### PR DESCRIPTION
The change set the worker MPM module by default instead of prefork MPM. This is a potential fix for the related BUG 29362431.

Edited to remove internal bug reference.