### PR TITLE
Correct image to extend, and pass in parameter to build.sh to define the network

### DIFF
--- a/OracleFMWInfrastructure/samples/12213-domain-home-in-image/Dockerfile.rcu
+++ b/OracleFMWInfrastructure/samples/12213-domain-home-in-image/Dockerfile.rcu
@@ -18,8 +18,7 @@
 #
 # From
 # -------------------------
-# FROM oracle/fmw-infrastructure:12.2.1.3
-FROM  container-registry.oracle.com/middleware/fmw-infrastructure:12.2.1.3
+FROM oracle/fmw-infrastructure:12.2.1.3
 
 # Maintainer
 # ----------

--- a/OracleFMWInfrastructure/samples/12213-domain-home-in-image/README.md
+++ b/OracleFMWInfrastructure/samples/12213-domain-home-in-image/README.md
@@ -85,7 +85,7 @@ To run RCU, start a container from the image created:
 **NOTE**: To have access to the `RCU.out`, map volume `/u01/oracle/` in the Administration Server container.
 
 ### Build the FMW Infrastructure Domain Image
-The Dockerfile in this sample extends the FMW Infrastructure install image and creates a domain configuration inside of the image. We provide a `build.sh` script to assist with the building of the image and setting the correct BUILD_ARGS that have been defined in the `domain.properties` and `rcu.properties` files. When running the images in Docker engine the database, RCU, and FMW Infrastructure image need to be running on the same Docker network (e.g. InfraNET). The `build.sh` takes one parameter the name of the network, example: 
+The Dockerfile in this sample extends the FMW Infrastructure install image and creates a domain configuration inside of the image. We provide a `build.sh` script to assist with the building of the image and setting the correct BUILD_ARGS that have been defined in the `domain.properties` and `rcu.properties` files. When running the images in Docker engine the database, RCU, and FMW Infrastructure images need to be running on the same Docker network (e.g. InfraNET). The `build.sh` takes one parameter the name of the network, example: 
 
        $ ./build.sh InfraNET
 

--- a/OracleFMWInfrastructure/samples/12213-domain-home-in-image/README.md
+++ b/OracleFMWInfrastructure/samples/12213-domain-home-in-image/README.md
@@ -85,7 +85,11 @@ To run RCU, start a container from the image created:
 **NOTE**: To have access to the `RCU.out`, map volume `/u01/oracle/` in the Administration Server container.
 
 ### Build the FMW Infrastructure Domain Image
-The Dockerfile in this sample extends the FMW Infrastructure install image and creates a domain configuration inside of the image. We provide a `build.sh` script to assist with the building of the image and setting the correct BUILD_ARGS that have been defined in the `domain.properties` and `rcu.properties` files. You can override the default values of the following parameters during configuration time in both these properties files. The script `./container-scripts/setEnv.sh` sets the build time environment variables to configure the domain, the following BUILD ARGS are set:
+The Dockerfile in this sample extends the FMW Infrastructure install image and creates a domain configuration inside of the image. We provide a `build.sh` script to assist with the building of the image and setting the correct BUILD_ARGS that have been defined in the `domain.properties` and `rcu.properties` files. When running the images in Docker engine the database, RCU, and FMW Infrastructure image need to be running on the same Docker network (e.g. InfraNET). The `build.sh` takes one parameter the name of the network, example: 
+
+       $ ./build.sh InfraNET
+
+ You can override the default values of the following parameters during configuration time in both these properties files. The script `./container-scripts/setEnv.sh` sets the build time environment variables to configure the domain, the following BUILD ARGS are set:
 
 * `CUSTOM_DOMAIN_NAME`
 * `CUSTOM_ADMIN_PORT`

--- a/OracleFMWInfrastructure/samples/12213-domain-home-in-image/build.sh
+++ b/OracleFMWInfrastructure/samples/12213-domain-home-in-image/build.sh
@@ -15,6 +15,13 @@
 #                           . Set the TAG_NAME environment variable. Overrides the default tag.
 #
 
+if [ "$#" -eq  "0" ]
+   then
+    network=""
+ else
+    network=" --network=$1"
+    echo "Setting network to ${network} when building the image"
+fi
 
 # Determine the tag name for the resulting image using the value in the TAG_NAME.
 # The setEnv.sh will set the TAG_NAME variable if the property is found in the
@@ -40,5 +47,5 @@ set_context
 . ${scriptDir}/container-scripts/setEnv.sh ${scriptDir}/properties/domain.properties ${scriptDir}/properties/rcu.properties
 
 tag_name
-echo "docker build $BUILD_ARG -t  ${tagName}  ${scriptDir}"
-docker build $BUILD_ARG -t  ${tagName} --network=InfraNET  ${scriptDir}
+echo "docker build $BUILD_ARG -t  ${tagName} ${network}  ${scriptDir}"
+docker build $BUILD_ARG -t  ${tagName} ${network}  ${scriptDir}


### PR DESCRIPTION
1- Correct Dockerfile.rcu to extend the correct image
2- Pass in one parameter to build.sh to define the network
3- Document the change to the build.sh script