### PR TITLE
[WIP] Dockerfiles and Scripts for Oracle WebLogic 14.1.1.0

### DIFF
--- a/OracleJava/README.md
+++ b/OracleJava/README.md
@@ -4,6 +4,17 @@ This repository contains a sample Docker configuration to facilitate installatio
 
 Oracle Java Server JRE provides the features from Oracle Java JDK commonly required for server-side applications (i.e. Running a Java EE application server). For more information about Server JRE, visit the [Understanding the Server JRE blog entry](https://blogs.oracle.com/java-platform-group/understanding-the-server-jre) from the Java Product Management team.
 
+## Building the Java 11 (JDK) base image
+[Download JDK 11](https://www.oracle.com/technetwork/java/javase/downloads/jdk11-downloads-5066655.html) `.tar.gz` file and drop it inside the folder `../OracleJava/java-11`.
+
+Build it using:
+
+```
+$ cd ../OracleJava/java-11
+$ docker build -t oracle/jdk:11 .
+```
+
+
 ## Building the Java 8 (Server JRE) base image
 [Download Server JRE 8](http://www.oracle.com/technetwork/java/javase/downloads/server-jre8-downloads-2133154.html) `.tar.gz` file and drop it inside the folder `../OracleJava/java-8`.
 

--- a/OracleJava/java-11/Dockerfile
+++ b/OracleJava/java-11/Dockerfile
@@ -1,0 +1,15 @@
+FROM oraclelinux:7-slim
+
+MAINTAINER Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>
+
+ENV JAVA_PKG=jdk-11.*_linux-x64_bin.tar.gz \
+    JAVA_HOME=/usr/java/jdk-11.*
+
+ADD $JAVA_PKG /usr/java/
+
+RUN export JAVA_DIR=$(ls -1 -d /usr/java/*) && \
+    ln -s $JAVA_DIR /usr/java/latest && \
+    ln -s $JAVA_DIR /usr/java/default && \
+    alternatives --install /usr/bin/java java $JAVA_DIR/bin/java 20000 && \
+    alternatives --install /usr/bin/javac javac $JAVA_DIR/bin/javac 20000 && \
+    alternatives --install /usr/bin/jar jar $JAVA_DIR/bin/jar 20000

--- a/OracleJava/java-11/build.sh
+++ b/OracleJava/java-11/build.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker build -t oracle/jdk:11 .

--- a/OracleJava/java-11/jdk-11.0.4_linux-x64_bin.tar.gz.download
+++ b/OracleJava/java-11/jdk-11.0.4_linux-x64_bin.tar.gz.download
@@ -1,5 +1,5 @@
-# Download the Server JRE (which includes necessary JDK bits for backend Java based solutions)
+# Download the JDK from
 #
-#  - http://www.oracle.com/technetwork/java/javase/downloads/server-jre8-downloads-2133154.html
+#  - https://www.oracle.com/technetwork/java/javase/downloads/jdk11-downloads-5066655.html
 #
-10badb89c60b0932ced8f41079d30e60 jdk-11.0.4_linux-x64_bin.tar.gz
+45962ed7a08d66775cb036e6f33cd576ecb1eab655c96dbe74851a3ebe1945fa jdk-11.0.4_linux-x64_bin.tar.gz

--- a/OracleJava/java-11/jdk-11.0.4_linux-x64_bin.tar.gz.download
+++ b/OracleJava/java-11/jdk-11.0.4_linux-x64_bin.tar.gz.download
@@ -1,0 +1,5 @@
+# Download the Server JRE (which includes necessary JDK bits for backend Java based solutions)
+#
+#  - http://www.oracle.com/technetwork/java/javase/downloads/server-jre8-downloads-2133154.html
+#
+10badb89c60b0932ced8f41079d30e60 jdk-11.0.4_linux-x64_bin.tar.gz

--- a/OracleWebLogic/dockerfiles/12.2.1.4/Dockerfile.developer
+++ b/OracleWebLogic/dockerfiles/12.2.1.4/Dockerfile.developer
@@ -95,6 +95,7 @@ COPY --from=builder --chown=oracle:oracle /u01 /u01
 COPY container-scripts/createAndStartEmptyDomain.sh container-scripts/create-wls-domain.py /u01/oracle/
 
 RUN chmod +xr $SCRIPT_FILE && \
+    chown oracle:oracle -R /u01 && \
     chown oracle:oracle -R /u01/oracle/createAndStartEmptyDomain.sh && \
     chown oracle:oracle -R /u01/oracle/create-wls-domain.py
 

--- a/OracleWebLogic/dockerfiles/12.2.1.4/Dockerfile.generic
+++ b/OracleWebLogic/dockerfiles/12.2.1.4/Dockerfile.generic
@@ -52,7 +52,7 @@ ENV FMW_PKG=fmw_12.2.1.4.0_wls_Disk1_1of1.zip \
 
 # Copy packages
 # -------------
-COPY $FMW_PKG install.file oraInst.loc /u01/
+COPY $FMW_PKG install.file oraInst.loc rda_lin64 rda.cfg /u01/
 RUN chown oracle:oracle -R /u01
 
 # Install
@@ -61,7 +61,10 @@ USER oracle
 
 RUN cd /u01 && ${JAVA_HOME}/bin/jar xf /u01/$FMW_PKG && cd - && \
     ${JAVA_HOME}/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME INSTALL_TYPE="WebLogic Server" && \
+    cp /u01/rda_lin64 /u01/oracle/oracle_common/rda/engine && \
+    cp /u01/rda.cfg /u01/oracle/oracle_common/rda/engine && \
     rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file && \
+    rm -rf /u01/rda.cfg /u01/rda_lin64 && \
     rm -rf /u01/oracle/cfgtoollogs
 
 # Final image stage
@@ -94,6 +97,7 @@ COPY --from=builder --chown=oracle:oracle /u01 /u01
 COPY container-scripts/createAndStartEmptyDomain.sh container-scripts/create-wls-domain.py /u01/oracle/
 
 RUN chmod +xr $SCRIPT_FILE && \
+    chown oracle:oracle -R /u01 && \
     chown oracle:oracle -R /u01/oracle/createAndStartEmptyDomain.sh && \
     chown oracle:oracle -R /u01/oracle/create-wls-domain.py
 

--- a/OracleWebLogic/dockerfiles/12.2.1.4/Dockerfile.slim
+++ b/OracleWebLogic/dockerfiles/12.2.1.4/Dockerfile.slim
@@ -96,6 +96,7 @@ COPY --from=builder --chown=oracle:oracle /u01 /u01
 COPY container-scripts/createAndStartEmptyDomain.sh container-scripts/create-wls-domain.py /u01/oracle/
 
 RUN chmod +xr $SCRIPT_FILE && \
+    chown oracle:oracle -R /u01 && \
     chown oracle:oracle -R /u01/oracle/createAndStartEmptyDomain.sh && \
     chown oracle:oracle -R /u01/oracle/create-wls-domain.py
 

--- a/OracleWebLogic/dockerfiles/12.2.1.4/README.md
+++ b/OracleWebLogic/dockerfiles/12.2.1.4/README.md
@@ -2,6 +2,8 @@ Oracle WebLogic Server on Docker
 =================================
 These Docker configurations have been used to create the Oracle WebLogic Server (WLS) image. Providing this WLS image facilitates the configuration and environment setup for DevOps users. This project includes the installation and creation of an empty WebLogic Server domain (an Administration Server only). These Oracle WebLogic Server 12.2.1.4 images are based on Oracle Linux and Oracle JRE 8 (Server).
 
+The WebLogic Server install image allows you to run a WebLogic multi-server domain/cluster or a WebLogic single server domain.  This makes it extremely simple to deploy applications and any resource the application might need.
+
 The certification of Oracle WebLogic Server on Docker does not require the use of any file presented in this repository. Customers and users are welcome to use them as starters, and customize, tweak, or create from scratch, new scripts and Dockerfiles.
 
 For more information on the certification, please see the [Oracle WebLogic Server on Docker certification whitepaper](http://www.oracle.com/technetwork/middleware/weblogic/overview/weblogic-server-docker-containers-2491959.pdf) and [The WebLogic Server Blog](https://blogs.oracle.com/WebLogicServer/) for updates.

--- a/OracleWebLogic/dockerfiles/14.1.1.0/Checksum.developer
+++ b/OracleWebLogic/dockerfiles/14.1.1.0/Checksum.developer
@@ -1,0 +1,6 @@
+# Download WebLogic Server Quick Installer 12.2.1.4
+# 
+# - http://www.oracle.com/technetwork/middleware/weblogic/downloads/wls-for-dev-1703574.html 
+#
+8f88d91600ecb6826a91a3b72f832c6a fmw_12.2.1.4.0_wls_quick_Disk1_1of1.zip
+

--- a/OracleWebLogic/dockerfiles/14.1.1.0/Checksum.generic
+++ b/OracleWebLogic/dockerfiles/14.1.1.0/Checksum.generic
@@ -1,0 +1,6 @@
+# Download WebLogic Server Generic Installer 12.2.1.4
+# 
+# - http://www.oracle.com/technetwork/middleware/weblogic/downloads/wls-for-dev-1703574.html 
+#
+4198256da12e06841611d9c1a1ab85eb fmw_12.2.1.4.0_wls_Disk1_1of1.zip
+

--- a/OracleWebLogic/dockerfiles/14.1.1.0/Checksum.slim
+++ b/OracleWebLogic/dockerfiles/14.1.1.0/Checksum.slim
@@ -1,0 +1,5 @@
+# Download WebLogic Server Slim Installer 12.2.1.4
+# 
+# - http://www.oracle.com/technetwork/middleware/weblogic/downloads/wls-for-dev-1703574.html 
+#
+df55639e00817308be249af5aa602bfb fmw_12.2.1.4.0_wls_quick_slim_Disk1_1of1.zip

--- a/OracleWebLogic/dockerfiles/14.1.1.0/Dockerfile.developer-11
+++ b/OracleWebLogic/dockerfiles/14.1.1.0/Dockerfile.developer-11
@@ -1,0 +1,109 @@
+#Copyright (c) 2014-2019 Oracle and/or its affiliates. All rights reserved.
+#
+#Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+# ORACLE DOCKERFILES PROJECT
+# --------------------------
+# This is the Dockerfile for WebLogic 14.1.10 Quick Install Distro
+#
+# REQUIRED FILES TO BUILD THIS IMAGE
+# ----------------------------------
+# (1) fmw_14.1.10.0_wls_quick_Disk1_1of1.zip
+#     Download the Developer Quick installer from http://www.oracle.com/technetwork/middleware/weblogic/downloads/wls-for-dev-1703574.html
+#
+# (2) server-jre-8uXX-linux-x64.tar.gz
+#     Download from http://www.oracle.com/technetwork/java/javase/downloads/server-jre8-downloads-2133154.html
+#
+# HOW TO BUILD THIS IMAGE
+# -----------------------
+# Put all downloaded files in the same directory as this Dockerfile
+# Run:
+#      $ docker build -f Dockerfile.developer -t oracle/weblogic:14.1.10-developer .
+#
+# IMPORTANT
+# ---------
+# The resulting image of this Dockerfile contains a WLS Empty Domain.
+#
+# From the OIracle Docker GitHub Project
+# --------------------------------------
+FROM oracle/jdk:11 as builder
+
+# Maintainer
+# ----------
+MAINTAINER Monica Riccelli <monica.riccelli@oracle.com>
+
+# Common environment variables required for this build (do NOT change)
+# --------------------------------------------------------------------
+ENV ORACLE_HOME=/u01/oracle \
+    USER_MEM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
+    PATH=$PATH:${JAVA_HOME}/bin:/u01/oracle/oracle_common/common/bin:/u01/oracle/wlserver/common/bin
+
+# Setup filesystem and oracle user
+# Adjust file permissions, go to /u01 as user 'oracle' to proceed with WLS installation
+# ------------------------------------------------------------
+RUN mkdir -p /u01 && \
+    chmod a+xr /u01 && \
+    useradd -b /u01 -d /u01/oracle -m -s /bin/bash oracle
+
+# Environment variables required for this build (do NOT change)
+# -------------------------------------------------------------
+# ENV FMW_PKG=fmw_14.1.1.0.0_wls_quick_Disk1_1of1.zip \
+ENV  FMW_JAR=fmw_14.1.1.0.0_wls_quick_generic.jar
+
+# Copy packages
+# -------------
+# COPY $FMW_PKG install.file oraInst.loc /u01/
+COPY $FMW_JAR install.file oraInst.loc /u01/
+RUN chown oracle:oracle -R /u01
+
+# Install
+# ------------------------------------------------------------
+USER oracle
+#RUN cd /u01 && ${JAVA_HOME}/bin/jar xf /u01/$FMW_PKG && cd - && \
+RUN cd /u01 && cd - && \
+    ${JAVA_HOME}/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME && \
+#    rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file && \
+    rm /u01/$FMW_JAR /u01/oraInst.loc /u01/install.file && \
+    rm -rf /u01/oracle/cfgtoollogs
+
+# Final image stage
+FROM oracle/jdk:11
+
+ENV ORACLE_HOME=/u01/oracle \
+    USER_MEM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
+    SCRIPT_FILE=/u01/oracle/createAndStartEmptyDomain.sh \
+    PATH=$PATH:${JAVA_HOME}/bin:/u01/oracle/oracle_common/common/bin:/u01/oracle/wlserver/common/bin
+
+# Domain and Server environment variables
+# ------------------------------------------------------------
+ENV DOMAIN_NAME="${DOMAIN_NAME:-base_domain}" \
+    ADMIN_LISTEN_PORT="${ADMIN_LISTEN_PORT:-7001}"  \
+    ADMIN_NAME="${ADMIN_NAME:-AdminServer}" \
+    DEBUG_FLAG=true \
+    PRODUCTION_MODE=dev \
+    ADMINISTRATION_PORT_ENABLED="${ADMINISTRATION_PORT_ENABLED:-true}" \
+    ADMINISTRATION_PORT="${ADMINISTRATION_PORT:-9002}"
+
+# Setup filesystem and oracle user
+# Adjust file permissions, go to /u01 as user 'oracle' to proceed with WLS installation
+# ------------------------------------------------------------
+RUN mkdir -p /u01 && \
+    chmod a+xr /u01 && \
+    useradd -b /u01 -d /u01/oracle -m -s /bin/bash oracle
+
+COPY --from=builder --chown=oracle:oracle /u01 /u01
+
+# Copy scripts
+#-------------
+COPY container-scripts/createAndStartEmptyDomain.sh container-scripts/create-wls-domain.py /u01/oracle/
+
+RUN chmod +xr $SCRIPT_FILE && \
+    chown oracle:oracle -R /u01/oracle/createAndStartEmptyDomain.sh && \
+    chown oracle:oracle -R /u01/oracle/create-wls-domain.py
+
+USER oracle
+
+WORKDIR ${ORACLE_HOME}
+
+# Define default command to start script.
+CMD ["/u01/oracle/createAndStartEmptyDomain.sh"]

--- a/OracleWebLogic/dockerfiles/14.1.1.0/Dockerfile.developer-8
+++ b/OracleWebLogic/dockerfiles/14.1.1.0/Dockerfile.developer-8
@@ -1,0 +1,109 @@
+#Copyright (c) 2014-2019 Oracle and/or its affiliates. All rights reserved.
+#
+#Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+# ORACLE DOCKERFILES PROJECT
+# --------------------------
+# This is the Dockerfile for WebLogic 14.1.10 Quick Install Distro
+#
+# REQUIRED FILES TO BUILD THIS IMAGE
+# ----------------------------------
+# (1) fmw_14.1.10.0_wls_quick_Disk1_1of1.zip
+#     Download the Developer Quick installer from http://www.oracle.com/technetwork/middleware/weblogic/downloads/wls-for-dev-1703574.html
+#
+# (2) server-jre-8uXX-linux-x64.tar.gz
+#     Download from http://www.oracle.com/technetwork/java/javase/downloads/server-jre8-downloads-2133154.html
+#
+# HOW TO BUILD THIS IMAGE
+# -----------------------
+# Put all downloaded files in the same directory as this Dockerfile
+# Run:
+#      $ docker build -f Dockerfile.developer -t oracle/weblogic:14.1.10-developer .
+#
+# IMPORTANT
+# ---------
+# The resulting image of this Dockerfile contains a WLS Empty Domain.
+#
+# From the OIracle Docker GitHub Project
+# --------------------------------------
+FROM oracle/serverjre:8 as builder
+
+# Maintainer
+# ----------
+MAINTAINER Monica Riccelli <monica.riccelli@oracle.com>
+
+# Common environment variables required for this build (do NOT change)
+# --------------------------------------------------------------------
+ENV ORACLE_HOME=/u01/oracle \
+    USER_MEM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
+    PATH=$PATH:${JAVA_HOME}/bin:/u01/oracle/oracle_common/common/bin:/u01/oracle/wlserver/common/bin
+
+# Setup filesystem and oracle user
+# Adjust file permissions, go to /u01 as user 'oracle' to proceed with WLS installation
+# ------------------------------------------------------------
+RUN mkdir -p /u01 && \
+    chmod a+xr /u01 && \
+    useradd -b /u01 -d /u01/oracle -m -s /bin/bash oracle
+
+# Environment variables required for this build (do NOT change)
+# -------------------------------------------------------------
+# ENV FMW_PKG=fmw_14.1.1.0.0_wls_quick_Disk1_1of1.zip \
+ENV  FMW_JAR=fmw_14.1.1.0.0_wls_quick_generic.jar
+
+# Copy packages
+# -------------
+# COPY $FMW_PKG install.file oraInst.loc /u01/
+COPY $FMW_JAR install.file oraInst.loc /u01/
+RUN chown oracle:oracle -R /u01
+
+# Install
+# ------------------------------------------------------------
+USER oracle
+#RUN cd /u01 && ${JAVA_HOME}/bin/jar xf /u01/$FMW_PKG && cd - && \
+RUN cd /u01 && cd - && \
+    ${JAVA_HOME}/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME && \
+#    rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file && \
+    rm /u01/$FMW_JAR /u01/oraInst.loc /u01/install.file && \
+    rm -rf /u01/oracle/cfgtoollogs
+
+# Final image stage
+FROM oracle/serverjre:8
+
+ENV ORACLE_HOME=/u01/oracle \
+    USER_MEM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
+    SCRIPT_FILE=/u01/oracle/createAndStartEmptyDomain.sh \
+    PATH=$PATH:${JAVA_HOME}/bin:/u01/oracle/oracle_common/common/bin:/u01/oracle/wlserver/common/bin
+
+# Domain and Server environment variables
+# ------------------------------------------------------------
+ENV DOMAIN_NAME="${DOMAIN_NAME:-base_domain}" \
+    ADMIN_LISTEN_PORT="${ADMIN_LISTEN_PORT:-7001}"  \
+    ADMIN_NAME="${ADMIN_NAME:-AdminServer}" \
+    DEBUG_FLAG=true \
+    PRODUCTION_MODE=dev \
+    ADMINISTRATION_PORT_ENABLED="${ADMINISTRATION_PORT_ENABLED:-true}" \
+    ADMINISTRATION_PORT="${ADMINISTRATION_PORT:-9002}"
+
+# Setup filesystem and oracle user
+# Adjust file permissions, go to /u01 as user 'oracle' to proceed with WLS installation
+# ------------------------------------------------------------
+RUN mkdir -p /u01 && \
+    chmod a+xr /u01 && \
+    useradd -b /u01 -d /u01/oracle -m -s /bin/bash oracle
+
+COPY --from=builder --chown=oracle:oracle /u01 /u01
+
+# Copy scripts
+#-------------
+COPY container-scripts/createAndStartEmptyDomain.sh container-scripts/create-wls-domain.py /u01/oracle/
+
+RUN chmod +xr $SCRIPT_FILE && \
+    chown oracle:oracle -R /u01/oracle/createAndStartEmptyDomain.sh && \
+    chown oracle:oracle -R /u01/oracle/create-wls-domain.py
+
+USER oracle
+
+WORKDIR ${ORACLE_HOME}
+
+# Define default command to start script.
+CMD ["/u01/oracle/createAndStartEmptyDomain.sh"]

--- a/OracleWebLogic/dockerfiles/14.1.1.0/Dockerfile.generic-11
+++ b/OracleWebLogic/dockerfiles/14.1.1.0/Dockerfile.generic-11
@@ -1,0 +1,108 @@
+#Copyright (c) 2014-2019 Oracle and/or its affiliates. All rights reserved.
+#
+#Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+# ORACLE DOCKERFILES PROJECT
+# --------------------------
+# This is the Dockerfile for Oracle WebLogic Server 14.1.1.0 Generic Distro
+#
+# REQUIRED FILES TO BUILD THIS IMAGE
+# ----------------------------------
+# (1) fmw_14.1.1.0.0_wls_Disk1_1of1.zip
+#     Download the Generic installer from http://www.oracle.com/technetwork/middleware/weblogic/downloads/wls-for-dev-1703574.html
+#
+# (2) server-jre-8uXX-linux-x64.tar.gz
+#     Download from http://www.oracle.com/technetwork/java/javase/downloads/server-jre8-downloads-2133154.html
+#
+# HOW TO BUILD THIS IMAGE
+# -----------------------
+# Put all downloaded files in the same directory as this Dockerfile
+# Run:
+#      $ docker build -f Dockerfile.generic -t oracle/weblogic:14.1.1.0-generic .
+#
+# IMPORTANT
+# ---------
+# The resulting image of this Dockerfile contains a WLS Empty Domain.
+#
+# From the OIracle Docker GitHub Project
+# --------------------------------------
+FROM oracle/jdk:11 as builder
+
+# Maintainer
+# ----------
+MAINTAINER Monica Riccelli <monica.riccelli@oracle.com>
+
+# Common environment variables required for this build (do NOT change)
+# --------------------------------------------------------------------
+ENV ORACLE_HOME=/u01/oracle \
+    USER_MEM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
+    PATH=$PATH:${JAVA_HOME}/bin:/u01/oracle/oracle_common/common/bin:/u01/oracle/wlserver/common/bin
+
+# Setup filesystem and oracle user
+# Adjust file permissions, go to /u01 as user 'oracle' to proceed with WLS installation
+# ------------------------------------------------------------
+RUN mkdir -p /u01 && \
+    chmod a+xr /u01 && \
+    useradd -b /u01 -d /u01/oracle -m -s /bin/bash oracle
+
+# Environment variables required for this build (do NOT change)
+# -------------------------------------------------------------
+# ENV FMW_PKG=fmw_14.1.1.0.0_wls_Disk1_1of1.zip \
+ENV FMW_JAR=fmw_14.1.1.0.0_wls_generic.jar
+
+# Copy packages
+# -------------
+# COPY $FMW_PKG install.file oraInst.loc /u01/
+COPY $FMW_JAR install.file oraInst.loc /u01/
+RUN chown oracle:oracle -R /u01
+
+# Install
+# ------------------------------------------------------------
+USER oracle
+
+# RUN cd /u01 && ${JAVA_HOME}/bin/jar xf /u01/$FMW_PKG && cd - && \
+RUN cd /u01  && cd - && \
+    ${JAVA_HOME}/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME INSTALL_TYPE="WebLogic Server" && \
+#    rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file && \
+    rm /u01/$FMW_JAR /u01/oraInst.loc /u01/install.file && \
+    rm -rf /u01/oracle/cfgtoollogs
+
+# Final image stage
+FROM oracle/jdk:11
+
+ENV ORACLE_HOME=/u01/oracle \
+    USER_MEM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
+    SCRIPT_FILE=/u01/oracle/createAndStartEmptyDomain.sh \
+    PATH=$PATH:${JAVA_HOME}/bin:/u01/oracle/oracle_common/common/bin:/u01/oracle/wlserver/common/bin
+
+# Domain and Server environment variables
+# ------------------------------------------------------------
+ENV DOMAIN_NAME="${DOMAIN_NAME:-base_domain}" \
+    ADMIN_LISTEN_PORT="${ADMIN_LISTEN_PORT:-7001}" \
+    ADMIN_NAME="${ADMIN_NAME:-AdminServer}" \
+    ADMINISTRATION_PORT_ENABLED="${ADMINISTRATION_PORT_ENABLED:-true}" \
+    ADMINISTRATION_PORT="${ADMINISTRATION_PORT:-9002}"
+
+# Setup filesystem and oracle user
+# Adjust file permissions, go to /u01 as user 'oracle' to proceed with WLS installation
+# ------------------------------------------------------------
+RUN mkdir -p /u01 && \
+    chmod a+xr /u01 && \
+    useradd -b /u01 -d /u01/oracle -m -s /bin/bash oracle
+
+COPY --from=builder --chown=oracle:oracle /u01 /u01
+
+# Copy scripts
+#-------------
+COPY container-scripts/createAndStartEmptyDomain.sh container-scripts/create-wls-domain.py /u01/oracle/
+
+RUN chmod +xr $SCRIPT_FILE && \
+    chown oracle:oracle -R /u01/oracle/createAndStartEmptyDomain.sh && \
+    chown oracle:oracle -R /u01/oracle/create-wls-domain.py
+
+USER oracle
+
+WORKDIR ${ORACLE_HOME}
+
+# Define default command to start script.
+CMD ["/u01/oracle/createAndStartEmptyDomain.sh"]

--- a/OracleWebLogic/dockerfiles/14.1.1.0/Dockerfile.generic-8
+++ b/OracleWebLogic/dockerfiles/14.1.1.0/Dockerfile.generic-8
@@ -1,0 +1,108 @@
+#Copyright (c) 2014-2019 Oracle and/or its affiliates. All rights reserved.
+#
+#Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+# ORACLE DOCKERFILES PROJECT
+# --------------------------
+# This is the Dockerfile for Oracle WebLogic Server 14.1.1.0 Generic Distro
+#
+# REQUIRED FILES TO BUILD THIS IMAGE
+# ----------------------------------
+# (1) fmw_14.1.1.0.0_wls_Disk1_1of1.zip
+#     Download the Generic installer from http://www.oracle.com/technetwork/middleware/weblogic/downloads/wls-for-dev-1703574.html
+#
+# (2) server-jre-8uXX-linux-x64.tar.gz
+#     Download from http://www.oracle.com/technetwork/java/javase/downloads/server-jre8-downloads-2133154.html
+#
+# HOW TO BUILD THIS IMAGE
+# -----------------------
+# Put all downloaded files in the same directory as this Dockerfile
+# Run:
+#      $ docker build -f Dockerfile.generic -t oracle/weblogic:14.1.1.0-generic .
+#
+# IMPORTANT
+# ---------
+# The resulting image of this Dockerfile contains a WLS Empty Domain.
+#
+# From the OIracle Docker GitHub Project
+# --------------------------------------
+FROM oracle/serverjre:8 as builder
+
+# Maintainer
+# ----------
+MAINTAINER Monica Riccelli <monica.riccelli@oracle.com>
+
+# Common environment variables required for this build (do NOT change)
+# --------------------------------------------------------------------
+ENV ORACLE_HOME=/u01/oracle \
+    USER_MEM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
+    PATH=$PATH:${JAVA_HOME}/bin:/u01/oracle/oracle_common/common/bin:/u01/oracle/wlserver/common/bin
+
+# Setup filesystem and oracle user
+# Adjust file permissions, go to /u01 as user 'oracle' to proceed with WLS installation
+# ------------------------------------------------------------
+RUN mkdir -p /u01 && \
+    chmod a+xr /u01 && \
+    useradd -b /u01 -d /u01/oracle -m -s /bin/bash oracle
+
+# Environment variables required for this build (do NOT change)
+# -------------------------------------------------------------
+# ENV FMW_PKG=fmw_14.1.1.0.0_wls_Disk1_1of1.zip \
+ENV FMW_JAR=fmw_14.1.1.0.0_wls_generic.jar
+
+# Copy packages
+# -------------
+# COPY $FMW_PKG install.file oraInst.loc /u01/
+COPY $FMW_JAR install.file oraInst.loc /u01/
+RUN chown oracle:oracle -R /u01
+
+# Install
+# ------------------------------------------------------------
+USER oracle
+
+# RUN cd /u01 && ${JAVA_HOME}/bin/jar xf /u01/$FMW_PKG && cd - && \
+RUN cd /u01  && cd - && \
+    ${JAVA_HOME}/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME INSTALL_TYPE="WebLogic Server" && \
+#    rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file && \
+    rm /u01/$FMW_JAR /u01/oraInst.loc /u01/install.file && \
+    rm -rf /u01/oracle/cfgtoollogs
+
+# Final image stage
+FROM oracle/serverjre:8
+
+ENV ORACLE_HOME=/u01/oracle \
+    USER_MEM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
+    SCRIPT_FILE=/u01/oracle/createAndStartEmptyDomain.sh \
+    PATH=$PATH:${JAVA_HOME}/bin:/u01/oracle/oracle_common/common/bin:/u01/oracle/wlserver/common/bin
+
+# Domain and Server environment variables
+# ------------------------------------------------------------
+ENV DOMAIN_NAME="${DOMAIN_NAME:-base_domain}" \
+    ADMIN_LISTEN_PORT="${ADMIN_LISTEN_PORT:-7001}" \
+    ADMIN_NAME="${ADMIN_NAME:-AdminServer}" \
+    ADMINISTRATION_PORT_ENABLED="${ADMINISTRATION_PORT_ENABLED:-true}" \
+    ADMINISTRATION_PORT="${ADMINISTRATION_PORT:-9002}"
+
+# Setup filesystem and oracle user
+# Adjust file permissions, go to /u01 as user 'oracle' to proceed with WLS installation
+# ------------------------------------------------------------
+RUN mkdir -p /u01 && \
+    chmod a+xr /u01 && \
+    useradd -b /u01 -d /u01/oracle -m -s /bin/bash oracle
+
+COPY --from=builder --chown=oracle:oracle /u01 /u01
+
+# Copy scripts
+#-------------
+COPY container-scripts/createAndStartEmptyDomain.sh container-scripts/create-wls-domain.py /u01/oracle/
+
+RUN chmod +xr $SCRIPT_FILE && \
+    chown oracle:oracle -R /u01/oracle/createAndStartEmptyDomain.sh && \
+    chown oracle:oracle -R /u01/oracle/create-wls-domain.py
+
+USER oracle
+
+WORKDIR ${ORACLE_HOME}
+
+# Define default command to start script.
+CMD ["/u01/oracle/createAndStartEmptyDomain.sh"]

--- a/OracleWebLogic/dockerfiles/14.1.1.0/Dockerfile.slim-11
+++ b/OracleWebLogic/dockerfiles/14.1.1.0/Dockerfile.slim-11
@@ -1,0 +1,110 @@
+#Copyright (c) 2014-2019 Oracle and/or its affiliates. All rights reserved.
+#
+#Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+# ORACLE DOCKERFILES PROJECT
+# --------------------------
+# This is the Dockerfile for Oracle WebLogic Server 14.1.1.0 Slim Distro
+#
+# REQUIRED FILES TO BUILD THIS IMAGE
+# ----------------------------------
+# (1) fmw_14.1.1.0.0_wls_quick_slim_Disk1_1of1.zip
+#     Download the Slim installer from http://www.oracle.com/technetwork/middleware/weblogic/downloads/wls-for-dev-1703574.html
+#
+# (2) server-jre-8uXX-linux-x64.tar.gz
+#     Download from http://www.oracle.com/technetwork/java/javase/downloads/server-jre8-downloads-2133154.html
+#
+# HOW TO BUILD THIS IMAGE
+# -----------------------
+# Put all downloaded files in the same directory as this Dockerfile
+# Run:
+#      $ docker build -f Dockerfile.slim -t oracle/weblogic:14.1.1.0-slim .
+#
+# IMPORTANT
+# ---------
+# The resulting image of this Dockerfile contains a WLS Empty Domain.
+#
+# From the OIracle Docker GitHub Project
+# ----------------------------------------
+FROM oracle/jdk:11 as builder
+
+# Maintainer
+# ----------
+MAINTAINER Monica Riccelli <monica.riccelli@oracle.com>
+
+# Common environment variables required for this build (do NOT change)
+# --------------------------------------------------------------------
+ENV ORACLE_HOME=/u01/oracle \
+    USER_MEM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
+    PATH=$PATH:${JAVA_HOME}/bin:/u01/oracle/oracle_common/common/bin:/u01/oracle/wlserver/common/bin
+
+# Setup filesystem and oracle user
+# Adjust file permissions, go to /u01 as user 'oracle' to proceed with WLS installation
+# ------------------------------------------------------------
+RUN mkdir -p /u01 && \
+    chmod a+xr /u01 && \
+    useradd -b /u01 -d /u01/oracle -m -s /bin/bash oracle
+
+# Environment variables required for this build (do NOT change)
+# -------------------------------------------------------------
+#ENV FMW_PKG=fmw_14.1.1.0.0_wls_quick_slim_Disk1_1of1.zip \
+ENV FMW_JAR=fmw_14.1.1.0.0_wls_quick_slim.jar
+
+# Copy packages
+# -------------
+#COPY $FMW_PKG install.file oraInst.loc /u01/
+COPY $FMW_JAR install.file oraInst.loc /u01/
+RUN chown oracle:oracle -R /u01
+
+# Install
+# ------------------------------------------------------------
+USER oracle
+
+# RUN cd /u01 && ${JAVA_HOME}/bin/jar xf /u01/$FMW_PKG && cd - && \
+RUN cd /u01 && cd - && \
+    ${JAVA_HOME}/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME && \
+#    rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file && \
+    rm /u01/$FMW_JAR /u01/oraInst.loc /u01/install.file && \
+    rm -rf /u01/oracle/cfgtoollogs
+
+# Final image stage
+FROM oracle/jdk:11
+
+ENV ORACLE_HOME=/u01/oracle \
+    USER_MEM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
+    SCRIPT_FILE=/u01/oracle/createAndStartEmptyDomain.sh \
+    PATH=$PATH:${JAVA_HOME}/bin:/u01/oracle/oracle_common/common/bin:/u01/oracle/wlserver/common/bin
+
+# Domain and Server environment variables
+# ------------------------------------------------------------
+ENV DOMAIN_NAME="${DOMAIN_NAME:-base_domain}" \
+    ADMIN_LISTEN_PORT="${ADMIN_LISTEN_PORT:-7001}" \
+    ADMIN_NAME="${ADMIN_NAME:-AdminServer}" \
+    ADMINISTRATION_PORT_ENABLED="${ADMINISTRATION_PORT_ENABLED:-true}" \
+    ADMINISTRATION_PORT="${ADMINISTRATION_PORT:-9002}" \
+    DEBUG_flag=false \
+    PRODUCTION_MODE=prod
+
+# Setup filesystem and oracle user
+# Adjust file permissions, go to /u01 as user 'oracle' to proceed with WLS installation
+# ------------------------------------------------------------
+RUN mkdir -p /u01 && \
+    chmod a+xr /u01 && \
+    useradd -b /u01 -d /u01/oracle -m -s /bin/bash oracle
+
+COPY --from=builder --chown=oracle:oracle /u01 /u01
+
+# Copy scripts
+#-------------
+COPY container-scripts/createAndStartEmptyDomain.sh container-scripts/create-wls-domain.py /u01/oracle/
+
+RUN chmod +xr $SCRIPT_FILE && \
+    chown oracle:oracle -R /u01/oracle/createAndStartEmptyDomain.sh && \
+    chown oracle:oracle -R /u01/oracle/create-wls-domain.py
+
+USER oracle
+
+WORKDIR ${ORACLE_HOME}
+
+# Define default command to start script.
+CMD ["/u01/oracle/createAndStartEmptyDomain.sh"]

--- a/OracleWebLogic/dockerfiles/14.1.1.0/Dockerfile.slim-8
+++ b/OracleWebLogic/dockerfiles/14.1.1.0/Dockerfile.slim-8
@@ -1,0 +1,110 @@
+#Copyright (c) 2014-2019 Oracle and/or its affiliates. All rights reserved.
+#
+#Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+# ORACLE DOCKERFILES PROJECT
+# --------------------------
+# This is the Dockerfile for Oracle WebLogic Server 14.1.1.0 Slim Distro
+#
+# REQUIRED FILES TO BUILD THIS IMAGE
+# ----------------------------------
+# (1) fmw_14.1.1.0.0_wls_quick_slim_Disk1_1of1.zip
+#     Download the Slim installer from http://www.oracle.com/technetwork/middleware/weblogic/downloads/wls-for-dev-1703574.html
+#
+# (2) server-jre-8uXX-linux-x64.tar.gz
+#     Download from http://www.oracle.com/technetwork/java/javase/downloads/server-jre8-downloads-2133154.html
+#
+# HOW TO BUILD THIS IMAGE
+# -----------------------
+# Put all downloaded files in the same directory as this Dockerfile
+# Run:
+#      $ docker build -f Dockerfile.slim -t oracle/weblogic:14.1.1.0-slim .
+#
+# IMPORTANT
+# ---------
+# The resulting image of this Dockerfile contains a WLS Empty Domain.
+#
+# From the OIracle Docker GitHub Project
+# ----------------------------------------
+FROM oracle/serverjre:8 as builder
+
+# Maintainer
+# ----------
+MAINTAINER Monica Riccelli <monica.riccelli@oracle.com>
+
+# Common environment variables required for this build (do NOT change)
+# --------------------------------------------------------------------
+ENV ORACLE_HOME=/u01/oracle \
+    USER_MEM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
+    PATH=$PATH:${JAVA_HOME}/bin:/u01/oracle/oracle_common/common/bin:/u01/oracle/wlserver/common/bin
+
+# Setup filesystem and oracle user
+# Adjust file permissions, go to /u01 as user 'oracle' to proceed with WLS installation
+# ------------------------------------------------------------
+RUN mkdir -p /u01 && \
+    chmod a+xr /u01 && \
+    useradd -b /u01 -d /u01/oracle -m -s /bin/bash oracle
+
+# Environment variables required for this build (do NOT change)
+# -------------------------------------------------------------
+#ENV FMW_PKG=fmw_14.1.1.0.0_wls_quick_slim_Disk1_1of1.zip \
+ENV FMW_JAR=fmw_14.1.1.0.0_wls_quick_slim.jar
+
+# Copy packages
+# -------------
+#COPY $FMW_PKG install.file oraInst.loc /u01/
+COPY $FMW_JAR install.file oraInst.loc /u01/
+RUN chown oracle:oracle -R /u01
+
+# Install
+# ------------------------------------------------------------
+USER oracle
+
+# RUN cd /u01 && ${JAVA_HOME}/bin/jar xf /u01/$FMW_PKG && cd - && \
+RUN cd /u01 && cd - && \
+    ${JAVA_HOME}/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME && \
+#    rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file && \
+    rm /u01/$FMW_JAR /u01/oraInst.loc /u01/install.file && \
+    rm -rf /u01/oracle/cfgtoollogs
+
+# Final image stage
+FROM oracle/serverjre:8
+
+ENV ORACLE_HOME=/u01/oracle \
+    USER_MEM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
+    SCRIPT_FILE=/u01/oracle/createAndStartEmptyDomain.sh \
+    PATH=$PATH:${JAVA_HOME}/bin:/u01/oracle/oracle_common/common/bin:/u01/oracle/wlserver/common/bin
+
+# Domain and Server environment variables
+# ------------------------------------------------------------
+ENV DOMAIN_NAME="${DOMAIN_NAME:-base_domain}" \
+    ADMIN_LISTEN_PORT="${ADMIN_LISTEN_PORT:-7001}" \
+    ADMIN_NAME="${ADMIN_NAME:-AdminServer}" \
+    ADMINISTRATION_PORT_ENABLED="${ADMINISTRATION_PORT_ENABLED:-true}" \
+    ADMINISTRATION_PORT="${ADMINISTRATION_PORT:-9002}" \
+    DEBUG_flag=false \
+    PRODUCTION_MODE=prod
+
+# Setup filesystem and oracle user
+# Adjust file permissions, go to /u01 as user 'oracle' to proceed with WLS installation
+# ------------------------------------------------------------
+RUN mkdir -p /u01 && \
+    chmod a+xr /u01 && \
+    useradd -b /u01 -d /u01/oracle -m -s /bin/bash oracle
+
+COPY --from=builder --chown=oracle:oracle /u01 /u01
+
+# Copy scripts
+#-------------
+COPY container-scripts/createAndStartEmptyDomain.sh container-scripts/create-wls-domain.py /u01/oracle/
+
+RUN chmod +xr $SCRIPT_FILE && \
+    chown oracle:oracle -R /u01/oracle/createAndStartEmptyDomain.sh && \
+    chown oracle:oracle -R /u01/oracle/create-wls-domain.py
+
+USER oracle
+
+WORKDIR ${ORACLE_HOME}
+
+# Define default command to start script.
+CMD ["/u01/oracle/createAndStartEmptyDomain.sh"]

--- a/OracleWebLogic/dockerfiles/14.1.1.0/README.md
+++ b/OracleWebLogic/dockerfiles/14.1.1.0/README.md
@@ -1,0 +1,100 @@
+Oracle WebLogic Server on Docker
+=================================
+These Docker configurations have been used to create the Oracle WebLogic Server (WLS) image. Providing this WLS image facilitates the configuration and environment setup for DevOps users. This project includes the installation and creation of an empty WebLogic Server domain (an Administration Server only). These Oracle WebLogic Server 14.1.1.0 images are based on Oracle Linux and Oracle JRE 8 (Server) or Oracle JDK 11.
+
+The certification of Oracle WebLogic Server on Docker does not require the use of any file presented in this repository. Customers and users are welcome to use them as starters, and customize, tweak, or create from scratch, new scripts and Dockerfiles.
+
+For more information on the certification, please see the [Oracle WebLogic Server on Docker certification whitepaper](http://www.oracle.com/technetwork/middleware/weblogic/overview/weblogic-server-docker-containers-2491959.pdf) and [The WebLogic Server Blog](https://blogs.oracle.com/WebLogicServer/) for updates.
+
+## How to build and run
+This project offers sample Dockerfiles for Oracle WebLogic Server 12cR2 (14.1.1.0). It provides at least one Dockerfile for the `developer` distribution, a second Dockerfile for the `generic` distribution, and a third Dockerfile for the `slim` distribution.  
+
+1- The WebLogic `generic` image is supported for `development` and `production` deployment of WebLogic configurations using Docker.   It contains the same binaries as those installed by the WebLogic generic installer.  The WebLogic generic image is primarily intended for WebLogic domains managed with the WebLogic Kubernetes Operator, when WLS console-based monitoring, and possibly configuration, is required.  All servers within a domain managed with the Operator will use the same WebLogic image.  Support is also provided for environments where Kubernetes and/or the WebLogic Kubernetes Operator is not being used.
+
+2- The WebLogic `slim` image is supported for `development` and `production` deployment of WebLogic configurations using Docker.  In order to reduce image size, it contains a subset of the binaries included in the WebLogic generic image.   The WebLogic console, WebLogic examples, WebLogic clients, Maven plug-ins and Java DB have been removed - all binaries that remain included are the same as those in the WebLogic generic image.  The WebLogic slim image is primarily intended for WebLogic domains managed with the WebLogic Kubernetes Operator, when WLS console-based monitoring and configuration is not required, and a smaller image size than the generic image is preferred.  If there are requirements to monitor the WebLogic configuration, they should be addressed using Prometheus and Grafana or other alternatives. All servers within a domain managed with the Operator will use the same WebLogic image.  Support is also provided for environments where Kubernetes and/or the WebLogic Kubernetes Operator is not being used.
+
+3- The WebLogic `developer` image is supported for `development` of  WebLogic applications in Docker containers.  In order to reduce image size, it contains a subset of the binaries included in the WebLogic generic image.   WebLogic examples and WLS Console help files have been removed - all binaries that remain included are the same as those in the WebLogic generic image.  The WebLogic developer image is primarily intended to provide a Docker image that is consistent with the WebLogic "quick installers" intended for `development` only.   Production WebLogic domains should use the WebLogic generic or WebLogic slim images.   
+
+
+To assist in building the images, you can use the [`buildDockerImage.sh`](dockerfiles/buildDockerImage.sh) script. See below for instructions and usage.
+
+The `buildDockerImage.sh` script is a utility shell script that performs MD5 checks and is an easy way for beginners to get started. Expert users are welcome to directly call `docker build` with their prefered set of parameters.
+
+### Building Oracle WebLogic Server Docker install images
+**IMPORTANT:** You must download the binary of Oracle WebLogic Server and put it in place (see `.download` files inside `dockerfiles/<version>`).  WebLogic Server 14.1.1.0 supports both Java SE 8 or 11. If you want to run WebLogic Server on Oracle Server JRE 8, you must build the image by using the Dockerfile in [`../../../OracleJava/java8`](https://github.com/oracle/docker-images/tree/master/OracleJava/java-8). There is no longer a Oracle Server JRE for Java SE 11, it is bundled into Oracle JDK 11.  If you want to run images of WebLogic based on the Oracle JDK 11 image, you must build the image by using the Dockerfile in [`../../../OracleJava/java11`](https://github.com/oracle/docker-images/tree/master/OracleJava/java-11).
+
+Before you build, select the version and distribution for which you want to build an image, then download the required packages (see `.download` files) and locate them in the folder of your distribution version of choice. Then, from the `dockerfiles` folder, run the `buildDockerImage.sh` script as root.
+
+        $ sh buildDockerImage.sh
+        Usage: buildDockerImage.sh -v [version] [-d | -g | -m] [-s] [-j]
+        Builds a Docker Image for Oracle WebLogic Server.
+
+        Parameters:
+           -v: version to build. Required.
+           Choose : 14.1.1.0
+           -d: creates image based on 'developer' distribution
+           -g: creates image based on 'generic' distribution
+           -m: creates image based on 'slim' distribution
+           -j: for WebLogic 14.1.1.0 indicate Server JRE 8 or JDK 11
+           -c: enables Docker image layer cache during build
+           -s: skips the MD5 check of packages
+
+        * select one distribution only: -d, -g, or -m
+
+        LICENSE UPL 1.0
+
+        Copyright (c) 2014-2019 Oracle and/or its affiliates. All rights reserved.
+
+**IMPORTANT:** The resulting images will have a single server domain (Administration Server only), by default.
+
+
+  1. To build the `14.1.1.0`image, from `dockerfiles`, call:
+
+        `$ sh buildDockerImage.sh -v 14.1.1.0 -d -j 11`
+
+  2. Verify that you now have this image in place with:
+
+        `$ docker images`
+     
+     If the WebLogic imagte is built extending Oracle Server JRE 8, then the built image will be called oracle/weblogic:14.1.1.0-developer-8
+     If the WebLogic imagte is built extending Oracle JDK 11, then the built image will be called oracle/weblogic:14.1.1.0-developer-11
+     
+
+### Running a single server domain from the image
+The WebLogic Server install image (built above) allows you to run a container with a single WebLogic Server domain.  This makes it extremely simple to deploy applications and any resource the application might need.
+
+#### Providing the Administration Server user name and password
+The user name and password must be supplied in a `domain.properties` file located in a HOST directory that you will map at Docker runtime with the `-v` option to the image directory `/u01/oracle/properties`. The properties file enables the scripts to configure the correct authentication for the WebLogic Server Administration Server.
+
+The format of the `domain.properties` file is key=value pair:
+
+	username=myadminusername
+	password=myadminpassword
+
+**Note**: Oracle recommends that the `domain.properties` file be deleted or secured after the container and the WebLogic Server are started so that the user name and password are not inadvertently exposed.
+
+#### Start the container
+Start a container from the image created in step 1.
+You can override the default values of the following parameters during runtime with the `-e` option:
+
+      * `ADMIN_NAME`                  (default: `AdminServer`)
+      * `ADMIN_LISTEN_PORT`           (default: `7001`)
+      * `DOMAIN_NAME`                 (default: `base_domain`)
+      * `ADMINISTRATION_PORT_ENABLED` (default: `true`)
+      * `ADMINISTRATION_PORT`         (default: `9002`)
+
+**NOTE**: For security, the Administration port 9002 is enabled by default, before running the container in WebLogic 14.1.1.0. If you prefer to not enable the Administration port when you issue the `docker run` command, set `ADMINISTRTATION_PORT_ENABLED` to false. If you intend to run these images in production, then you must change the Production Mode to `production`. When you set the `DOMAIN_NAME`, the `DOMAIN_HOME=/u01/oracle/user_projects/domains/$DOMAIN_NAME`.
+
+	$ docker run -d -p 7001:7001 -p 9002:9002  -v `HOST PATH where the domain.properties file is`:/u01/oracle/properties -e ADMINISTRATION_PORT_ENABLED=true -e DOMAIN_NAME=docker_domain oracle/weblogic:14.1.1.0-developer-11
+
+Run the WLS Administration Console:
+
+        $ docker inspect --format '{{.NetworkSettings.IPAddress}}' <container-name>
+
+In your browser, enter `https://xxx.xx.x.x:9002/console`. Your browser will request that you accept the Security Exception. To avoid the Security Exception, you must update the WebLogic Server SSL configuration with a custom identity certificate.
+
+## Samples for Oracle WebLogic Server domain creation
+To give users an idea of how to create a WebLogic domain and cluster from a custom Dockerfile which extends the WebLogic Server install image, we provide a few samples for 12c versions of the developer distribution. For an example, look at the `12214-domain` sample.
+
+## Copyright
+Copyright (c) 2014, 2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleWebLogic/dockerfiles/14.1.1.0/container-scripts/create-wls-domain.py
+++ b/OracleWebLogic/dockerfiles/14.1.1.0/container-scripts/create-wls-domain.py
@@ -1,0 +1,91 @@
+#Copyright (c) 2014-2018 Oracle and/or its affiliates. All rights reserved.
+#
+#Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+# WebLogic on Docker Default Domain
+#
+# Domain, as defined in DOMAIN_NAME, will be created in this script. Name defaults to 'base_domain'.
+#
+# Since : October, 2014
+# Author: monica.riccelli@oracle.com
+# ==============================================
+domain_name  = os.environ.get("DOMAIN_NAME", "base_domain")
+admin_name  = os.environ.get("ADMIN_NAME", "AdminServer")
+admin_listen_port   = int(os.environ.get("ADMIN_LISTEN_PORT", "7001"))
+domain_path  = '/u01/oracle/user_projects/domains/%s' % domain_name
+production_mode = os.environ.get("PRODUCTION_MODE", "prod")
+administration_port_enabled = os.environ.get("ADMINISTRATION_PORT_ENABLED", "true")
+administration_port = int(os.environ.get("ADMINISTRATION_PORT", "9002"))
+
+print('domain_name                 : [%s]' % domain_name);
+print('admin_listen_port           : [%s]' % admin_listen_port);
+print('domain_path                 : [%s]' % domain_path);
+print('production_mode             : [%s]' % production_mode);
+print('admin name                  : [%s]' % admin_name);
+print('administration_port_enabled : [%s]' % administration_port_enabled);
+print('administration_port         : [%s]' % administration_port);
+
+# Open default domain template
+# ============================
+readTemplate("/u01/oracle/wlserver/common/templates/wls/wls.jar")
+
+set('Name', domain_name)
+setOption('DomainName', domain_name)
+
+# Set Administration Port 
+# =======================
+if administration_port_enabled != "false":
+   set('AdministrationPort', administration_port)
+   set('AdministrationPortEnabled', 'true')
+
+# Disable Admin Console
+# --------------------
+# cmo.setConsoleEnabled(false)
+
+# Configure the Administration Server and SSL port.
+# =================================================
+cd('/Servers/AdminServer')
+set('Name', admin_name)
+set('ListenAddress', '')
+set('ListenPort', admin_listen_port)
+if administration_port_enabled != "false":
+   create('AdminServer','SSL')
+   cd('SSL/AdminServer')
+   set('Enabled', 'True')
+
+# Define the user password for weblogic
+# =====================================
+cd(('/Security/%s/User/weblogic') % domain_name)
+cmo.setName(username)
+cmo.setPassword(password)
+
+# Write the domain and close the domain template
+# ==============================================
+setOption('OverwriteDomain', 'true')
+setOption('ServerStartMode',production_mode)
+
+# Create Node Manager
+# ===================
+#cd('/NMProperties')
+#set('ListenAddress','')
+#set('ListenPort',5556)
+#set('CrashRecoveryEnabled', 'true')
+#set('NativeVersionEnabled', 'true')
+#set('StartScriptEnabled', 'false')
+#set('SecureListener', 'false')
+#set('LogLevel', 'FINEST')
+
+# Set the Node Manager user name and password 
+# ===========================================
+#cd('/SecurityConfiguration/%s' % domain_name)
+#set('NodeManagerUsername', username)
+#set('NodeManagerPasswordEncrypted', password)
+
+# Write Domain
+# ============
+writeDomain(domain_path)
+closeTemplate()
+
+# Exit WLST
+# =========
+exit()

--- a/OracleWebLogic/dockerfiles/14.1.1.0/container-scripts/createAndStartEmptyDomain.sh
+++ b/OracleWebLogic/dockerfiles/14.1.1.0/container-scripts/createAndStartEmptyDomain.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+#Copyright (c) 2014-2018 Oracle and/or its affiliates. All rights reserved.
+#
+#Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+
+# If AdminServer.log does not exists, container is starting for 1st time
+# So it should start NM and also associate with AdminServer
+# Otherwise, only start NM (container restarted)
+########### SIGTERM handler ############
+function _term() {
+   echo "Stopping container."
+   echo "SIGTERM received, shutting down the server!"
+   ${DOMAIN_HOME}/bin/stopWebLogic.sh
+}
+
+########### SIGKILL handler ############
+function _kill() {
+   echo "SIGKILL received, shutting down the server!"
+   kill -9 $childPID
+}
+
+# Set SIGTERM handler
+trap _term SIGTERM
+
+# Set SIGKILL handler
+trap _kill SIGKILL
+
+#Define DOMAIN_HOME
+export DOMAIN_HOME=/u01/oracle/user_projects/domains/$DOMAIN_NAME
+echo "Domain Home is: " $DOMAIN_HOME
+
+ADD_DOMAIN=1
+if [ ! -f ${DOMAIN_HOME}/servers/AdminServer/logs/AdminServer.log ]; then
+    ADD_DOMAIN=0
+fi
+
+mkdir -p $ORACLE_HOME/properties
+# Create Domain only if 1st execution
+if [ $ADD_DOMAIN -eq 0 ]; then
+   PROPERTIES_FILE=/u01/oracle/properties/domain.properties
+   if [ ! -e "$PROPERTIES_FILE" ]; then
+      echo "A properties file with the username and password needs to be supplied."
+      exit
+   fi
+
+   # Get Username
+   USER=`awk '{print $1}' $PROPERTIES_FILE | grep username | cut -d "=" -f2`
+   if [ -z "$USER" ]; then
+      echo "The domain username is blank.  The Admin username must be set in the properties file."
+      exit
+   fi
+   # Get Password
+   PASS=`awk '{print $1}' $PROPERTIES_FILE | grep password | cut -d "=" -f2`
+   if [ -z "$PASS" ]; then
+      echo "The domain password is blank.  The Admin password must be set in the properties file."
+      exit
+   fi
+
+   # Create an empty domain
+   wlst.sh -skipWLSModuleScanning -loadProperties $PROPERTIES_FILE  /u01/oracle/create-wls-domain.py
+   mkdir -p ${DOMAIN_HOME}/servers/AdminServer/security/
+   echo "username=${USER}" >> $DOMAIN_HOME/servers/AdminServer/security/boot.properties
+   echo "password=${PASS}" >> $DOMAIN_HOME/servers/AdminServer/security/boot.properties
+   ${DOMAIN_HOME}/bin/setDomainEnv.sh
+fi
+
+# Start Admin Server and tail the logs
+${DOMAIN_HOME}/startWebLogic.sh
+touch ${DOMAIN_HOME}/servers/AdminServer/logs/AdminServer.log
+tail -f ${DOMAIN_HOME}/servers/AdminServer/logs/AdminServer.log &
+
+childPID=$!
+wait $childPID

--- a/OracleWebLogic/dockerfiles/14.1.1.0/fmw_14.1.1.0.0_wls_Disk1_1of1.zip.download
+++ b/OracleWebLogic/dockerfiles/14.1.1.0/fmw_14.1.1.0.0_wls_Disk1_1of1.zip.download
@@ -1,0 +1,5 @@
+# Download WebLogic Server Generic Installer 12.2.1.4
+#
+# - http://www.oracle.com/technetwork/middleware/weblogic/downloads/wls-for-dev-1703574.html
+#
+4198256da12e06841611d9c1a1ab85eb fmw_12.2.1.4.0_wls_Disk1_1of1.zip

--- a/OracleWebLogic/dockerfiles/14.1.1.0/fmw_14.1.1.0.0_wls_quick_Disk1_1of1.zip.download
+++ b/OracleWebLogic/dockerfiles/14.1.1.0/fmw_14.1.1.0.0_wls_quick_Disk1_1of1.zip.download
@@ -1,0 +1,5 @@
+# Download WebLogic Server Quick Installer 12.2.1.4
+#
+# - http://www.oracle.com/technetwork/middleware/weblogic/downloads/wls-for-dev-1703574.html
+#
+8f88d91600ecb6826a91a3b72f832c6a fmw_12.2.1.4.0_wls_quick_Disk1_1of1.zip

--- a/OracleWebLogic/dockerfiles/14.1.1.0/fmw_14.1.1.0.0_wls_quick_slim_Disk1_1of1.zip.download
+++ b/OracleWebLogic/dockerfiles/14.1.1.0/fmw_14.1.1.0.0_wls_quick_slim_Disk1_1of1.zip.download
@@ -1,0 +1,5 @@
+# Download WebLogic Server Slim Installer 12.2.1.4
+#
+# - http://www.oracle.com/technetwork/middleware/weblogic/downloads/wls-for-dev-1703574.html
+#
+df55639e00817308be249af5aa602bfb fmw_12.2.1.4.0_wls_quick_slim_Disk1_1of1.zip

--- a/OracleWebLogic/dockerfiles/14.1.1.0/install.file
+++ b/OracleWebLogic/dockerfiles/14.1.1.0/install.file
@@ -1,0 +1,12 @@
+# Copyright (c) 2014-2019 Oracle and/or its affiliates. All rights reserved.
+[ENGINE]
+
+#DO NOT CHANGE THIS.
+Response File Version=1.0.0.0.0
+
+[GENERIC]
+
+INSTALL_TYPE=WebLogic Server
+SOFTWARE ONLY TYPE=true
+DECLINE_SECURITY_UPDATES=true
+SECURITY_UPDATES_VIA_MYORACLESUPPORT=false

--- a/OracleWebLogic/dockerfiles/14.1.1.0/oraInst.loc
+++ b/OracleWebLogic/dockerfiles/14.1.1.0/oraInst.loc
@@ -1,0 +1,2 @@
+inventory_loc=/u01/oracle/.inventory
+inst_group=oracle

--- a/OracleWebLogic/dockerfiles/14.1.1.0/properties/domain.properties
+++ b/OracleWebLogic/dockerfiles/14.1.1.0/properties/domain.properties
@@ -1,0 +1,2 @@
+username=myweblogicuser
+password=welcome1

--- a/OracleWebLogic/dockerfiles/buildDockerImage.sh
+++ b/OracleWebLogic/dockerfiles/buildDockerImage.sh
@@ -4,7 +4,7 @@
 # Author: bruno.borges@oracle.com
 # Description: script to build a Docker image for WebLogic
 #
-#Copyright (c) 2014-2018 Oracle and/or its affiliates. All rights reserved.
+#Copyright (c) 2014-2019 Oracle and/or its affiliates. All rights reserved.
 #
 #Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
@@ -12,7 +12,7 @@
 usage() {
 cat << EOF
 
-Usage: buildDockerImage.sh -v [version] [-d | -g | -m ] [-s] [-c]
+Usage: buildDockerImage.sh -v [version] [-d | -g | -m ] [-j] [-s] [-c]
 Builds a Docker Image for Oracle WebLogic.
 
 Parameters:
@@ -20,11 +20,12 @@ Parameters:
        Choose one of: $(for i in $(ls -d */); do echo -n "${i%%/}  "; done)
    -d: creates image based on 'developer' distribution
    -g: creates image based on 'generic' distribution
+   -j: creates a 14.1.1.0 image based on 'JDK 8 or 11' 
    -m: creates image based on 'slim' distribution
    -c: enables Docker image layer cache during build
    -s: skips the MD5 check of packages
 
-* select one distribution only: -d, -g, or -m
+* select one distribution only: -d, -g, -j, or -m
 
 LICENSE UPL 1.0
 
@@ -52,30 +53,41 @@ DEVELOPER=0
 GENERIC=0
 SLIM=0
 VERSION="12.2.1.4"
+JDKVER=8
 SKIPMD5=0
 NOCACHE=true
-while getopts "hcsdgmiv:" optname; do
+while getopts "hsdgmc:j:v:" optname; do
   case "$optname" in
     "h")
       usage
       ;;
     "s")
       SKIPMD5=1
