### PR TITLE
Amend Oracle Coherence Docker files to build images that will run on OpenShift

### DIFF
--- a/OracleCoherence/dockerfiles/12.2.1.0.0/Dockerfile.quickinstall
+++ b/OracleCoherence/dockerfiles/12.2.1.0.0/Dockerfile.quickinstall
@@ -27,7 +27,7 @@
 
 # Pull base image
 # ---------------
-FROM oracle/serverjre:8
+FROM oracle/serverjre:8 AS builder
 
 # Maintainer
 # ----------
@@ -43,24 +43,60 @@ ENV FMW_PKG=fmw_12.2.1.0.0_coherence_quick_Disk1_1of1.zip \
 ENV COHERENCE_HOME=$ORACLE_HOME/coherence
 
 RUN mkdir -p /u01 && \
-   useradd -b /u01 -d /u01/oracle -m -s /bin/bash oracle
+   useradd -b /u01 -d /u01/oracle -m -s /bin/bash -u 1000 -g 0 oracle
 
 # Copy files required to build this image
 COPY $FMW_PKG install.file oraInst.loc /u01/
-COPY start.sh                          /start.sh
-COPY extend-cache-config.xml           $COHERENCE_HOME/conf/extend-cache-config.xml
 
-RUN chmod 755 /start.sh && \
-   chmod a+xr /u01 && \
-   chown -R oracle:oracle /u01
+RUN chmod a+xr /u01 && \
+    chown -R oracle:root /u01
 
 USER oracle
 
 # Install and configure Oracle JDK
 # Setup required packages (unzip), filesystem, and oracle user
-# ------------------------------------------------------------
 RUN cd /u01 && $JAVA_HOME/bin/jar xf /u01/$FMW_PKG && cd - && \
     $JAVA_HOME/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME && \
     rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file
+
+# ---------------------------------------------------------------------------
+# Final stage image containing the installed Oracle Home
+FROM oracle/serverjre:8
+
+ENV ORACLE_HOME=/u01/oracle/oracle_home \
+    PATH=$PATH:/usr/java/default/bin:/u01/oracle/oracle_home/oracle_common/common/bin \
+    CONFIG_JVM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
+    COHERENCE_HOME=/u01/oracle/oracle_home/coherence \
+    DEPENDENCY_MODULES=/u01/coherence/thirdparty/lib
+
+# Create the oracle user with the uid 1000
+# Allow the start script to dynamically modify the /etc/passwd file when
+# running in environments that create a dynamic user
+# see: https://docs.okd.io/latest/creating_images/guidelines.html
+RUN mkdir -p /u01 && \
+    mkdir -p /logs && \
+    useradd -b /u01 -d /u01/oracle -m -s /bin/bash -u 1000 -g 0 oracle &&\
+    chmod g=u /etc/passwd
+
+COPY --from=builder /u01/oracle    /u01/oracle
+COPY start.sh                      /start.sh
+COPY extend-cache-config.xml       $COHERENCE_HOME/conf/extend-cache-config.xml
+
+# The directories created below are created with the owner oracle and the group 0 (root)
+# This ensures that the image is compatible with OpenShift which runs containers with a
+# random user that is a member of the root group regardless of the user configured in
+# this Dockerfile.
+# see: https://docs.okd.io/latest/creating_images/guidelines.html
+RUN chgrp -R 0 /u01 && \
+    chmod -R g=u /u01 && \
+    chmod 755 /start.sh && \
+    chgrp -R 0 /start.sh && \
+    chmod -R g=u /start.sh && \
+    chgrp -R 0 /logs && \
+    chmod -R g=u /logs
+
+# The oracle user was added with the uid 1000. We use the uid here rather than the username
+# for OpenShift best practice - see https://docs.okd.io/latest/creating_images/guidelines.html
+USER 1000
 
 ENTRYPOINT ["/start.sh"]

--- a/OracleCoherence/dockerfiles/12.2.1.0.0/Dockerfile.standalone
+++ b/OracleCoherence/dockerfiles/12.2.1.0.0/Dockerfile.standalone
@@ -27,7 +27,7 @@
 
 # Pull base image
 # ---------------
-FROM oracle/serverjre:8
+FROM oracle/serverjre:8 AS builder
 
 # Maintainer
 # ----------
