### PR TITLE
Add container scripts needed for Coherence demo

### DIFF
--- a/OracleWebLogic/samples/12213-coherence-domain-in-image-wdt/container-scripts/setEnv.sh
+++ b/OracleWebLogic/samples/12213-coherence-domain-in-image-wdt/container-scripts/setEnv.sh
@@ -1,0 +1,75 @@
+#!/bin/bash ex
+
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+# The Universal Permissive License (UPL), Version 1.0
+#
+# This example creates the BUILD_ARG environment variable as a string of --build-arg for 
+# the arguments passed on the docker build command. The variable file that is used for the WDT
+# create domain step is the input to this script. This insures that the values persisted
+# as environment variables in the docker image match the configured domain home.
+
+BUILD_ARG=''
+if [ "$#" -eq  "0" ]; then
+    echo "A properties file with variable definitions should be supplied."
+    exit 1
+ else
+    PROPERTIES_FILE=$1
+    echo Export environment variables from the ${PROPERTIES_FILE} properties file
+fi
+
+DOMAIN_DIR=`awk '{print $1}' $PROPERTIES_FILE | grep ^DOMAIN_NAME= | cut -d "=" -f2`
+if [ ! -n "$DOMAIN_DIR" ]; then  
+   if [ -n "$DOMAIN_NAME" ]; then
+      DOMAIN_DIR=$DOMAIN_NAME
+   fi
+fi
+if [ -n "$DOMAIN_DIR" ]; then
+     DOMAIN_NAME=$DOMAIN_DIR
+     export DOMAIN_NAME
+     echo DOMAIN_NAME=$DOMAIN_NAME
+     BUILD_ARG="$BUILD_ARG --build-arg CUSTOM_DOMAIN_NAME=$DOMAIN_NAME"
+fi
+
+ADMIN_HOST=`awk '{print $1}' $PROPERTIES_FILE | grep ^ADMIN_HOST= | cut -d "=" -f2`
+if [ -n "$ADMIN_HOST" ]; then
+    export ADMIN_HOST
+    echo ADMIN_HOST=$ADMIN_HOST
+    BUILD_ARG="$BUILD_ARG --build-arg CUSTOM_ADMIN_HOST=$ADMIN_HOST"
+fi
+
+ADMIN_NAME=`awk '{print $1}' $PROPERTIES_FILE | grep ^ADMIN_NAME= | cut -d "=" -f2`
+if [ -n "$ADMIN_NAME" ]; then
+    export ADMIN_NAME
+    echo ADMIN_NAME=$ADMIN_NAME
+    BUILD_ARG="$BUILD_ARG --build-arg CUSTOM_ADMIN_NAME=$ADMIN_NAME"
+fi
+
+ADMIN_PORT=`awk '{print $1}' $PROPERTIES_FILE | grep ^ADMIN_PORT= | cut -d "=" -f2`
+if [ -n "$ADMIN_PORT" ]; then
+    export ADMIN_PORT
+    echo ADMIN_PORT=$ADMIN_PORT
+    BUILD_ARG="$BUILD_ARG --build-arg CUSTOM_ADMIN_PORT=$ADMIN_PORT"
+fi
+
+MANAGED_SERVER_PORT=`awk '{print $1}' $PROPERTIES_FILE | grep ^MANAGED_SERVER_PORT= | cut -d "=" -f2`
+if [ -n "$MANAGED_SERVER_PORT" ]; then
+    export MANAGED_SERVER_PORT 
+    echo MANAGED_SERVER_PORT=$MANAGED_SERVER_PORT
+    BUILD_ARG="$BUILD_ARG --build-arg CUSTOM_MANAGED_SERVER_PORT=$MANAGED_SERVER_PORT"
+fi
+
+DEBUG_PORT=`awk '{print $1}' $PROPERTIES_FILE | grep ^DEBUG_PORT= | cut -d "=" -f2`
+if [ -n "$DEBUG_PORT" ]; then
+    export DEBUG_PORT
+    echo DEBUG_PORT=$DEBUG_PORT
+    BUILD_ARG="$BUILD_ARG --build-arg CUSTOM_DEBUG_PORT=$DEBUG_PORT"
+fi
+
+CUSTOM_TAG_NAME=`awk '{print $1}' $PROPERTIES_FILE | grep ^IMAGE_TAG= | cut -d "=" -f2`
+if [ -n "$CUSTOM_TAG_NAME" ]; then
+    TAG_NAME=${CUSTOM_TAG_NAME}
+    export TAG_NAME
+    echo "Set the image tag name to $TAG_NAME"
+fi
+
+echo BUILD_ARG=$BUILD_ARG

