### PR TITLE
Fixed documentation extending JRE and leave *.loc file

### DIFF
--- a/OracleFMWInfrastructure/dockerfiles/12.2.1.3/Dockerfile
+++ b/OracleFMWInfrastructure/dockerfiles/12.2.1.3/Dockerfile
@@ -16,7 +16,8 @@
 # ---------
 # The resulting image of this Dockerfile contains a FMW Infra Base Domain.
 #
-# From
+# Extend base JRE image
+# You must build the image by using the Dockerfile in GitHub project `../../../OracleJava/java8`
 # -------------------------
 FROM oracle/serverjre:8 as builder
 
@@ -52,7 +53,7 @@ RUN chown oracle:oracle -R /u01
 USER oracle
 RUN cd /u01 && $JAVA_HOME/bin/jar xf /u01/$FMW_PKG && cd - && \
     $JAVA_HOME/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME INSTALL_TYPE="WebLogic Server" && \
-    rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file
+    rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/install.file
 
 # Final image stage
 FROM oracle/serverjre:8

--- a/OracleFMWInfrastructure/dockerfiles/12.2.1.3/Dockerfile
+++ b/OracleFMWInfrastructure/dockerfiles/12.2.1.3/Dockerfile
@@ -18,7 +18,7 @@
 #
 # Extend base JRE image
 # You must build the image by using the Dockerfile in GitHub project `../../../OracleJava/java8`
-# -------------------------
+# ----------------------------------------------------------------------------------------------
 FROM oracle/serverjre:8 as builder
 
 # Maintainer

--- a/OracleFMWInfrastructure/dockerfiles/12.2.1.4/Dockerfile
+++ b/OracleFMWInfrastructure/dockerfiles/12.2.1.4/Dockerfile
@@ -16,8 +16,9 @@
 # ---------
 # The resulting image of this Dockerfile contains a FMW Infra Base Domain.
 #
-# From
-# -------------------------
+# Extend base JRE image
+# You must build the image by using the Dockerfile in GitHub project `../../../OracleJava/java8`
+# ----------------------------------------------------------------------------------------------
 FROM oracle/serverjre:8 as builder
 
 # Maintainer
@@ -52,7 +53,7 @@ RUN chown oracle:oracle -R /u01
 USER oracle
 RUN cd /u01 && $JAVA_HOME/bin/jar xf /u01/$FMW_PKG && cd - && \
     $JAVA_HOME/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME INSTALL_TYPE="WebLogic Server" && \
-    rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file && \
+    rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/install.file && \
     rm -rf /u01/oracle/cfgtoollogs
 
 # Final image stage

--- a/OracleWebLogic/dockerfiles/12.2.1.3/Dockerfile.developer
+++ b/OracleWebLogic/dockerfiles/12.2.1.3/Dockerfile.developer
@@ -25,8 +25,8 @@
 # The resulting image of this Dockerfile contains a WLS Empty Domain.
 #
 # Extend base JRE image
-# You must build the image by using the Dockerfile in `../../../OracleJava/java8`
-# -------------------------
+# You must build the image by using the Dockerfile in GitHub project `../../../OracleJava/java8`
+# ----------------------------------------------------------------------------------------------
 FROM oracle/serverjre:8
 
 # Maintainer

--- a/OracleWebLogic/dockerfiles/12.2.1.3/Dockerfile.developer
+++ b/OracleWebLogic/dockerfiles/12.2.1.3/Dockerfile.developer
@@ -24,8 +24,8 @@
 # ---------
 # The resulting image of this Dockerfile contains a WLS Empty Domain.
 #
-# Pull base image
-# From the Oracle Registry
+# Extend base JRE image
+# You must build the image by using the Dockerfile in `../../../OracleJava/java8`
 # -------------------------
 FROM oracle/serverjre:8
 
@@ -79,7 +79,7 @@ RUN  chown oracle:oracle -R /u01  && \
 USER oracle
 RUN cd /u01 && ${JAVA_HOME}/bin/jar xf /u01/$FMW_PKG && cd - && \
     ${JAVA_HOME}/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME && \
-    rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file && \
+    rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/install.file && \
     rm -rf /u01/oracle/cfgtoollogs
 
 WORKDIR ${ORACLE_HOME}

--- a/OracleWebLogic/dockerfiles/12.2.1.3/Dockerfile.generic
+++ b/OracleWebLogic/dockerfiles/12.2.1.3/Dockerfile.generic
@@ -24,8 +24,9 @@
 # ---------
 # The resulting image of this Dockerfile contains a WLS Empty Domain.
 #
