### PR TITLE
Updating CODEOWNERS for OracleJava 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,7 +15,7 @@
 /OracleGoldenGate/        @sbalousek
 /OracleHTTPServer/        @Prabhat-Kishore
 /OracleInstantClient/     @cjbj
-/OracleJava/              @aureliogrb
+/OracleJava/              @aureliogrb @Djelibeybi
 /OracleRestDataServices/  @gvenzl
 /OracleTuxedo/            @toddinpal
 /OracleWebCenterSites/    @ashishchalak


### PR DESCRIPTION
Including myself for `OracleJava` so future PRs from @aureliogrb are automatically assigned to me for review.

Signed-off-by: Avi Miller <avi.miller@oracle.com>