--- a/OracleWebLogic/samples/12213-coherence-domain-in-image-wdt/container-scripts/startAdminServer.sh
+++ b/OracleWebLogic/samples/12213-coherence-domain-in-image-wdt/container-scripts/startAdminServer.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+#Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+#
+#Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+#
+# Start the domain Admin Server.
+
+# Locate the runtime properties
+PROPERTIES_FILE=${PROPERTIES_FILE_DIR}/security.properties
+if [ ! -e "$PROPERTIES_FILE" ]; then
+    echo "A security.properties file with the username and password needs to be supplied."
+    echo "The file was not found in the properties directory ${PROPERTIES_FILE_DIR}"
+    exit
+fi
+
+# Define Admin Server JAVA_OPTIONS
+JAVA_OPTIONS=`awk '{print $1}' $PROPERTIES_FILE | grep ^JAVA_OPTIONS= | cut -d "=" -f2`
+if [ -z "${JAVA_OPTIONS}" ]; then
+    JAVA_OPTIONS="-Dweblogic.StdoutDebugEnabled=false"
+fi
+export ${JAVA_OPTIONS}
+echo "Java Options: ${JAVA_OPTIONS}"
+
+DERBY_FLAG=false
+export ${DERBY_FLAG}
+
+export AS_HOME="${DOMAIN_HOME}/servers/${ADMIN_NAME}"
+export AS_SECURITY="${AS_HOME}/security"
+export AS_LOGS="${AS_HOME}/logs"
+
+if [ -f ${AS_LOGS}}/${ADMIN_NAME}.log ]; then
+    exit
+fi
+
+echo "Admin Server Home: ${AS_HOME}"
+echo "Admin Server Security: ${AS_SECURITY}"
+echo "Admin Server Logs: ${AS_LOGS}"
+
+USER=`awk '{print $1}' $PROPERTIES_FILE | grep ^username= | cut -d "=" -f2`
+if [ -z "$USER" ]; then
+    echo "The domain username is blank.  The Admin username must be set in the properties file."
+    exit 1
+fi
+
+PASS=`awk '{print $1}' $PROPERTIES_FILE | grep ^password= | cut -d "=" -f2`
+if [ -z "$PASS" ]; then
+    echo "The domain password is blank.  The Admin password must be set in the properties file."
+    exit 1
+fi
+
+mkdir -p ${AS_SECURITY}
+echo "username=${USER}" >> ${AS_SECURITY}/boot.properties
+echo "password=${PASS}" >> ${AS_SECURITY}/boot.properties
+
+# Start Admin Server and tail the logs
+${DOMAIN_HOME}/bin/setDomainEnv.sh
+${DOMAIN_HOME}/startWebLogic.sh
+
+tail -f ${AS_LOGS}/${ADMIN_NAME}.log &
+
+childPID=$!
+wait $childPID

--- a/OracleWebLogic/samples/12213-coherence-domain-in-image-wdt/container-scripts/startManagedServer.sh
+++ b/OracleWebLogic/samples/12213-coherence-domain-in-image-wdt/container-scripts/startManagedServer.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+#Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+#
+#Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+#
+# Start a Domain Managed Server.
+
+PROPERTIES_FILE=${PROPERTIES_FILE_DIR}/security.properties
+if [ ! -e "$PROPERTIES_FILE" ]; then
+    echo "A security.properties file with variable definitions needs to be supplied."
+    exit
+fi
+
+JAVA_OPTIONS=`awk '{print $1}' $PROPERTIES_FILE | grep ^JAVA_OPTIONS= | cut -d "=" -f2`
+if [ -z "$JAVA_OPTIONS" ]; then
+    JAVA_OPTIONS="-Dweblogic.StdoutDebugEnabled=false"
+fi
+
+export MS_HOME="${DOMAIN_HOME}/servers/${MANAGED_SERVER_NAME}"
+export MS_SECURITY="${MS_HOME}/security"
+export MS_LOGS="${MS_HOME}/logs"
+
+if [ -f ${MS_LOGS}/${MANAGED_SERVER_NAME}.log ]; then
+    exit
+fi
+
+# Wait for the domain Admin Server to become available
+${SCRIPT_HOME}/waitForAdminServer.sh
+
+echo "Managed Server Name: ${MANAGED_SERVER_NAME}"
+echo "Managed Server Home: ${MS_HOME}"
+echo "Managed Server Security: ${MS_SECURITY}"
+echo "Managed Server Logs: ${MS_LOGS}"
+
+USER=`awk '{print $1}' $PROPERTIES_FILE | grep ^username= | cut -d "=" -f2`
+if [ -z "$USER" ]; then
+    echo "The admin username is blank.  The admin username must be set in the properties file."
+    exit 
+fi
+
+PASS=`awk '{print $1}' $PROPERTIES_FILE | grep ^password= | cut -d "=" -f2`
+if [ -z "$PASS" ]; then
+    echo "The admin password is blank.  The admin password must be set in the properties file."
+    exit
+fi
+
+mkdir -p ${MS_SECURITY}
+echo username=$USER > ${MS_SECURITY}/boot.properties
+echo password=$PASS >> ${MS_SECURITY}/boot.properties
+
+# Start Managed Server 
+${DOMAIN_HOME}/bin/setDomainEnv.sh
+echo 'Start Managed Server: ${MANAGED_SERVER_NAME}'
+${DOMAIN_HOME}/bin/startManagedWebLogic.sh ${MANAGED_SERVER_NAME} http://${ADMIN_HOST}:${ADMIN_PORT}
+
+# Tail Managed Server Log
+tail -f ${MS_LOGS}/${MANAGED_SERVER_NAME}.log &
+
+childPID=$!
+wait $childPID

--- a/OracleWebLogic/samples/12213-coherence-domain-in-image-wdt/container-scripts/waitForAdminServer.sh
+++ b/OracleWebLogic/samples/12213-coherence-domain-in-image-wdt/container-scripts/waitForAdminServer.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+#Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+#
+#Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+#
+# This script will wait until Admin Server is available.
+# There is no timeout!
+#
+echo "Waiting for WebLogic Admin Server on $ADMIN_HOST:$ADMIN_PORT to become available..."
+while :
+do
+  (echo > /dev/tcp/$ADMIN_HOST/$ADMIN_PORT) >/dev/null 2>&1
+  available=$?
+  if [[ $available -eq 0 ]]; then
+    echo "WebLogic Admin Server is now available. Proceeding..."
+    break
+  fi
+  sleep 1
+done


### PR DESCRIPTION
The container scripts are needed to build the docker image used by the Coherence demo.