-# Pull base image
-# From the Oracle Registry
+# Extend base JRE image
+# You must either build the image by using the Dockerfile in `../../../OracleJava/java8` or                                                                          
+# pull the latest image from the Oracle Container Registry and tag it as `oracle/serverjre:8`
 # -------------------------
 FROM oracle/serverjre:8
 
@@ -77,7 +78,7 @@ USER oracle
 RUN cd /u01 && ${JAVA_HOME}/bin/jar xf /u01/$FMW_PKG && cd - && \
     ls /u01 && \
     ${JAVA_HOME}/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME INSTALL_TYPE="WebLogic Server" && \
-    rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file && \
+    rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/install.file && \
     rm -rf /u01/oracle/cfgtoollogs
 
 WORKDIR ${ORACLE_HOME}

--- a/OracleWebLogic/dockerfiles/12.2.1.3/Dockerfile.generic
+++ b/OracleWebLogic/dockerfiles/12.2.1.3/Dockerfile.generic
@@ -25,9 +25,8 @@
 # The resulting image of this Dockerfile contains a WLS Empty Domain.
 #
 # Extend base JRE image
-# You must either build the image by using the Dockerfile in `../../../OracleJava/java8` or                                                                          
-# pull the latest image from the Oracle Container Registry and tag it as `oracle/serverjre:8`
-# -------------------------
+# You must build the image by using the Dockerfile in the GitHub project `../../../OracleJava/java8`
+# --------------------------------------------------------------------------------------------------
 FROM oracle/serverjre:8
 
 # Maintainer