+      echo "Set- Skip md5sum"
       ;;
     "d")
       DEVELOPER=1
+      echo "Set- Distribution:Developer"
       ;;
     "g")
       GENERIC=1
+      echo "Set- Distribution:Generic"
+      ;;
+    "j")
+      JDKVER="$OPTARG"
+      echo "Set- JDK Version $JDKVER"
       ;;
     "m")
       SLIM=1
+      echo "Set- Distribution:Slim"
       ;;
     "v")
       VERSION="$OPTARG"
+      echo "Set- WebLogic's Version $VERSION"
       ;;
     "c")
       NOCACHE=false
+      echo "Set- NOCACHE to false"
       ;;
     *)
     # Should not occur
@@ -98,8 +110,15 @@ else
   exit 1
 fi
 
+# Which JDK FOR VERSION 14.1.1.0
+if [ "$VERSION" == "14.1.1.0" ]; then
+   DIST="$DISTRIBUTION-$JDKVER"
+   echo "Version= $VERSION Distribution= $DIST"
+fi
+
+
 # WebLogic Image Name
-IMAGE_NAME="oracle/weblogic:$VERSION-$DISTRIBUTION"
+IMAGE_NAME="oracle/weblogic:$VERSION-$DIST"
 
 # Go into version folder
 cd $VERSION