@@ -43,24 +43,60 @@ ENV FMW_PKG=fmw_12.2.1.0.0_coherence_Disk1_1of1.zip \
 ENV COHERENCE_HOME=$ORACLE_HOME/coherence
 
 RUN mkdir -p /u01 && \
-   useradd -b /u01 -d /u01/oracle -m -s /bin/bash oracle
+   useradd -b /u01 -d /u01/oracle -m -s /bin/bash -u 1000 -g 0 oracle
 
 # Copy files required to build this image
 COPY $FMW_PKG install.file oraInst.loc /u01/
-COPY start.sh                          /start.sh
-COPY extend-cache-config.xml           $COHERENCE_HOME/conf/extend-cache-config.xml
 
-RUN chmod 755 /start.sh && \
-   chmod a+xr /u01 && \
-   chown -R oracle:oracle /u01
+RUN chmod a+xr /u01 && \
+    chown -R oracle:root /u01
 
 USER oracle
 
 # Install and configure Oracle JDK
 # Setup required packages (unzip), filesystem, and oracle user
-# ------------------------------------------------------------
 RUN cd /u01 && $JAVA_HOME/bin/jar xf /u01/$FMW_PKG && cd - && \
     $JAVA_HOME/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME && \
     rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file
+
+# ---------------------------------------------------------------------------
+# Final stage image containing the installed Oracle Home
+FROM oracle/serverjre:8
+
+ENV ORACLE_HOME=/u01/oracle/oracle_home \
+    PATH=$PATH:/usr/java/default/bin:/u01/oracle/oracle_home/oracle_common/common/bin \
+    CONFIG_JVM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
+    COHERENCE_HOME=/u01/oracle/oracle_home/coherence \
+    DEPENDENCY_MODULES=/u01/coherence/thirdparty/lib
+
+# Create the oracle user with the uid 1000
+# Allow the start script to dynamically modify the /etc/passwd file when
+# running in environments that create a dynamic user
+# see: https://docs.okd.io/latest/creating_images/guidelines.html
+RUN mkdir -p /u01 && \
+    mkdir -p /logs && \
+    useradd -b /u01 -d /u01/oracle -m -s /bin/bash -u 1000 -g 0 oracle &&\
+    chmod g=u /etc/passwd
+
+COPY --from=builder /u01/oracle    /u01/oracle
+COPY start.sh                      /start.sh
+COPY extend-cache-config.xml       $COHERENCE_HOME/conf/extend-cache-config.xml
+
+# The directories created below are created with the owner oracle and the group 0 (root)
+# This ensures that the image is compatible with OpenShift which runs containers with a
+# random user that is a member of the root group regardless of the user configured in
+# this Dockerfile.
+# see: https://docs.okd.io/latest/creating_images/guidelines.html
+RUN chgrp -R 0 /u01 && \
+    chmod -R g=u /u01 && \
+    chmod 755 /start.sh && \
+    chgrp -R 0 /start.sh && \
+    chmod -R g=u /start.sh && \
+    chgrp -R 0 /logs && \
+    chmod -R g=u /logs
+
+# The oracle user was added with the uid 1000. We use the uid here rather than the username
+# for OpenShift best practice - see https://docs.okd.io/latest/creating_images/guidelines.html
+USER 1000
 
 ENTRYPOINT ["/start.sh"]

