### PR TITLE
New GraalVM CE release

### DIFF
--- a/GraalVM/CE/19/Dockerfile.java11
+++ b/GraalVM/CE/19/Dockerfile.java11
@@ -9,8 +9,9 @@ FROM oraclelinux:7-slim
 #       E.g.:  docker build --build-arg "https_proxy=..." --build-arg "http_proxy=..." --build-arg "no_proxy=..." ...
 
 ARG GRAALVM_VERSION=19.3.0.2
-ARG JAVA_VERSION=java8
-ARG GRAALVM_PKG=https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$GRAALVM_VERSION/graalvm-ce-$JAVA_VERSION-linux-amd64-$GRAALVM_VERSION.tar.gz 
+ARG JAVA_VERSION=java11
+ARG GRAALVM_PKG=https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$GRAALVM_VERSION/graalvm-ce-$JAVA_VERSION-GRAALVM_ARCH-$GRAALVM_VERSION.tar.gz 
+ARG TARGETPLATFORM
 
 ENV LANG=en_US.UTF-8 \
     JAVA_HOME=/opt/graalvm-ce-$JAVA_VERSION-$GRAALVM_VERSION/
@@ -28,6 +29,8 @@ RUN fc-cache -f -v
 
 ADD gu-wrapper.sh /usr/local/bin/gu
 RUN set -eux \
+    && if [ "$TARGETPLATFORM" == "linux/amd64" ]; then GRAALVM_PKG=${GRAALVM_PKG/GRAALVM_ARCH/linux-amd64}; fi \
+    && if [ "$TARGETPLATFORM" == "linux/arm64" ]; then GRAALVM_PKG=${GRAALVM_PKG/GRAALVM_ARCH/linux-aarch64}; fi \
     && curl --fail --silent --location --retry 3 ${GRAALVM_PKG} \
     | gunzip | tar x -C /opt/ \
 

--- a/GraalVM/CE/19/README.md
+++ b/GraalVM/CE/19/README.md
@@ -12,6 +12,20 @@ Further details can be found on [www.graalvm.org](https://www.graalvm.org).
 
 The images are intended for use in the **FROM** field of a downstream Dockerfile. For example, specify `FROM oracle/graalvm-ce:latest` or a version tag.
 
+# Building the images
+
+For building a GraalVM Java 8 image use:
+
+```
+docker build --build-arg GRAALVM_VERSION=<GraalVM Version> --build-arg JAVA_VERSION=java8 -t oracle/graalvm-ce:<GraalVM Version>-java8 .
+```
+
+For building GraalVM Java 11 amd64 and arm64 images use:
+
+```
+docker buildx build --platform linux/amd64 --build-arg GRAALVM_VERSION=<GraalVM Version> --build-arg JAVA_VERSION=java11 -t oracle/graalvm-ce:<GraalVM Version>-java11-amd64 --output=type=docker -f Dockerfile.java11 .
+docker buildx build --platform linux/arm64 --build-arg GRAALVM_VERSION=<GraalVM Version> --build-arg JAVA_VERSION=java11 -t oracle/graalvm-ce:<GraalVM Version>-java11-arm64 --output=type=docker -f Dockerfile.java11 .
+```
 
 # License
 The GraalVM CE Dockerfile is licensed under the [Universal Permissive License (UPL), Version 1](https://opensource.org/licenses/UPL).  This license applies to the Dockerfile only, and not to any resulting Docker image.


### PR DESCRIPTION
- New GraalVM CE 19.3.0.2 release
- Adding first multiarch amd64/arm64 image: `oracle/graalvm-ce:19.3.0.2-java11`