@@ -141,7 +160,7 @@ echo "Building image '$IMAGE_NAME' ..."
 
 # BUILD THE IMAGE (replace all environment variables)
 BUILD_START=$(date '+%s')
-docker build --force-rm=$NOCACHE --no-cache=$NOCACHE $PROXY_SETTINGS -t $IMAGE_NAME -f Dockerfile.$DISTRIBUTION . || {
+docker build --force-rm=$NOCACHE --no-cache=$NOCACHE $PROXY_SETTINGS -t $IMAGE_NAME -f Dockerfile.$DIST . || {
   echo "There was an error building the image."
   exit 1
 }
@@ -152,7 +171,7 @@ echo ""
 
 if [ $? -eq 0 ]; then
 cat << EOF
-  WebLogic Docker Image for '$DISTRIBUTION' version $VERSION is ready to be extended:
+  WebLogic Docker Image for '$DIST' version $VERSION is ready to be extended:
 
     --> $IMAGE_NAME
 

--- a/OracleWebLogic/dockerfiles/buildDockerImage.sh
+++ b/OracleWebLogic/dockerfiles/buildDockerImage.sh
@@ -114,6 +114,9 @@ fi
 if [ "$VERSION" == "14.1.1.0" ]; then
    DIST="$DISTRIBUTION-$JDKVER"
    echo "Version= $VERSION Distribution= $DIST"
+else
+   DIST="$DISTRIBUTION"
+   echo "Version= $VERSION Distribution= $DIST"
 fi
 
 
@@ -157,6 +160,7 @@ fi
 # BUILDING THE IMAGE #
 # ################## #
 echo "Building image '$IMAGE_NAME' ..."
+echo "Building image using Dockerfile.'$DIST'"
 
 # BUILD THE IMAGE (replace all environment variables)
 BUILD_START=$(date '+%s')


### PR DESCRIPTION
These are the Dockerfiles for WebLogic Server 14.1.1.0
Oracle WebLogic 14.1.1.0 supports both Oracle Server JRE 8 and Oracle JDK 11.  
-Added Dockerfiles for WLS on JDK 11
-Added Dockerfiles for WLS on Server JRE 8
-Changes to buildDockerImage.sh to take new argument -j 8|11
-Edits to README.md
-Dockerfile for JDK 11

****Please do not merge this PR - we need to time it with GA of WebLogic 14.1.1.0