--- a/OracleWebLogic/dockerfiles/12.2.1.3/README.md
+++ b/OracleWebLogic/dockerfiles/12.2.1.3/README.md
@@ -12,7 +12,7 @@ This project offers sample Dockerfiles for Oracle WebLogic Server 12cR2 (12.2.1.
 The `buildDockerImage.sh` script is a utility shell script that performs MD5 checks and is an easy way for beginners to get started. Expert users are welcome to directly call `docker build` with their prefered set of parameters.
 
 ### Building Oracle WebLogic Server Docker install images
-**IMPORTANT:** You must download the binary of Oracle WebLogic Server and put it in place (see `.download` files inside `dockerfiles/<version>`). The WebLogic image extends the Oracle JRE Server 8 image. You must either build the image by using the Dockerfile in [`../../../OracleJava/java8`](https://github.com/oracle/docker-images/tree/master/OracleJava/java-8) or pull the latest image from the [Oracle Container Registry](https://container-registry.oracle.com) or the [Docker Store](https://store.docker.com).
+**IMPORTANT:** You must download the binary of Oracle WebLogic Server and put it in place (see `.download` files inside `dockerfiles/<version>`). The WebLogic image extends the Oracle JRE Server 8 image. You must build the image by using the Dockerfile in [`../../../OracleJava/java8`](https://github.com/oracle/docker-images/tree/master/OracleJava/java-8).
 
 Before you build, select the version and distribution for which you want to build an image, then download the required packages (see `.download` files) and locate them in the folder of your distribution version of choice. Then, from the `dockerfiles` folder, run the `buildDockerImage.sh` script as root.
 

--- a/OracleWebLogic/dockerfiles/12.2.1.4/Dockerfile.developer
+++ b/OracleWebLogic/dockerfiles/12.2.1.4/Dockerfile.developer
@@ -25,9 +25,8 @@
 # The resulting image of this Dockerfile contains a WLS Empty Domain.
 #
 # Extend base JRE image
-# You must either build the image by using the Dockerfile in GitHub project `../../../OracleJava/java8` or                                                                          
-# pull the latest image from the Oracle Container Registry and tag it as `oracle/serverjre:8`
-# --------------------------------------
+# You must build the image by using the Dockerfile in GitHub project `../../../OracleJava/java8`                                                                          
+# ----------------------------------------------------------------------------------------------
 FROM oracle/serverjre:8 as builder
 
 # Maintainer

--- a/OracleWebLogic/dockerfiles/12.2.1.4/Dockerfile.developer
+++ b/OracleWebLogic/dockerfiles/12.2.1.4/Dockerfile.developer
@@ -24,7 +24,9 @@
 # ---------
 # The resulting image of this Dockerfile contains a WLS Empty Domain.
 #
-# From the OIracle Docker GitHub Project
+# Extend base JRE image
+# You must either build the image by using the Dockerfile in GitHub project `../../../OracleJava/java8` or                                                                          
+# pull the latest image from the Oracle Container Registry and tag it as `oracle/serverjre:8`
 # --------------------------------------
 FROM oracle/serverjre:8 as builder
 
@@ -60,7 +62,7 @@ RUN chown oracle:oracle -R /u01
 USER oracle
 RUN cd /u01 && ${JAVA_HOME}/bin/jar xf /u01/$FMW_PKG && cd - && \
     ${JAVA_HOME}/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME && \
-    rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file && \
+    rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/install.file && \
     rm -rf /u01/oracle/cfgtoollogs
 
 # Final image stage

--- a/OracleWebLogic/dockerfiles/12.2.1.4/Dockerfile.generic
+++ b/OracleWebLogic/dockerfiles/12.2.1.4/Dockerfile.generic
@@ -24,7 +24,9 @@
 # ---------
 # The resulting image of this Dockerfile contains a WLS Empty Domain.
 #
-# From the OIracle Docker GitHub Project
+# Extend base JRE image
+# You must either build the image by using the Dockerfile in GitHub project `../../../OracleJava/java8` or
+# pull the latest image from the Oracle Container Registry and tag it as `oracle/serverjre:8`
 # --------------------------------------
 FROM oracle/serverjre:8 as builder
 
@@ -61,7 +63,7 @@ USER oracle
 
 RUN cd /u01 && ${JAVA_HOME}/bin/jar xf /u01/$FMW_PKG && cd - && \
     ${JAVA_HOME}/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME INSTALL_TYPE="WebLogic Server" && \
-    rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file && \
+    rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/install.file && \
     rm -rf /u01/oracle/cfgtoollogs
 
 # Final image stage

--- a/OracleWebLogic/dockerfiles/12.2.1.4/Dockerfile.generic
+++ b/OracleWebLogic/dockerfiles/12.2.1.4/Dockerfile.generic
@@ -25,9 +25,8 @@
 # The resulting image of this Dockerfile contains a WLS Empty Domain.
 #
 # Extend base JRE image
-# You must either build the image by using the Dockerfile in GitHub project `../../../OracleJava/java8` or
-# pull the latest image from the Oracle Container Registry and tag it as `oracle/serverjre:8`
-# --------------------------------------
+# You must build the image by using the Dockerfile in GitHub project `../../../OracleJava/java8`
+# ----------------------------------------------------------------------------------------------
 FROM oracle/serverjre:8 as builder
 
 # Maintainer

--- a/OracleWebLogic/dockerfiles/12.2.1.4/Dockerfile.slim
+++ b/OracleWebLogic/dockerfiles/12.2.1.4/Dockerfile.slim
@@ -24,7 +24,9 @@
 # ---------
 # The resulting image of this Dockerfile contains a WLS Empty Domain.
 #
-# From the OIracle Docker GitHub Project
+# Extend base JRE image
+# You must either build the image by using the Dockerfile in GitHub project `../../../OracleJava/java8` or
+# pull the latest image from the Oracle Container Registry and tag it as `oracle/serverjre:8`
 # ----------------------------------------
 FROM oracle/serverjre:8 as builder
 
@@ -61,7 +63,7 @@ USER oracle
 
 RUN cd /u01 && ${JAVA_HOME}/bin/jar xf /u01/$FMW_PKG && cd - && \
     ${JAVA_HOME}/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME && \
-    rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file && \
+    rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/install.file && \
     rm -rf /u01/oracle/cfgtoollogs
 
 # Final image stage

--- a/OracleWebLogic/dockerfiles/12.2.1.4/Dockerfile.slim
+++ b/OracleWebLogic/dockerfiles/12.2.1.4/Dockerfile.slim
@@ -25,9 +25,8 @@
 # The resulting image of this Dockerfile contains a WLS Empty Domain.
 #
 # Extend base JRE image
-# You must either build the image by using the Dockerfile in GitHub project `../../../OracleJava/java8` or
-# pull the latest image from the Oracle Container Registry and tag it as `oracle/serverjre:8`
-# ----------------------------------------
+# You must build the image by using the Dockerfile in GitHub project `../../../OracleJava/java8`
+# ----------------------------------------------------------------------------------------------
 FROM oracle/serverjre:8 as builder
 
 # Maintainer


### PR DESCRIPTION
Fix  #1435
Do not remove *.loc file it is needed to do OPatch lsinventory 