### PR TITLE
Read JAVA_OPTIONS fix

### DIFF
--- a/OracleWebLogic/samples/12213-domain-home-in-image/container-scripts/startAdminServer.sh
+++ b/OracleWebLogic/samples/12213-domain-home-in-image/container-scripts/startAdminServer.sh
@@ -88,7 +88,7 @@ if [ -z "${PASS}" ]; then
 fi
 
 #Define Java Options
-JAVA_OPTIONS=`awk '{print $1}' ${SEC_PROPERTIES_FILE} | grep ^JAVA_OPTIONS= | cut -d "=" -f2`
+JAVA_OPTIONS=`awk '{print $1}' ${SEC_PROPERTIES_FILE} | grep ^JAVA_OPTIONS= | cut -d "=" -f2-`
 if [ -z "${JAVA_OPTIONS}" ]; then
    JAVA_OPTIONS="-Dweblogic.StdoutDebugEnabled=false"
 fi


### PR DESCRIPTION
If you add JVM arguments of type -Dkey1=value1 -D key2=value2... in JAVA_OPTIONS property of file security.properties, only the "-Dkey1" part gets captured and added as JVM arguments when starting the server. Adding the "-" to the "-f2" argument fix the problem because you get the rest of the value. This could also be applyed to password value because equals sign could be part of a password.