### PR TITLE
rand_pwd should only echo password and not INFO:

### DIFF
--- a/OracleSOASuite/dockerfiles/12.2.1.3/container-scripts/createDomainAndStart.sh
+++ b/OracleSOASuite/dockerfiles/12.2.1.3/container-scripts/createDomainAndStart.sh
@@ -44,7 +44,7 @@ function rand_pwd(){
       echo "INFO: Password does not Match the criteria, re-generating..." >&2
     fi
   done
-  echo "INFO: ${s}" 
+  echo "${s}" 
 }
 
 #==================================================


### PR DESCRIPTION
If rand_pwd echo's "INFO: ${s}", then DB_SCHEMA_PASSWORD wrongly gets value as INFO: and does not adhere to Oracle DB password requirements.
Hence rand_pwd should only echo password and not echo with INFO:.