### PR TITLE
Update createWLSDomain.sh

### DIFF
--- a/OracleWebLogic/samples/12213-domain/container-scripts/createWLSDomain.sh
+++ b/OracleWebLogic/samples/12213-domain/container-scripts/createWLSDomain.sh
@@ -30,7 +30,8 @@ trap _kill SIGKILL
 export DOMAIN_HOME=$CUSTOM_DOMAIN_ROOT/$CUSTOM_DOMAIN_NAME
 echo "Domain Home is:  $DOMAIN_HOME"
 
-if [  -f ${DOMAIN_HOME}/servers/${CUSTOM_ADMIN_NAME}/logs/${CUSTOM_ADMIN_NAME}.log ]; then
+if [ ! -f ${DOMAIN_HOME}/servers/${CUSTOM_ADMIN_NAME}/logs/${CUSTOM_ADMIN_NAME}.log ]; then
+    echo "Log file cannot be found. Exiting..."
     exit
 fi
 


### PR DESCRIPTION
Reference Issue: #1340 

Prevent the existence of the file from resulting in an exit. The implication is that with the previous line, restarting the Docker container would immediately exit as the first run of this would create the log file this is checking the existence for.