### PR TITLE
Must use Oracle Linux yum server release package

### DIFF
--- a/OracleCloudInfrastructure/terraform-oci/Dockerfile
+++ b/OracleCloudInfrastructure/terraform-oci/Dockerfile
@@ -3,7 +3,7 @@ FROM oraclelinux:7-slim
 ARG TERRAFORM_VERSION
 ARG OCI_PROVIDER_VERSION
 
-RUN yum-config-manager --enable ol7_developer \
+RUN yum -y install oraclelinux-developer-release-el7 \
    && yum -y install terraform${TERRAFORM_VERSION} terraform-provider-oci${OCI_PROVIDER_VERSION} \
    && rm -rf /var/cache/yum/*
 


### PR DESCRIPTION
To access ol7_developer repo, must install oraclelinux-developer-release-el7 first.