### PR TITLE
Hotfix podman support

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/buildDockerImage.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/buildDockerImage.sh
@@ -48,14 +48,35 @@ checksumPackages() {
   fi
 }
 
+# Check Podman version
+checkPodmanVersion() {
+  # Get Podman version
+  echo "Checking Podman version."
+  PODMAN_VERSION=$(docker info --format '{{.host.BuildahVersion}}')
+  # Remove dot in Podman version
+  PODMAN_VERSION=${PODMAN_VERSION//./}
+
+  if [ -z "$PODMAN_VERSION" ]; then
+    exit 1;
+  elif [ "$PODMAN_VERSION" -lt "${MIN_PODMAN_VERSION//./}" ]; then
+    echo "Podman version is below the minimum required version $MIN_PODMAN_VERSION"
+    echo "Please upgrade your Podman installation to proceed."
+    exit 1;
+  fi
+}
+
 # Check Docker version
 checkDockerVersion() {
   # Get Docker Server version
-  DOCKER_VERSION=$(docker version --format '{{.Server.Version | printf "%.5s" }}')
+  echo "Checking Docker version."
+  DOCKER_VERSION=$(docker version --format '{{.Server.Version | printf "%.5s" }}'|| exit 0)
   # Remove dot in Docker version
   DOCKER_VERSION=${DOCKER_VERSION//./}
 
-  if [ "$DOCKER_VERSION" -lt "${MIN_DOCKER_VERSION//./}" ]; then
+  if [ -z "$DOCKER_VERSION" ]; then
+    # docker could be aliased to podman and errored out (https://github.com/containers/libpod/pull/4608)
+    checkPodmanVersion
+  elif [ "$DOCKER_VERSION" -lt "${MIN_DOCKER_VERSION//./}" ]; then
     echo "Docker version is below the minimum required version $MIN_DOCKER_VERSION"
     echo "Please upgrade your Docker installation to proceed."
     exit 1;
@@ -74,6 +95,7 @@ VERSION="19.3.0"
 SKIPMD5=0
 DOCKEROPS=""
 MIN_DOCKER_VERSION="17.09"
+MIN_PODMAN_VERSION="1.6.0"
 DOCKERFILE="Dockerfile"
 
 if [ "$#" -eq 0 ]; then

--- a/OracleDatabase/SingleInstance/dockerfiles/buildDockerImage.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/buildDockerImage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 # 
 # Since: April, 2016
 # Author: gerald.venzl@oracle.com


### PR DESCRIPTION
Relates to issue #1376 - 
1. If unable to test for supported Docker version, test for supported Podman version
2. If errors are encountered at any stage, exit.

For background of podman/buildah see https://docs.oracle.com/en/operating-systems/oracle-linux/8/relnotes8.0/ol8-features-container.html 

Buildah libs in Podman have had multi-stage build support for some time but improvements were made in 1.6.0 and it's as good a place to start as any. The first podman RPM shipped with OL8 included buildah libs 1.9.0 so it could be raised to that version.

I may have over-complicated it, let me know your thoughts.

