### PR TITLE
Updated versions of the JDK and ServerJRE in the Dockerfiles to Jan CPU

### DIFF
--- a/OracleJava/java-11/Dockerfile
+++ b/OracleJava/java-11/Dockerfile
@@ -41,8 +41,8 @@ ENV LANG en_US.UTF-8
 # Environment variables for the builder image.  
 # Required to validate that you are using the correct file
 
-ENV JAVA_PKG=jdk-11.0.5_linux-x64_bin.tar.gz \
-	JAVA_SHA256=387e60bdad6d6fc20d41cd712536f0f7adbb086fa73bc3cb225b3edad0bfa0a6 \
+ENV JAVA_PKG=jdk-11.0.6_linux-x64_bin.tar.gz \
+	JAVA_SHA256=a11bac55a96493556f349eead956b94d32f6a71031373771dca4cc72b89a82b4 \
 	JAVA_HOME=/usr/java/jdk-11
 
 ##
@@ -59,7 +59,7 @@ FROM oraclelinux:7-slim
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
-ENV JAVA_VERSION=11.0.5 \
+ENV JAVA_VERSION=11.0.6 \
 	JAVA_HOME=/usr/java/jdk-11
 
 ENV	PATH $JAVA_HOME/bin:$PATH	

--- a/OracleJava/java-8/Dockerfile
+++ b/OracleJava/java-8/Dockerfile
@@ -42,8 +42,8 @@ ENV LANG en_US.UTF-8
 # Environment variables for the builder image.  
 # Required to validate that you are using the correct file
 
-ENV JAVA_PKG=server-jre-8u231-linux-x64.tar.gz \
-	JAVA_SHA256=1d59a0ea3ef302d5851370b838693b0b6bde4c3f32015a4de0a9e4d202a988fc \
+ENV JAVA_PKG=server-jre-8u241-linux-x64.tar.gz \
+	JAVA_SHA256=d2ae0d694eb1a1f6e87678028ff5a74e2b4ea3011ca687016e7611bed1e82d0e \
 	JAVA_HOME=/usr/java/jdk-8
 
 COPY $JAVA_PKG /tmp/jdk.tgz
@@ -60,7 +60,7 @@ FROM oraclelinux:7-slim
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
-ENV JAVA_VERSION=1.8.0_231 \
+ENV JAVA_VERSION=1.8.0_241 \
 	JAVA_HOME=/usr/java/jdk-8 
 	
 ENV	PATH $JAVA_HOME/bin:$PATH


### PR DESCRIPTION
Update the ServerJRE and JDK versions on the dockerfiles so 8u231 -> 8u241 and 11.0.5 -> 11.0.6