### PR TITLE
Add the missing .download files referenced in buildDockerImage.sh

### DIFF
--- a/OracleBI/dockerfiles/12.2.1.2/fmw_12.2.1.3.0_bi_linux64_Disk1_1of2.zip.download
+++ b/OracleBI/dockerfiles/12.2.1.2/fmw_12.2.1.3.0_bi_linux64_Disk1_1of2.zip.download
@@ -1,0 +1,6 @@
+# Download Oracle Business Intelligence 12.2.1.2.0
+#
+# https://www.oracle.com/technetwork/middleware/bi/downloads/default-3237328.html
+#
+#
+7f72f6e4d1c6db376308ae7da1a09d46  fmw_12.2.1.2.0_bi_linux64_Disk1_1of2.zip

--- a/OracleBI/dockerfiles/12.2.1.2/fmw_12.2.1.3.0_bi_linux64_Disk1_2of2.zip.download
+++ b/OracleBI/dockerfiles/12.2.1.2/fmw_12.2.1.3.0_bi_linux64_Disk1_2of2.zip.download
@@ -1,0 +1,6 @@
+# Download Oracle Business Intelligence 12.2.1.2.0
+#
+# https://www.oracle.com/technetwork/middleware/bi/downloads/default-3237328.html
+#
+#
+25cd88d077933e2786c3a3c60780303f  fmw_12.2.1.2.0_bi_linux64_Disk1_2of2.zip

--- a/OracleBI/dockerfiles/12.2.1.3/fmw_12.2.1.3.0_bi_linux64_Disk1_1of2.zip.download
+++ b/OracleBI/dockerfiles/12.2.1.3/fmw_12.2.1.3.0_bi_linux64_Disk1_1of2.zip.download
@@ -1,0 +1,6 @@
+# Download Oracle Business Intelligence 12.2.1.3.0
+#
+# https://www.oracle.com/technetwork/middleware/bi/downloads/default-3852322.html
+#
+#
+5e9c138a23165bc374a93a8a1d72c7d0  fmw_12.2.1.3.0_bi_linux64_Disk1_1of2.zip

--- a/OracleBI/dockerfiles/12.2.1.3/fmw_12.2.1.3.0_bi_linux64_Disk1_2of2.zip.download
+++ b/OracleBI/dockerfiles/12.2.1.3/fmw_12.2.1.3.0_bi_linux64_Disk1_2of2.zip.download
@@ -1,0 +1,6 @@
+# Download Oracle Business Intelligence 12.2.1.3.0
+#
+# https://www.oracle.com/technetwork/middleware/bi/downloads/default-3852322.html
+#
+#
+4efe2d497c0581dd8c97669acccfadc1  fmw_12.2.1.3.0_bi_linux64_Disk1_2of2.zip


### PR DESCRIPTION
The buildDockerImage.sh script makes a reference to .download files that don't exist.

This commit adds the missing files in the same format as used for other sub-projects
of the docker-images project.