### PR TITLE
Indentation in tnsnames.ora

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/createDB.sh
@@ -66,13 +66,13 @@ dbca -silent -responseFile $ORACLE_BASE/dbca.rsp ||
 
 echo "$ORACLE_SID=localhost:1521/$ORACLE_SID" > $ORACLE_HOME/network/admin/tnsnames.ora
 echo "$ORACLE_PDB= 
-(DESCRIPTION = 
-  (ADDRESS = (PROTOCOL = TCP)(HOST = 0.0.0.0)(PORT = 1521))
-  (CONNECT_DATA =
-    (SERVER = DEDICATED)
-    (SERVICE_NAME = $ORACLE_PDB)
-  )
-)" >> $ORACLE_HOME/network/admin/tnsnames.ora
+  (DESCRIPTION = 
+    (ADDRESS = (PROTOCOL = TCP)(HOST = 0.0.0.0)(PORT = 1521))
+    (CONNECT_DATA =
+      (SERVER = DEDICATED)
+      (SERVICE_NAME = $ORACLE_PDB)
+    )
+  )" >> $ORACLE_HOME/network/admin/tnsnames.ora
 
 # Remove second control file, make PDB auto open
 sqlplus / as sysdba << EOF

--- a/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/createDB.sh
@@ -66,13 +66,13 @@ dbca -silent -createDatabase -responseFile $ORACLE_BASE/dbca.rsp ||
 
 echo "$ORACLE_SID=localhost:1521/$ORACLE_SID" > $ORACLE_HOME/network/admin/tnsnames.ora
 echo "$ORACLE_PDB= 
-(DESCRIPTION = 
-  (ADDRESS = (PROTOCOL = TCP)(HOST = 0.0.0.0)(PORT = 1521))
-  (CONNECT_DATA =
-    (SERVER = DEDICATED)
-    (SERVICE_NAME = $ORACLE_PDB)
-  )
-)" >> $ORACLE_HOME/network/admin/tnsnames.ora
+  (DESCRIPTION = 
+    (ADDRESS = (PROTOCOL = TCP)(HOST = 0.0.0.0)(PORT = 1521))
+    (CONNECT_DATA =
+      (SERVER = DEDICATED)
+      (SERVICE_NAME = $ORACLE_PDB)
+    )
+  )" >> $ORACLE_HOME/network/admin/tnsnames.ora
 
 # Remove second control file, fix local_listener, make PDB auto open, enable EM global port
 sqlplus / as sysdba << EOF

--- a/OracleDatabase/SingleInstance/dockerfiles/18.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/18.3.0/createDB.sh
@@ -66,13 +66,13 @@ dbca -silent -createDatabase -responseFile $ORACLE_BASE/dbca.rsp ||
 
 echo "$ORACLE_SID=localhost:1521/$ORACLE_SID" > $ORACLE_HOME/network/admin/tnsnames.ora
 echo "$ORACLE_PDB= 
-(DESCRIPTION = 
-  (ADDRESS = (PROTOCOL = TCP)(HOST = 0.0.0.0)(PORT = 1521))
-  (CONNECT_DATA =
-    (SERVER = DEDICATED)
-    (SERVICE_NAME = $ORACLE_PDB)
-  )
-)" >> $ORACLE_HOME/network/admin/tnsnames.ora
+  (DESCRIPTION = 
+    (ADDRESS = (PROTOCOL = TCP)(HOST = 0.0.0.0)(PORT = 1521))
+    (CONNECT_DATA =
+      (SERVER = DEDICATED)
+      (SERVICE_NAME = $ORACLE_PDB)
+    )
+  )" >> $ORACLE_HOME/network/admin/tnsnames.ora
 
 # Remove second control file, fix local_listener, make PDB auto open, enable EM global port
 sqlplus / as sysdba << EOF

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
@@ -66,13 +66,13 @@ dbca -silent -createDatabase -responseFile $ORACLE_BASE/dbca.rsp ||
 
 echo "$ORACLE_SID=localhost:1521/$ORACLE_SID" > $ORACLE_HOME/network/admin/tnsnames.ora
 echo "$ORACLE_PDB= 
-(DESCRIPTION = 
-  (ADDRESS = (PROTOCOL = TCP)(HOST = 0.0.0.0)(PORT = 1521))
-  (CONNECT_DATA =
-    (SERVER = DEDICATED)
-    (SERVICE_NAME = $ORACLE_PDB)
-  )
-)" >> $ORACLE_HOME/network/admin/tnsnames.ora
+  (DESCRIPTION = 
+    (ADDRESS = (PROTOCOL = TCP)(HOST = 0.0.0.0)(PORT = 1521))
+    (CONNECT_DATA =
+      (SERVER = DEDICATED)
+      (SERVICE_NAME = $ORACLE_PDB)
+    )
+  )" >> $ORACLE_HOME/network/admin/tnsnames.ora
 
 # Remove second control file, fix local_listener, make PDB auto open, enable EM global port
 sqlplus / as sysdba << EOF


### PR DESCRIPTION
Hi! I've faced with a tricky problem. Getting "ORA-12154: TNS:could not resolve the connect identifier" when trying to connect to my PDB via JDBC thin client using string "user/password@tnsname" within docker container. Meanwhile I still was able to connect via sqlplus using the same string. As I figured out later the problem was in not indented strings in tnsnames.ora. Here in  [Oracle docs](https://docs.oracle.com/cd/A57673_01/DOC/net/doc/NWUS233/apb.htm) I have found a rule "_Any keyword in a configuration file that should be recognized as beginning a parameter that includes one or more keyword-value pairs must be in the far left column of a line. If it is indented by one or more spaces, it is interpreted as a continuation of the previous line._". Look like JDBC thin client can't recognize those not indented strings with parameters if you not follow this rule.