### PR TITLE
Changes for spike troubleshooting

### DIFF
--- a/OracleSOASuite/dockerfiles/12.2.1.3/Dockerfile
+++ b/OracleSOASuite/dockerfiles/12.2.1.3/Dockerfile
@@ -23,8 +23,9 @@ MAINTAINER Prashanth Nagaraja <prashanth.nagaraja@oracle.com>
 # Environment variables required for this build (do NOT change)
 # -------------------------------------------------------------
 USER root
-ENV FMW_JAR1=fmw_12.2.1.3.0_soa.jar \
-    FMW_JAR2=fmw_12.2.1.3.0_osb.jar
+ENV FMW_JAR1=fmw_12.2.1.3.0_soa.jar 
+#\
+#    FMW_JAR2=fmw_12.2.1.3.0_osb.jar
 
 #
 # Copy files and packages for install
@@ -40,7 +41,7 @@ USER oracle
 COPY install/* /u01/
 RUN cd /u01 && \
   $JAVA_HOME/bin/java -jar $FMW_JAR1 -silent -responseFile /u01/soasuite.response -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME && \
-  $JAVA_HOME/bin/java -jar $FMW_JAR2 -silent -responseFile /u01/soasuite.response -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME INSTALL_TYPE="Service Bus" && \
+#  $JAVA_HOME/bin/java -jar $FMW_JAR2 -silent -responseFile /u01/soasuite.response -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME INSTALL_TYPE="Service Bus" && \
   rm -fr /u01/*.jar /u01/*.response /u01/*.loc
 
 #

--- a/OracleSOASuite/dockerfiles/12.2.1.3/container-scripts/createDomainAndStart.sh
+++ b/OracleSOASuite/dockerfiles/12.2.1.3/container-scripts/createDomainAndStart.sh
@@ -152,6 +152,8 @@ then
     echo "INFO: SOA RCU has already been loaded. Skipping..."
 fi
 
+RUN_RCU="false"
+
 if [ "$RUN_RCU" = "true" ] 
 then
   setupRCU
@@ -205,6 +207,7 @@ then
   if [ $retval -ne 0 ]; 
   then
     echo "ERROR: Domain Configuration failed. Please check the logs"
+    sleep 1800
     exit
   else
     updateListenAddress

--- a/OracleSOASuite/dockerfiles/12.2.1.3/install/soasuite.download
+++ b/OracleSOASuite/dockerfiles/12.2.1.3/install/soasuite.download
@@ -8,4 +8,4 @@
 #  - V886445-01.zip - Oracle Fusion Middleware 12c (12.2.1.3.0) Service Bus
 #
 0028f065488979dccea599d56b4db458  fmw_12.2.1.3.0_soa.jar
-9d53300c41d7c47873be515b80df6e87  fmw_12.2.1.3.0_osb.jar
+# 9d53300c41d7c47873be515b80df6e87  fmw_12.2.1.3.0_osb.jar


### PR DESCRIPTION
We had to remove the OSB component otherwise the image size exceeded 10GB and wouldn't upload to ECR.

To build the image you need to log into and accept the terms for the oracle images that this image is based off.  See the original read me, but here are some extra steps that are not covered in it:
https://container-registry.oracle.com/
Then log into their repository with docker - https://docs.oracle.com/cd/E37670_01/E75728/html/oracle-registry-server.html
And download the required images:
oracle/fmw-infrastructure:12.2.1.3
The images download with different names, tag them with the name above.
You also need to have the SOA binaries fmw_12.2.1.3.0_soa.jar present in the 12.2.1.3 folder.
Build the image with `docker-images/OracleSOASuite/dockerfiles/buildDockerImage.sh -v 12.2.1.3`
Then tag it to match the name of the SOA image in the ECR repository