### PR TITLE
SOA Readme update to add ADMIN_HOST in environment file adminserver.env.list

### DIFF
--- a/OracleSOASuite/dockerfiles/README.md
+++ b/OracleSOASuite/dockerfiles/README.md
@@ -125,6 +125,7 @@ Create an environment file adminserver.env.list
     ADMIN_PASSWORD=<admin_password>
     MANAGED_SERVER=<managed servername>
     DOMAIN_TYPE=<soa/osb/bpm>
+    ADMIN_HOST=<Admin host name>
     
 Sample Data will look like this:
 
@@ -135,6 +136,7 @@ Sample Data will look like this:
     ADMIN_PASSWORD=Welcome1
     MANAGED_SERVER=soa_server1
     DOMAIN_TYPE=soa
+    ADMIN_HOST=slc09cwi.us.oracle.com
     
 To start a docker container with a SOA domain and the WebLogic AdminServer call `docker run` command and pass the above `adminserver.env.list` file.
 

--- a/OracleSOASuite/dockerfiles/README.md
+++ b/OracleSOASuite/dockerfiles/README.md
@@ -136,7 +136,7 @@ Sample Data will look like this:
     ADMIN_PASSWORD=Welcome1
     MANAGED_SERVER=soa_server1
     DOMAIN_TYPE=soa
-    ADMIN_HOST=slc09cwi.us.oracle.com
+    ADMIN_HOST=admin.yourcompany.com
     
 To start a docker container with a SOA domain and the WebLogic AdminServer call `docker run` command and pass the above `adminserver.env.list` file.
 
@@ -173,7 +173,7 @@ Sample Data will look like this:
 
     MANAGED_SERVER=soa_server1
     DOMAIN_TYPE=soa
-    ADMIN_HOST=slc09cwi.us.oracle.com
+    ADMIN_HOST=admin.yourcompany.com
     ADMIN_PORT=7001
     
 To start a docker container for SOA server you can simply call `docker run` command and passing `soaserver.env.list`. 


### PR DESCRIPTION
README.md does not gives details on adding **ADMIN_HOST** in environment file "adminserver.env.list ".

If ADMIN_HOST value is not passed during starting Admin Server container,  it will wrongly pick  ADMIN_HOST value as **InfraAdminContainer**, default value of base image (oracle/fmw-infrastructure:12.2.1.3) i.e., from https://github.com/oracle/docker-images/blob/c5b1cbb04af0323ef8495becb6ad5b5481311f1e/OracleFMWInfrastructure/dockerfiles/12.2.1.3/Dockerfile#L66

If ADMIN_HOST not set to correct value, WebLogic Console will not be accessible as this value will be updated external dns address ( as reported in #1443 )