### PR TITLE
Resolve issues with the WebLogic domain-in-image samples when patches are applied on top of the domain image

### DIFF
--- a/OracleFMWInfrastructure/samples/12213-domain-home-in-image/Dockerfile
+++ b/OracleFMWInfrastructure/samples/12213-domain-home-in-image/Dockerfile
@@ -67,11 +67,11 @@ COPY container-scripts/* /u01/oracle/container-scripts/
 #Create directory where domain will be written to
 USER root
 RUN chmod +x /u01/oracle/container-scripts/* && \
-    mkdir -p ${PROPERTIES_FILE_DIR} && \
+    mkdir -p +xwr ${PROPERTIES_FILE_DIR} && \
     chown -R oracle:oracle ${PROPERTIES_FILE_DIR} && \
     mkdir -p $DOMAIN_HOME && \
-    chown -R oracle:oracle $DOMAIN_HOME && \
-    chmod -R a+xwr $DOMAIN_HOME
+    chown -R oracle:oracle $DOMAIN_HOME/.. && \
+    chmod -R a+xwr $DOMAIN_HOME/..
 
 USER oracle
 COPY properties/*.properties ${PROPERTIES_FILE_DIR}/

--- a/OracleFMWInfrastructure/samples/12213-domain-home-in-image/Dockerfile
+++ b/OracleFMWInfrastructure/samples/12213-domain-home-in-image/Dockerfile
@@ -62,21 +62,21 @@ ENV ORACLE_HOME="/u01/oracle" \
     PATH="$PATH:${JAVA_HOME}/bin:/u01/oracle/oracle_common/common/bin:/u01/oracle/wlserver/common/bin:/u01/oracle/container-scripts:${DOMAIN_HOME}/bin"
 
 # Add files required to build this image
-COPY container-scripts/* /u01/oracle/container-scripts/
+COPY --chown=oracle:oracle container-scripts/* /u01/oracle/container-scripts/
 
 #Create directory where domain will be written to
 USER root
 RUN chmod +x /u01/oracle/container-scripts/* && \
-    mkdir -p +xwr ${PROPERTIES_FILE_DIR} && \
+    mkdir -p ${PROPERTIES_FILE_DIR} && \
     chown -R oracle:oracle ${PROPERTIES_FILE_DIR} && \
     mkdir -p $DOMAIN_HOME && \
     chown -R oracle:oracle $DOMAIN_HOME/.. && \
     chmod -R a+xwr $DOMAIN_HOME/..
 
-USER oracle
-COPY properties/*.properties ${PROPERTIES_FILE_DIR}/
+COPY --chown=oracle:oracle properties/*.properties ${PROPERTIES_FILE_DIR}/
 
 # Configuration of WLS Domain
+USER oracle
 RUN /u01/oracle/container-scripts/createFMWDomain.sh && \
     echo ". $DOMAIN_HOME/bin/setDomainEnv.sh" >> /u01/oracle/.bashrc && \
     chmod -R a+x $DOMAIN_HOME/bin/*.sh  && \

--- a/OracleFMWInfrastructure/samples/12213-domain-home-in-image/Dockerfile
+++ b/OracleFMWInfrastructure/samples/12213-domain-home-in-image/Dockerfile
@@ -73,6 +73,7 @@ RUN chmod +x /u01/oracle/container-scripts/* && \
     chown -R oracle:oracle $DOMAIN_HOME && \
     chmod -R a+xwr $DOMAIN_HOME
 
+USER oracle
 COPY properties/*.properties ${PROPERTIES_FILE_DIR}/
 
 # Configuration of WLS Domain

--- a/OracleFMWInfrastructure/samples/12213-domain-home-in-image/README.md
+++ b/OracleFMWInfrastructure/samples/12213-domain-home-in-image/README.md
@@ -115,6 +115,7 @@ The Dockerfile in this sample extends the FMW Infrastructure install image and c
 
        $ docker images
 
+**NOTE**: The docker build command makes use of the `--no-cache` option to ensure that each build will create a new domain and not pickup anything from the Docker cache unexpectedly.
 
 #### Start the container
 Start a container from the image created in step 1.

--- a/OracleFMWInfrastructure/samples/12213-domain-home-in-image/README.md
+++ b/OracleFMWInfrastructure/samples/12213-domain-home-in-image/README.md
@@ -76,7 +76,7 @@ The database is created with the default password `Oradoc_db1`. To change the da
 ### Build and run RCU
 Many of the Oracle Fusion Middleware components require the existence of schemas in a database prior to installation. These schemas are created and loaded in your database using the Repository Creation Utility (RCU). To facilitate running RCU, you can build an image using the `Dockerfile.rcu`.
 
-       $ docker build -f Dockerfile.rcu -t 12213-fmw-rcu .
+       $ docker build --force-rm=true --no-cache=true -f Dockerfile.rcu -t 12213-fmw-rcu .
 
 To run RCU, start a container from the image created:
 
@@ -109,7 +109,7 @@ The Dockerfile in this sample extends the FMW Infrastructure install image and c
 
   1. To build the `12.2.1.3` FMW Infrastructure domain image, run:
 
-       $ docker build $BUILD_ARG --network InfraNET -f Dockerfile -t 12213-fmw-domain-home-in-image .
+       $ docker build --force-rm=true --no-cache=true $BUILD_ARG --network InfraNET -f Dockerfile -t 12213-fmw-domain-home-in-image .
 
   2. Verify that you now have this image in place with:
 

--- a/OracleFMWInfrastructure/samples/12213-domain-home-in-image/build.sh
+++ b/OracleFMWInfrastructure/samples/12213-domain-home-in-image/build.sh
@@ -47,5 +47,5 @@ set_context
 . ${scriptDir}/container-scripts/setEnv.sh ${scriptDir}/properties/domain.properties ${scriptDir}/properties/rcu.properties
 
 tag_name
-echo "docker build $BUILD_ARG -t  ${tagName} ${network}  ${scriptDir}"
-docker build $BUILD_ARG -t  ${tagName} ${network}  ${scriptDir}
+echo "docker build --force-rm=true --no-cache=true $BUILD_ARG -t  ${tagName} ${network}  ${scriptDir}"
+docker build --force-rm=true --no-cache=true $BUILD_ARG -t  ${tagName} ${network}  ${scriptDir}

--- a/OracleFMWInfrastructure/samples/12213-domain-home-in-image/build_rcu.sh
+++ b/OracleFMWInfrastructure/samples/12213-domain-home-in-image/build_rcu.sh
@@ -5,4 +5,4 @@
 #Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 #
 #Build image to run RCU
-docker build -f Dockerfile.rcu -t 12213-fmw-rcu .
+docker build --force-rm=true --no-cache=true -f Dockerfile.rcu -t 12213-fmw-rcu .

--- a/OracleFMWInfrastructure/samples/12213-patch-fmw-for-k8s/Dockerfile
+++ b/OracleFMWInfrastructure/samples/12213-patch-fmw-for-k8s/Dockerfile
@@ -40,7 +40,7 @@ ENV PATCH_PKG="p29135930_122130_Generic.zip"
 
 # Copy patch 29135930 
 # --------------------------------
-COPY $PATCH_PKG /u01/
+COPY --chown=oracle:oracle $PATCH_PKG /u01/
 
 # Apply Patch 29135930
 # --------------------------------------------

--- a/OracleFMWInfrastructure/samples/12213-patch-fmw-for-k8s/README.md
+++ b/OracleFMWInfrastructure/samples/12213-patch-fmw-for-k8s/README.md
@@ -8,7 +8,7 @@ If you want to patch on top of FMW Infrastructure 12.2.1.3, download the file, [
 
 To build, run:
 
-        $ docker build -t oracle/fmw-infrastructure:12213-update-k8s .
+        $ docker build --force-rm=true --no-cache=true -t oracle/fmw-infrastructure:12213-update-k8s .
 
 ## Verify that the patch has been applied correctly
 Run a container from the image:

--- a/OracleFMWInfrastructure/samples/12213-patch-fmw-for-k8s/build.sh
+++ b/OracleFMWInfrastructure/samples/12213-patch-fmw-for-k8s/build.sh
@@ -5,4 +5,4 @@
 #Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 #
 # Build the image using Dockerfile to apply patch p29135930 based on FMW Infrastructure 12.2.1.3 
-docker build -t oracle/fmw-infrastructure:12213-update-k8s .
+docker build --force-rm=true --no-cache=true -t oracle/fmw-infrastructure:12213-update-k8s .

--- a/OracleFMWInfrastructure/samples/12213-patch/Dockerfile
+++ b/OracleFMWInfrastructure/samples/12213-patch/Dockerfile
@@ -32,7 +32,7 @@ ENV PATCH_PKG="p27117282_122130_Generic.zip"
 
 # Copy supplemental package and scripts
 # --------------------------------
-COPY $PATCH_PKG /u01/
+COPY --chown=oracle:oracle $PATCH_PKG /u01/
 
 # Installation of Supplemental Quick Installer
 # --------------------------------------------

--- a/OracleFMWInfrastructure/samples/12213-patch/README.md
+++ b/OracleFMWInfrastructure/samples/12213-patch/README.md
@@ -9,7 +9,7 @@ Download from My Oracle Support the file [p27117282_122130_Generic.zip](http://s
 
 To build, run:
 
-        $ docker build -t oracle/fmw-infra:12213-p27117282 .
+        $ docker build --force-rm=true --no-cache=true -t oracle/fmw-infra:12213-p27117282 .
 
 ## Verify that the Patch has been applied correctly
 Run a container from the image

--- a/OracleWebLogic/samples/12213-domain-home-in-image-wdt/Dockerfile
+++ b/OracleWebLogic/samples/12213-domain-home-in-image-wdt/Dockerfile
@@ -33,6 +33,7 @@
 #            --build-arg WDT_ARCHIVE=archive.zip \
 #            --build-arg WDT_VARIABLE=properties/docker-build/domain.properties \
 #            --force-rm=true \
+#            --no-cache=true \
 #            -t 12213-domain-home-in-image-wdt .
 #
 # If the ADMIN_HOST, ADMIN_PORT, MS_PORT, DOMAIN_NAME are not provided, the variables 
@@ -138,10 +139,6 @@ RUN if [ -n "$WDT_MODEL" ]; then MODEL_OPT="-model_file $PROPERTIES_FILE_DIR/${W
         $ARCHIVE_OPT && \
         echo ". $DOMAIN_HOME/bin/setDomainEnv.sh" >> /u01/oracle/.bashrc && \
         rm -rf $PROPERTIES_FILE_DIR 
-
-# Mount the domain home and the WDT home for easy access.
-VOLUME $DOMAIN_HOME
-VOLUME $WDT_HOME
 
 # Expose admin server, managed server port and domain debug port
 EXPOSE $ADMIN_PORT $MANAGED_SERVER_PORT $DEBUG_PORT

--- a/OracleWebLogic/samples/12213-domain-home-in-image-wdt/README.md
+++ b/OracleWebLogic/samples/12213-domain-home-in-image-wdt/README.md
@@ -73,6 +73,7 @@ To build this sample keeping the defaults, run:
           --build-arg WDT_ARCHIVE=archive.zip \
           --build-arg WDT_VARIABLE=properties/docker-build/domain.properties \
           --force-rm=true \
+          --no-cache=true \
           -t 12213-domain-home-in-image-wdt .
 
 This will use the model, variable, and archive files in the sample directory.
@@ -92,6 +93,7 @@ To parse the sample variable file and build the sample, run:
           --build-arg WDT_ARCHIVE=archive.zip \
           --build-arg WDT_VARIABLE=properties/docker-build/domain.properties \
           --force-rm=true \
+          --no-cache=true \
           -t 12213-domain-home-in-image-wdt .
 
 The Admin Server and each Managed Server are run in containers from this build image. In the sample, the securities.properties file

--- a/OracleWebLogic/samples/12213-domain-home-in-image-wdt/README.md
+++ b/OracleWebLogic/samples/12213-domain-home-in-image-wdt/README.md
@@ -101,6 +101,8 @@ The Admin Server and each Managed Server are run in containers from this build i
   start of the Admin or Managed server. Mount the properties/docker-run directory to the container so that file can be accessed by the
   server start script. It is the responsibility of the user to manage this volume, and the security.properties, in the container.
 
+**NOTE:** The docker build command makes use of the `--no-cache` option to ensure that each build will create a new domain and not pickup anything from the Docker cache unexpectedly.
+
 To start the containerized Administration Server, run:
 
     $ docker run -d --name wlsadmin --hostname wlsadmin -p 7001:7001 -v <sample-directory>/properties/docker-run:/u01/oracle/properties 12213-domain-home-in-image-wdt

--- a/OracleWebLogic/samples/12213-domain-home-in-image-wdt/build.sh
+++ b/OracleWebLogic/samples/12213-domain-home-in-image-wdt/build.sh
@@ -190,6 +190,7 @@ build_domain_image() {
        $MODEL_ARGS \
        $ADDITIONAL_BUILD_ARGS \
        --force-rm=true \
+       --no-cache=true \
        -f ${dockerFile} \
        -t ${tagName} \
        ${scriptDir}"
@@ -201,6 +202,7 @@ build_domain_image() {
        $MODEL_ARGS \
        $ADDITIONAL_BUILD_ARGS \
        --force-rm=true \
+       --no-cache=true \
        -f ${dockerFile} \
        -t ${tagName} \
        ${scriptDir}

--- a/OracleWebLogic/samples/12213-domain-home-in-image-wdt/quickBuild.sh
+++ b/OracleWebLogic/samples/12213-domain-home-in-image-wdt/quickBuild.sh
@@ -18,5 +18,6 @@ docker build \
     --build-arg WDT_VARIABLE=properties/docker-build/domain.properties \
     --build-arg WDT_ARCHIVE=archive.zip \
     --force-rm=true \
+    --no-cache=true \
     -t 12213-domain-home-in-image-wdt .
 

--- a/OracleWebLogic/samples/12213-domain-home-in-image/Dockerfile
+++ b/OracleWebLogic/samples/12213-domain-home-in-image/Dockerfile
@@ -59,6 +59,7 @@ RUN chmod +xw /u01/oracle/*.sh && \
     chown -R oracle:oracle $DOMAIN_HOME && \
     chmod -R a+xwr $DOMAIN_HOME
 
+USER oracle
 COPY properties/docker-build/domain*.properties ${PROPERTIES_FILE_DIR}/
 
 # Configuration of WLS Domain

--- a/OracleWebLogic/samples/12213-domain-home-in-image/Dockerfile
+++ b/OracleWebLogic/samples/12213-domain-home-in-image/Dockerfile
@@ -47,22 +47,22 @@ ENV ORACLE_HOME=/u01/oracle \
     PATH=$PATH:/u01/oracle/oracle_common/common/bin:/u01/oracle/wlserver/common/bin:${DOMAIN_HOME}:${DOMAIN_HOME}/bin:/u01/oracle
 
 # Add files required to build this image
-COPY container-scripts/* /u01/oracle/
+COPY --chown=oracle:oracle container-scripts/* /u01/oracle/
 
 #Create directory where domain will be written to
 USER root
 RUN chmod +xw /u01/oracle/*.sh && \
     chmod +xw /u01/oracle/*.py && \
-    mkdir -p +xwr ${PROPERTIES_FILE_DIR} && \
+    mkdir -p ${PROPERTIES_FILE_DIR} && \
     chown -R oracle:oracle ${PROPERTIES_FILE_DIR} && \
     mkdir -p $DOMAIN_HOME && \
     chown -R oracle:oracle $DOMAIN_HOME/.. && \
     chmod -R a+xwr $DOMAIN_HOME/..
 
-USER oracle
-COPY properties/docker-build/domain*.properties ${PROPERTIES_FILE_DIR}/
+COPY --chown=oracle:oracle properties/docker-build/domain*.properties ${PROPERTIES_FILE_DIR}/
 
 # Configuration of WLS Domain
+USER oracle
 RUN /u01/oracle/createWLSDomain.sh && \
     echo ". $DOMAIN_HOME/bin/setDomainEnv.sh" >> /u01/oracle/.bashrc && \
     chmod -R a+x $DOMAIN_HOME/bin/*.sh  && \

--- a/OracleWebLogic/samples/12213-domain-home-in-image/Dockerfile
+++ b/OracleWebLogic/samples/12213-domain-home-in-image/Dockerfile
@@ -53,11 +53,11 @@ COPY container-scripts/* /u01/oracle/
 USER root
 RUN chmod +xw /u01/oracle/*.sh && \
     chmod +xw /u01/oracle/*.py && \
-    mkdir -p ${PROPERTIES_FILE_DIR} && \
+    mkdir -p +xwr ${PROPERTIES_FILE_DIR} && \
     chown -R oracle:oracle ${PROPERTIES_FILE_DIR} && \
     mkdir -p $DOMAIN_HOME && \
-    chown -R oracle:oracle $DOMAIN_HOME && \
-    chmod -R a+xwr $DOMAIN_HOME
+    chown -R oracle:oracle $DOMAIN_HOME/.. && \
+    chmod -R a+xwr $DOMAIN_HOME/..
 
 USER oracle
 COPY properties/docker-build/domain*.properties ${PROPERTIES_FILE_DIR}/

--- a/OracleWebLogic/samples/12213-domain-home-in-image/README.md
+++ b/OracleWebLogic/samples/12213-domain-home-in-image/README.md
@@ -60,8 +60,9 @@ Under the directory `docker-images/OracleWebLogic/samples/12213-domain-home-in-i
 To build this sample, run:
 
  	$ . container-scripts/setEnv.sh ./properties/docker-build/domain.properties
-	$ docker build --force-rm=true --no-cache=true $BUILD_ARG -t 12213-domain-home-in-image .
+ 	$ docker build --force-rm=true --no-cache=true $BUILD_ARG -t 12213-domain-home-in-image .
 
+**NOTE:** The docker build command makes use of the `--no-cache` option to ensure that each build will create a new domain and not pickup anything from the Docker cache unexpectedly.
 
 **During Docker Run:** of the Administration and Managed Servers, the user name and password need to be passed in as well as some optional parameters. The property file is located in a `docker-images/OracleWebLogic/samples/12213-domain-home-in-image/properties/docker_run` in the HOST. On the Docker run command line, add the `-v` option which maps the property file into the image directory `/u01/oracle/properties`.
 

--- a/OracleWebLogic/samples/12213-domain-home-in-image/README.md
+++ b/OracleWebLogic/samples/12213-domain-home-in-image/README.md
@@ -60,7 +60,7 @@ Under the directory `docker-images/OracleWebLogic/samples/12213-domain-home-in-i
 To build this sample, run:
 
  	$ . container-scripts/setEnv.sh ./properties/docker-build/domain.properties
- 	$ docker build $BUILD_ARG  --force-rm=true -t 12213-domain-home-in-image .
+	$ docker build --force-rm=true --no-cache=true $BUILD_ARG -t 12213-domain-home-in-image .
 
 
 **During Docker Run:** of the Administration and Managed Servers, the user name and password need to be passed in as well as some optional parameters. The property file is located in a `docker-images/OracleWebLogic/samples/12213-domain-home-in-image/properties/docker_run` in the HOST. On the Docker run command line, add the `-v` option which maps the property file into the image directory `/u01/oracle/properties`.

--- a/OracleWebLogic/samples/12213-domain-home-in-image/build.sh
+++ b/OracleWebLogic/samples/12213-domain-home-in-image/build.sh
@@ -40,4 +40,4 @@ set_context
 . ${scriptDir}/container-scripts/setEnv.sh ${scriptDir}/properties/docker-build/domain.properties
 
 tag_name
-docker build $BUILD_ARG -t  ${tagName}  ${scriptDir}
+docker build --force-rm=true --no-cache=true $BUILD_ARG -t  ${tagName}  ${scriptDir}

--- a/OracleWebLogic/samples/12213-patch-wls-for-k8s/Dockerfile.patch-ontop-12213
+++ b/OracleWebLogic/samples/12213-patch-wls-for-k8s/Dockerfile.patch-ontop-12213
@@ -53,7 +53,7 @@ ENV PATCH_PKG2="p29135930_122130_Generic.zip"
 # --------------------------------
 # Copy patches 27117282 & 29135930 
 # --------------------------------
-COPY $PATCH_PKG1 $PATCH_PKG2 /u01/
+COPY --chown=oracle:oracle $PATCH_PKG1 $PATCH_PKG2 /u01/
 
 # PATCH_PKG1 (27117282) is only needed if the WebLogic binary image
 # is created manually from this Github project under dockerfiles/12.2.1.3.

--- a/OracleWebLogic/samples/12213-patch-wls-for-k8s/Dockerfile.patch-ontop-12213-psu
+++ b/OracleWebLogic/samples/12213-patch-wls-for-k8s/Dockerfile.patch-ontop-12213-psu
@@ -42,7 +42,7 @@ ENV PATCH_PKG2="p29135930_12213181016_Generic.zip"
 
 # Copy supplemental package and scripts
 # --------------------------------
-COPY $PATCH_PKG0 $PATCH_PKG1 $PATCH_PKG2 /u01/
+COPY --chown=oracle:oracle $PATCH_PKG0 $PATCH_PKG1 $PATCH_PKG2 /u01/
 
 # Installation of Supplemental Quick Installer
 # --------------------------------------------

--- a/OracleWebLogic/samples/12213-patch-wls-for-k8s/README.md
+++ b/OracleWebLogic/samples/12213-patch-wls-for-k8s/README.md
@@ -27,9 +27,9 @@ If you want to patch on top of WebLogic Server 12.2.1.3 October PSU download:
 
 To build, run:
 
-        $ docker build -t oracle/weblogic:12213-patch-wls-for-k8s -f Dockerfile.patch-ontop-12213 .
+        $ docker build --force-rm=true --no-cache=true -t oracle/weblogic:12213-patch-wls-for-k8s -f Dockerfile.patch-ontop-12213 .
         or
-        $ docker build -t oracle/weblogic:12213-patch-wls-for-k8s -f Dockerfile.patch-ontop-12213-psu .
+        $ docker build --force-rm=true --no-cache=true -t oracle/weblogic:12213-patch-wls-for-k8s -f Dockerfile.patch-ontop-12213-psu .
 
 ## Verify that the patch has been applied correctly
 Run a container from the image:

--- a/OracleWebLogic/samples/12213-patch-wls-for-k8s/build.sh
+++ b/OracleWebLogic/samples/12213-patch-wls-for-k8s/build.sh
@@ -6,4 +6,4 @@
 #
 # Build the image using Dockerfile.patch-ontop-12213 to apply patch p29135930 based on WebLogic 12.2.1.3, or build 
 # the image using Dockerfile.patch-ontop-12213-psu to apply patch p29135930  ontop of WebLogic 12.2.1.3 October PSU.
-docker build -t oracle/weblogic:12213-patch-wls-for-k8s -f Dockerfile.$1 .
+docker build --force-rm=true --no-cache=true -t oracle/weblogic:12213-patch-wls-for-k8s -f Dockerfile.$1 .

--- a/OracleWebLogic/samples/12213-patch/Dockerfile
+++ b/OracleWebLogic/samples/12213-patch/Dockerfile
@@ -32,7 +32,7 @@ ENV PATCH_PKG="p27117282_122130_Generic.zip"
 
 # Copy supplemental package and scripts
 # --------------------------------
-COPY $PATCH_PKG /u01/
+COPY --chown=oracle:oracle $PATCH_PKG /u01/
 
 # Installation of Supplemental Quick Installer
 # --------------------------------------------

--- a/OracleWebLogic/samples/12213-patch/README.md
+++ b/OracleWebLogic/samples/12213-patch/README.md
@@ -9,7 +9,7 @@ Then download file [p27117282_122130_Generic.zip](http://support.oracle.com) and
 
 To build, run:
 
-        $ docker build -t oracle/weblogic:12213-p27117282 .
+        $ docker build --force-rm=true --no-cache=true -t oracle/weblogic:12213-p27117282 .
 
 ## Run Single Server Domain
 #### Providing the Administration Server user name and password


### PR DESCRIPTION
WebLogic Operator team has gotten reports from other Oracle teams that the samples used to create a domain home in a docker image did not function when an OPatch was applied to on the docker image created with the domain home.

Updates to the WebLogic samples are required such that the images run as `oracle` user which then enables an OPatch to be applied on top of the domain image. File permission errors resulted without these changes to how the Dockerfiles setup directories an apply the OPatch. An additional update to the docker build flags was made so that the docker cache is not used.