### PR TITLE
Chown only specific scripts to reduce image size

### DIFF
--- a/OracleWebLogic/dockerfiles/12.2.1.4/Dockerfile.developer
+++ b/OracleWebLogic/dockerfiles/12.2.1.4/Dockerfile.developer
@@ -96,7 +96,7 @@ COPY --from=builder --chown=oracle:oracle /u01 /u01
 COPY container-scripts/createAndStartEmptyDomain.sh container-scripts/create-wls-domain.py /u01/oracle/
 
 RUN chmod +xr $SCRIPT_FILE && \
-    chown oracle:oracle -R /u01
+    chown oracle:oracle $SCRIPT_FILE /u01/oracle/create-wls-domain.py
 
 USER oracle
 

--- a/OracleWebLogic/dockerfiles/12.2.1.4/Dockerfile.generic
+++ b/OracleWebLogic/dockerfiles/12.2.1.4/Dockerfile.generic
@@ -95,7 +95,7 @@ COPY --from=builder --chown=oracle:oracle /u01 /u01
 COPY container-scripts/createAndStartEmptyDomain.sh container-scripts/create-wls-domain.py /u01/oracle/
 
 RUN chmod +xr $SCRIPT_FILE && \
-    chown oracle:oracle -R /u01 
+    chown oracle:oracle $SCRIPT_FILE /u01/oracle/create-wls-domain.py 
 
 USER oracle
 

--- a/OracleWebLogic/dockerfiles/12.2.1.4/Dockerfile.slim
+++ b/OracleWebLogic/dockerfiles/12.2.1.4/Dockerfile.slim
@@ -97,7 +97,7 @@ COPY --from=builder --chown=oracle:oracle /u01 /u01
 COPY container-scripts/createAndStartEmptyDomain.sh container-scripts/create-wls-domain.py /u01/oracle/
 
 RUN chmod +xr $SCRIPT_FILE && \
-    chown oracle:oracle -R /u01
+    chown oracle:oracle $SCRIPT_FILE /u01/oracle/create-wls-domain.py
 
 USER oracle
 


### PR DESCRIPTION
This earlier version performed an unnecessary chown on the entire /u01.  This duplicates the entire layer costing significant image size.