--- a/OracleCoherence/dockerfiles/12.2.1.0.0/start.sh
+++ b/OracleCoherence/dockerfiles/12.2.1.0.0/start.sh
@@ -5,6 +5,12 @@
 trap "echo TRAPed signal" HUP INT QUIT KILL TERM
 
 main() {
+#   Support running as an arbitrary user. See OpenShift best practice https://docs.okd.io/latest/creating_images/guidelines.html
+    if ! whoami &> /dev/null; then
+      if [ -w /etc/passwd ]; then
+        echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
+      fi
+    fi
 
     COMMAND=server
     SCRIPT_NAME=$(basename "${0}")

--- a/OracleCoherence/dockerfiles/12.2.1.2.0/Dockerfile.quickinstall
+++ b/OracleCoherence/dockerfiles/12.2.1.2.0/Dockerfile.quickinstall
@@ -27,7 +27,7 @@
 
 # Pull base image
 # ---------------
-FROM oracle/serverjre:8
+FROM oracle/serverjre:8 AS builder
 
 # Maintainer
 # ----------
@@ -43,24 +43,60 @@ ENV FMW_PKG=fmw_12.2.1.2.0_coherence_quick_Disk1_1of1.zip \
 ENV COHERENCE_HOME=$ORACLE_HOME/coherence
 
 RUN mkdir -p /u01 && \
-   useradd -b /u01 -d /u01/oracle -m -s /bin/bash oracle
+   useradd -b /u01 -d /u01/oracle -m -s /bin/bash -u 1000 -g 0 oracle
 
 # Copy files required to build this image
 COPY $FMW_PKG install.file oraInst.loc /u01/
-COPY start.sh                          /start.sh
-COPY extend-cache-config.xml           $COHERENCE_HOME/conf/extend-cache-config.xml
 
-RUN chmod 755 /start.sh && \
-   chmod a+xr /u01 && \
-   chown -R oracle:oracle /u01
+RUN chmod a+xr /u01 && \
+    chown -R oracle:root /u01
 
 USER oracle
 
 # Install and configure Oracle JDK
 # Setup required packages (unzip), filesystem, and oracle user
-# ------------------------------------------------------------
 RUN cd /u01 && $JAVA_HOME/bin/jar xf /u01/$FMW_PKG && cd - && \
     $JAVA_HOME/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME && \
     rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file
+
+# ---------------------------------------------------------------------------
+# Final stage image containing the installed Oracle Home
+FROM oracle/serverjre:8
+
+ENV ORACLE_HOME=/u01/oracle/oracle_home \
+    PATH=$PATH:/usr/java/default/bin:/u01/oracle/oracle_home/oracle_common/common/bin \
+    CONFIG_JVM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
+    COHERENCE_HOME=/u01/oracle/oracle_home/coherence \
+    DEPENDENCY_MODULES=/u01/coherence/thirdparty/lib
+
+# Create the oracle user with the uid 1000
+# Allow the start script to dynamically modify the /etc/passwd file when
+# running in environments that create a dynamic user
+# see: https://docs.okd.io/latest/creating_images/guidelines.html
+RUN mkdir -p /u01 && \
+    mkdir -p /logs && \
+    useradd -b /u01 -d /u01/oracle -m -s /bin/bash -u 1000 -g 0 oracle &&\
+    chmod g=u /etc/passwd
+
+COPY --from=builder /u01/oracle    /u01/oracle
+COPY start.sh                      /start.sh
+COPY extend-cache-config.xml       $COHERENCE_HOME/conf/extend-cache-config.xml
+
+# The directories created below are created with the owner oracle and the group 0 (root)
+# This ensures that the image is compatible with OpenShift which runs containers with a
+# random user that is a member of the root group regardless of the user configured in
+# this Dockerfile.
+# see: https://docs.okd.io/latest/creating_images/guidelines.html
+RUN chgrp -R 0 /u01 && \
+    chmod -R g=u /u01 && \
+    chmod 755 /start.sh && \
+    chgrp -R 0 /start.sh && \
+    chmod -R g=u /start.sh && \
+    chgrp -R 0 /logs && \
+    chmod -R g=u /logs
+
+# The oracle user was added with the uid 1000. We use the uid here rather than the username
+# for OpenShift best practice - see https://docs.okd.io/latest/creating_images/guidelines.html
+USER 1000
 
 ENTRYPOINT ["/start.sh"]

--- a/OracleCoherence/dockerfiles/12.2.1.2.0/start.sh
+++ b/OracleCoherence/dockerfiles/12.2.1.2.0/start.sh
@@ -5,6 +5,12 @@
 trap "echo TRAPed signal" HUP INT QUIT KILL TERM
 
 main() {
+#   Support running as an arbitrary user. See OpenShift best practice https://docs.okd.io/latest/creating_images/guidelines.html
+    if ! whoami &> /dev/null; then
+      if [ -w /etc/passwd ]; then
+        echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
+      fi
+    fi
 
     COMMAND=server
     SCRIPT_NAME=$(basename "${0}")

--- a/OracleCoherence/dockerfiles/12.2.1.3.0/Dockerfile.quickinstall
+++ b/OracleCoherence/dockerfiles/12.2.1.3.0/Dockerfile.quickinstall
@@ -27,7 +27,7 @@
 
 # Pull base image
 # ---------------
-FROM oracle/serverjre:8
+FROM oracle/serverjre:8 AS builder
 
 # Maintainer
 # ----------
@@ -43,24 +43,60 @@ ENV FMW_PKG=fmw_12.2.1.3.0_coherence_quick_Disk1_1of1.zip \
 ENV COHERENCE_HOME=$ORACLE_HOME/coherence
 
 RUN mkdir -p /u01 && \
-   useradd -b /u01 -d /u01/oracle -m -s /bin/bash oracle
+   useradd -b /u01 -d /u01/oracle -m -s /bin/bash -u 1000 -g 0 oracle
 
 # Copy files required to build this image
 COPY $FMW_PKG install.file oraInst.loc /u01/
-COPY start.sh                          /start.sh
-COPY extend-cache-config.xml           $COHERENCE_HOME/conf/extend-cache-config.xml
 
-RUN chmod 755 /start.sh && \
-   chmod a+xr /u01 && \
-   chown -R oracle:oracle /u01
+RUN chmod a+xr /u01 && \
+    chown -R oracle:root /u01
 
 USER oracle
 
 # Install and configure Oracle JDK
 # Setup required packages (unzip), filesystem, and oracle user
-# ------------------------------------------------------------
 RUN cd /u01 && $JAVA_HOME/bin/jar xf /u01/$FMW_PKG && cd - && \
     $JAVA_HOME/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME && \
     rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file
+
+# ---------------------------------------------------------------------------
+# Final stage image containing the installed Oracle Home
+FROM oracle/serverjre:8
+
+ENV ORACLE_HOME=/u01/oracle/oracle_home \
+    PATH=$PATH:/usr/java/default/bin:/u01/oracle/oracle_home/oracle_common/common/bin \
+    CONFIG_JVM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
+    COHERENCE_HOME=/u01/oracle/oracle_home/coherence \
+    DEPENDENCY_MODULES=/u01/coherence/thirdparty/lib
+
+# Create the oracle user with the uid 1000
+# Allow the start script to dynamically modify the /etc/passwd file when
+# running in environments that create a dynamic user
+# see: https://docs.okd.io/latest/creating_images/guidelines.html
+RUN mkdir -p /u01 && \
+    mkdir -p /logs && \
+    useradd -b /u01 -d /u01/oracle -m -s /bin/bash -u 1000 -g 0 oracle &&\
+    chmod g=u /etc/passwd
+
+COPY --from=builder /u01/oracle    /u01/oracle
+COPY start.sh                      /start.sh
+COPY extend-cache-config.xml       $COHERENCE_HOME/conf/extend-cache-config.xml
+
+# The directories created below are created with the owner oracle and the group 0 (root)
+# This ensures that the image is compatible with OpenShift which runs containers with a
+# random user that is a member of the root group regardless of the user configured in
+# this Dockerfile.
+# see: https://docs.okd.io/latest/creating_images/guidelines.html
+RUN chgrp -R 0 /u01 && \
+    chmod -R g=u /u01 && \
+    chmod 755 /start.sh && \
+    chgrp -R 0 /start.sh && \
+    chmod -R g=u /start.sh && \
+    chgrp -R 0 /logs && \
+    chmod -R g=u /logs
+
+# The oracle user was added with the uid 1000. We use the uid here rather than the username
+# for OpenShift best practice - see https://docs.okd.io/latest/creating_images/guidelines.html
+USER 1000
 
 ENTRYPOINT ["/start.sh"]

--- a/OracleCoherence/dockerfiles/12.2.1.3.0/Dockerfile.standalone
+++ b/OracleCoherence/dockerfiles/12.2.1.3.0/Dockerfile.standalone
@@ -27,7 +27,7 @@
 
 # Pull base image
 # ---------------
-FROM oracle/serverjre:8
+FROM oracle/serverjre:8 AS builder
 
 # Maintainer
 # ----------
@@ -43,24 +43,60 @@ ENV FMW_PKG=fmw_12.2.1.3.0_coherence_Disk1_1of1.zip \
 ENV COHERENCE_HOME=$ORACLE_HOME/coherence
 
 RUN mkdir -p /u01 && \
-   useradd -b /u01 -d /u01/oracle -m -s /bin/bash oracle
+   useradd -b /u01 -d /u01/oracle -m -s /bin/bash -u 1000 -g 0 oracle
 
 # Copy files required to build this image
 COPY $FMW_PKG install.file oraInst.loc /u01/
-COPY start.sh                          /start.sh
-COPY extend-cache-config.xml           $COHERENCE_HOME/conf/extend-cache-config.xml
 
-RUN chmod 755 /start.sh && \
-   chmod a+xr /u01 && \
-   chown -R oracle:oracle /u01
+RUN chmod a+xr /u01 && \
+    chown -R oracle:root /u01
 
 USER oracle
 
 # Install and configure Oracle JDK
 # Setup required packages (unzip), filesystem, and oracle user
-# ------------------------------------------------------------
 RUN cd /u01 && $JAVA_HOME/bin/jar xf /u01/$FMW_PKG && cd - && \
     $JAVA_HOME/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME && \
     rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file
+
+# ---------------------------------------------------------------------------
+# Final stage image containing the installed Oracle Home
+FROM oracle/serverjre:8
+
+ENV ORACLE_HOME=/u01/oracle/oracle_home \
+    PATH=$PATH:/usr/java/default/bin:/u01/oracle/oracle_home/oracle_common/common/bin \
+    CONFIG_JVM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
+    COHERENCE_HOME=/u01/oracle/oracle_home/coherence \
+    DEPENDENCY_MODULES=/u01/coherence/thirdparty/lib
+
+# Create the oracle user with the uid 1000
+# Allow the start script to dynamically modify the /etc/passwd file when
+# running in environments that create a dynamic user
+# see: https://docs.okd.io/latest/creating_images/guidelines.html
+RUN mkdir -p /u01 && \
+    mkdir -p /logs && \
+    useradd -b /u01 -d /u01/oracle -m -s /bin/bash -u 1000 -g 0 oracle &&\
+    chmod g=u /etc/passwd
+
+COPY --from=builder /u01/oracle    /u01/oracle
+COPY start.sh                      /start.sh
+COPY extend-cache-config.xml       $COHERENCE_HOME/conf/extend-cache-config.xml
+
+# The directories created below are created with the owner oracle and the group 0 (root)
+# This ensures that the image is compatible with OpenShift which runs containers with a
+# random user that is a member of the root group regardless of the user configured in
+# this Dockerfile.
+# see: https://docs.okd.io/latest/creating_images/guidelines.html
+RUN chgrp -R 0 /u01 && \
+    chmod -R g=u /u01 && \
+    chmod 755 /start.sh && \
+    chgrp -R 0 /start.sh && \
+    chmod -R g=u /start.sh && \
+    chgrp -R 0 /logs && \
+    chmod -R g=u /logs
+
+# The oracle user was added with the uid 1000. We use the uid here rather than the username
+# for OpenShift best practice - see https://docs.okd.io/latest/creating_images/guidelines.html
+USER 1000
 
 ENTRYPOINT ["/start.sh"]

--- a/OracleCoherence/dockerfiles/12.2.1.3.0/start.sh
+++ b/OracleCoherence/dockerfiles/12.2.1.3.0/start.sh
@@ -5,6 +5,12 @@
 trap "echo TRAPed signal" HUP INT QUIT KILL TERM
 
 main() {
+#   Support running as an arbitrary user. See OpenShift best practice https://docs.okd.io/latest/creating_images/guidelines.html
+    if ! whoami &> /dev/null; then
+      if [ -w /etc/passwd ]; then
+        echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
+      fi
+    fi
 
     COMMAND=server
     SCRIPT_NAME=$(basename "${0}")

--- a/OracleCoherence/dockerfiles/12.2.1.4.0/src/main/docker/Dockerfile
+++ b/OracleCoherence/dockerfiles/12.2.1.4.0/src/main/docker/Dockerfile
@@ -44,7 +44,7 @@ ENV FMW_PKG=fmw_12.2.1.4.0_coherence_quick_Disk1_1of1.zip \
     CONFIG_JVM_ARGS="-Djava.security.egd=file:/dev/./urandom"
 
 RUN mkdir -p /u01 && \
-    useradd -b /u01 -d /u01/oracle -m -s /bin/bash oracle
+    useradd -b /u01 -d /u01/oracle -m -s /bin/bash -u 1000 -g 0 oracle
 
 # Copy files required to build this image
 COPY $FMW_PKG install.file oraInst.loc /u01/
@@ -55,38 +55,50 @@ RUN chmod a+xr /u01 && \
 USER oracle
 
 # Install Coherence
-# ------------------------------------------------------------
 RUN cd /u01 && $JAVA_HOME/bin/jar xf /u01/$FMW_PKG && cd - && \
     $JAVA_HOME/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME && \
     rm /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file
 
+# ---------------------------------------------------------------------------
 # Final stage image containing the installed Oracle Home
 FROM oracle/serverjre:8
 
 ENV ORACLE_HOME=/u01/oracle/oracle_home \
     PATH=$PATH:/usr/java/default/bin:/u01/oracle/oracle_home/oracle_common/common/bin \
-    CONFIG_JVM_ARGS="-Djava.security.egd=file:/dev/./urandom"
+    CONFIG_JVM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
+    COHERENCE_HOME=/u01/oracle/oracle_home/coherence \
+    DEPENDENCY_MODULES=/u01/coherence/thirdparty/lib
 
-ENV COHERENCE_HOME=$ORACLE_HOME/coherence
-ENV DEPENDENCY_MODULES=/u01/coherence/thirdparty/lib
-
+# Create the oracle user with the uid 1000
+# Allow the start script to dynamically modify the /etc/passwd file when
+# running in environments that create a dynamic user
+# see: https://docs.okd.io/latest/creating_images/guidelines.html
 RUN mkdir -p /u01 && \
-    useradd -b /u01 -d /u01/oracle -m -s /bin/bash oracle
+    mkdir -p /logs && \
+    useradd -b /u01 -d /u01/oracle -m -s /bin/bash -u 1000 -g 0 oracle &&\
+    chmod g=u /etc/passwd
 
-COPY start.sh /start.sh
+COPY --from=builder /u01/oracle    /u01/oracle
+COPY start.sh                      /start.sh
+COPY extend-cache-config.xml       $COHERENCE_HOME/conf/extend-cache-config.xml
+COPY logging.properties            $COHERENCE_HOME/conf/logging.properties
+COPY coherence/thirdparty/lib/     $DEPENDENCY_MODULES/
 
-RUN mkdir -p /logs && \
+# The directories created below are created with the owner oracle and the group 0 (root)
+# This ensures that the image is compatible with OpenShift which runs containers with a
+# random user that is a member of the root group regardless of the user configured in
+# this Dockerfile.
+# see: https://docs.okd.io/latest/creating_images/guidelines.html
+RUN chgrp -R 0 /u01 && \
+    chmod -R g=u /u01 && \
     chmod 755 /start.sh && \
-    chmod a+xr /u01 && \
-    chown oracle:oracle -R /u01 && \
-    chown oracle:oracle -R /logs
+    chgrp -R 0 /start.sh && \
+    chmod -R g=u /start.sh && \
+    chgrp -R 0 /logs && \
+    chmod -R g=u /logs
 
-COPY --from=builder --chown=oracle:oracle /u01/oracle /u01/oracle
-
-COPY --chown=oracle:oracle extend-cache-config.xml     $COHERENCE_HOME/conf/extend-cache-config.xml
-COPY --chown=oracle:oracle logging.properties          $COHERENCE_HOME/conf/logging.properties
-COPY --chown=oracle:oracle coherence/thirdparty/lib/   $DEPENDENCY_MODULES/
-
-USER oracle
+# The oracle user was added with the uid 1000. We use the uid here rather than the username
+# for OpenShift best practice - see https://docs.okd.io/latest/creating_images/guidelines.html
+USER 1000
 
 ENTRYPOINT ["/start.sh"]

--- a/OracleCoherence/dockerfiles/12.2.1.4.0/src/main/docker/start.sh
+++ b/OracleCoherence/dockerfiles/12.2.1.4.0/src/main/docker/start.sh
@@ -9,6 +9,13 @@ trap "echo TRAPed signal" HUP INT QUIT KILL TERM
 
 main()
     {
+#   Support running as an arbitrary user. See OpenShift best practice https://docs.okd.io/latest/creating_images/guidelines.html
+    if ! whoami &> /dev/null; then
+      if [ -w /etc/passwd ]; then
+        echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
+      fi
+    fi
+
     COMMAND=server
     SCRIPT_NAME=$(basename "${0}")
     MAIN_CLASS="com.tangosol.net.DefaultCacheServer"


### PR DESCRIPTION
When running containers on OpenShift the images run with an arbitrary user created dynamically regardless of the user specified in any Dockerfile. Whilst it is possible to configure OpenShift to allow any user in a container and work around this restriction we do not want to force customers to have to lower the OpenShift security policies.

This change makes sure that the files added to the images are owned by the oracle user and are readable/writable by the root group. The user created by OpenShift will be in the root group and will hence be able to run the images. See: https://docs.okd.io/latest/creating_images/guidelines.html