### PR TITLE
Minor improvements to the shell scripts for oracle database configs

### DIFF
--- a/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/12.2.0.1/checkSpace.sh
+++ b/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/12.2.0.1/checkSpace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
@@ -18,6 +18,7 @@ if [ $AVAILABLE_SPACE_GB -lt $REQUIRED_SPACE_GB ]; then
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   echo "$script_name: ERROR - There is not enough space available in the docker container."
   echo "$script_name: The container needs at least $REQUIRED_SPACE_GB GB , but only $AVAILABLE_SPACE_GB available."
+  echo "If needed, you can increase the size limit in dockerd using \`--storage-opt dm.basesize=$((REQUIRED_SPACE_GB+1))G -s devicemapper'"
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   exit 1;
 fi;

--- a/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/12.2.0.1/configCMAN.sh
+++ b/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/12.2.0.1/configCMAN.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/12.2.0.1/functions.sh
+++ b/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/12.2.0.1/functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/12.2.0.1/installDBBinaries.sh
+++ b/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/12.2.0.1/installDBBinaries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/12.2.0.1/runOracle.sh
+++ b/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/12.2.0.1/runOracle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/12.2.0.1/setupDB.sh
+++ b/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/12.2.0.1/setupDB.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/12.2.0.1/setupLinuxEnv.sh
+++ b/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/12.2.0.1/setupLinuxEnv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/18.3.0/checkSpace.sh
+++ b/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/18.3.0/checkSpace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
@@ -18,6 +18,7 @@ if [ $AVAILABLE_SPACE_GB -lt $REQUIRED_SPACE_GB ]; then
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   echo "$script_name: ERROR - There is not enough space available in the docker container."
   echo "$script_name: The container needs at least $REQUIRED_SPACE_GB GB , but only $AVAILABLE_SPACE_GB available."
+  echo "If needed, you can increase the size limit in dockerd using \`--storage-opt dm.basesize=$((REQUIRED_SPACE_GB+1))G -s devicemapper'"
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   exit 1;
 fi;

--- a/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/18.3.0/configCMAN.sh
+++ b/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/18.3.0/configCMAN.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/18.3.0/functions.sh
+++ b/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/18.3.0/functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/18.3.0/installDBBinaries.sh
+++ b/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/18.3.0/installDBBinaries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/18.3.0/runOracle.sh
+++ b/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/18.3.0/runOracle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/18.3.0/setupDB.sh
+++ b/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/18.3.0/setupDB.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/18.3.0/setupLinuxEnv.sh
+++ b/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/18.3.0/setupLinuxEnv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/19.3.0/checkSpace.sh
+++ b/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/19.3.0/checkSpace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.
@@ -18,6 +18,7 @@ if [ $AVAILABLE_SPACE_GB -lt $REQUIRED_SPACE_GB ]; then
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   echo "$script_name: ERROR - There is not enough space available in the docker container."
   echo "$script_name: The container needs at least $REQUIRED_SPACE_GB GB , but only $AVAILABLE_SPACE_GB available."
+  echo "If needed, you can increase the size limit in dockerd using \`--storage-opt dm.basesize=$((REQUIRED_SPACE_GB+1))G -s devicemapper'"
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   exit 1;
 fi;

--- a/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/19.3.0/configCMAN.sh
+++ b/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/19.3.0/configCMAN.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/19.3.0/functions.sh
+++ b/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/19.3.0/functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/19.3.0/installDBBinaries.sh
+++ b/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/19.3.0/installDBBinaries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/19.3.0/runOracle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/19.3.0/setupDB.sh
+++ b/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/19.3.0/setupDB.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/19.3.0/setupLinuxEnv.sh
+++ b/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/19.3.0/setupLinuxEnv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/buildDockerImage.sh
+++ b/OracleDatabase/RAC/OracleConnectionManager/dockerfiles/buildDockerImage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Since: January, 2018

--- a/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/12.2.0.1/checkSpace.sh
+++ b/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/12.2.0.1/checkSpace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
@@ -18,6 +18,7 @@ if [ $AVAILABLE_SPACE_GB -lt $REQUIRED_SPACE_GB ]; then
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   echo "$script_name: ERROR - There is not enough space available in the docker container."
   echo "$script_name: The container needs at least $REQUIRED_SPACE_GB GB , but only $AVAILABLE_SPACE_GB available."
+  echo "If needed, you can increase the size limit in dockerd using \`--storage-opt dm.basesize=$((REQUIRED_SPACE_GB+1))G -s devicemapper'"
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   exit 1;
 fi;

--- a/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/12.2.0.1/runOracle.sh
+++ b/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/12.2.0.1/runOracle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/12.2.0.1/setupLinuxEnv.sh
+++ b/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/12.2.0.1/setupLinuxEnv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/12.2.0.1/setupSudo.sh
+++ b/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/12.2.0.1/setupSudo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/18.3.0/checkSpace.sh
+++ b/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/18.3.0/checkSpace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
@@ -18,6 +18,7 @@ if [ $AVAILABLE_SPACE_GB -lt $REQUIRED_SPACE_GB ]; then
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   echo "$script_name: ERROR - There is not enough space available in the docker container."
   echo "$script_name: The container needs at least $REQUIRED_SPACE_GB GB , but only $AVAILABLE_SPACE_GB available."
+  echo "If needed, you can increase the size limit in dockerd using \`--storage-opt dm.basesize=$((REQUIRED_SPACE_GB+1))G -s devicemapper'"
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   exit 1;
 fi;

--- a/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/18.3.0/runOracle.sh
+++ b/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/18.3.0/runOracle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/18.3.0/setupLinuxEnv.sh
+++ b/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/18.3.0/setupLinuxEnv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/18.3.0/setupSudo.sh
+++ b/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/18.3.0/setupSudo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/19.3.0/checkSpace.sh
+++ b/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/19.3.0/checkSpace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
@@ -18,6 +18,7 @@ if [ $AVAILABLE_SPACE_GB -lt $REQUIRED_SPACE_GB ]; then
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   echo "$script_name: ERROR - There is not enough space available in the docker container."
   echo "$script_name: The container needs at least $REQUIRED_SPACE_GB GB , but only $AVAILABLE_SPACE_GB available."
+  echo "If needed, you can increase the size limit in dockerd using \`--storage-opt dm.basesize=$((REQUIRED_SPACE_GB+1))G -s devicemapper'"
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   exit 1;
 fi;

--- a/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/19.3.0/runOracle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/19.3.0/setupLinuxEnv.sh
+++ b/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/19.3.0/setupLinuxEnv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/19.3.0/setupSudo.sh
+++ b/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/19.3.0/setupSudo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/buildDockerImage.sh
+++ b/OracleDatabase/RAC/OracleRACStorageServer/dockerfiles/buildDockerImage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 # 
 # Since: January, 2018

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/AddNode.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/AddNode.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/DelNode.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/DelNode.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/GridHomeCleanup.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/GridHomeCleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/OracleHomeCleanup.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/OracleHomeCleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/applyGridPatch.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/applyGridPatch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/checkDBStatus.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/checkDBStatus.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/checkSpace.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/checkSpace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
@@ -18,6 +18,7 @@ if [ $AVAILABLE_SPACE_GB -lt $REQUIRED_SPACE_GB ]; then
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   echo "$script_name: ERROR - There is not enough space available in the docker container."
   echo "$script_name: The container needs at least $REQUIRED_SPACE_GB GB , but only $AVAILABLE_SPACE_GB available."
+  echo "If needed, you can increase the size limit in dockerd using \`--storage-opt dm.basesize=$((REQUIRED_SPACE_GB+1))G -s devicemapper'"
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   exit 1;
 fi;

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/configGrid.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/configGrid.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/enableRAC.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/enableRAC.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/fixupPreq.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/fixupPreq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/functions.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/installDBBinaries.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/installDBBinaries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/installGridBinaries.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/installGridBinaries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/remoteListener.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/remoteListener.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/resetOSPassword.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/resetOSPassword.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/runOracle.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/runOracle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/runUserScripts.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/runUserScripts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/setPassword.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/setPassword.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/setupDB.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/setupDB.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/setupGrid.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/setupGrid.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/setupGridEnv.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/setupGridEnv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/setupLinuxEnv.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/setupLinuxEnv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/setupdockeroracleinit.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/setupdockeroracleinit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/stopOracle.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/12.2.0.1/stopOracle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/AddNode.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/AddNode.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/DelNode.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/DelNode.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/GridHomeCleanup.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/GridHomeCleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/OracleHomeCleanup.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/OracleHomeCleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/applyGridPatch.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/applyGridPatch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/checkDBStatus.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/checkDBStatus.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/checkSpace.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/checkSpace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
@@ -18,6 +18,7 @@ if [ $AVAILABLE_SPACE_GB -lt $REQUIRED_SPACE_GB ]; then
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   echo "$script_name: ERROR - There is not enough space available in the docker container."
   echo "$script_name: The container needs at least $REQUIRED_SPACE_GB GB , but only $AVAILABLE_SPACE_GB available."
+  echo "If needed, you can increase the size limit in dockerd using \`--storage-opt dm.basesize=$((REQUIRED_SPACE_GB+1))G -s devicemapper'"
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   exit 1;
 fi;

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/configGrid.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/configGrid.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/enableRAC.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/enableRAC.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/fixupPreq.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/fixupPreq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/functions.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/installDBBinaries.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/installDBBinaries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/installGridBinaries.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/installGridBinaries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/remoteListener.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/remoteListener.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/resetOSPassword.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/resetOSPassword.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/runOracle.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/runOracle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/runUserScripts.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/runUserScripts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/setPassword.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/setPassword.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/setupDB.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/setupDB.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/setupGrid.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/setupGrid.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/setupGridEnv.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/setupGridEnv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/setupLinuxEnv.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/setupLinuxEnv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/stopOracle.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/18.3.0/stopOracle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/AddNode.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/AddNode.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/DelNode.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/DelNode.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/GridHomeCleanup.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/GridHomeCleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/MultiRACInstall.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/MultiRACInstall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 while true; do
 case "$1" in

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/OracleHomeCleanup.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/OracleHomeCleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/applyGridPatch.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/applyGridPatch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/checkDBStatus.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/checkDBStatus.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/checkSpace.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/checkSpace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.
@@ -18,6 +18,7 @@ if [ $AVAILABLE_SPACE_GB -lt $REQUIRED_SPACE_GB ]; then
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   echo "$script_name: ERROR - There is not enough space available in the docker container."
   echo "$script_name: The container needs at least $REQUIRED_SPACE_GB GB , but only $AVAILABLE_SPACE_GB available."
+  echo "If needed, you can increase the size limit in dockerd using \`--storage-opt dm.basesize=$((REQUIRED_SPACE_GB+1))G -s devicemapper'"
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   exit 1;
 fi;

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/configGrid.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/configGrid.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/enableRAC.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/enableRAC.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/fixupPreq.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/fixupPreq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/functions.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/installDBBinaries.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/installDBBinaries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/installGridBinaries.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/installGridBinaries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/remoteListener.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/remoteListener.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/resetOSPassword.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/resetOSPassword.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/runOracle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/runUserScripts.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/runUserScripts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/setCrontab.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/setCrontab.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 * * * * * /tmp/reset_failed_units.sh

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/setPassword.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/setPassword.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/setupDB.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/setupDB.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/setupGrid.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/setupGrid.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/setupGridEnv.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/setupGridEnv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/setupLinuxEnv.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/setupLinuxEnv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/stopOracle.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/stopOracle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/buildDockerImage.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/buildDockerImage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # 
 # Since: November, 2018
 # Author: paramdeep.saini@oracle.com

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/samples/applypatch/19.3.0/patches/applyDBPatches.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/samples/applypatch/19.3.0/patches/applyDBPatches.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/samples/applypatch/19.3.0/patches/applyGridPatches.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/samples/applypatch/19.3.0/patches/applyGridPatches.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/samples/applypatch/19.3.0/patches/fixupPreq.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/samples/applypatch/19.3.0/patches/fixupPreq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/RAC/OracleRealApplicationClusters/samples/applypatch/buildPatchedDockerImage.sh
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/samples/applypatch/buildPatchedDockerImage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/11.2.0.2/checkDBStatus.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/11.2.0.2/checkDBStatus.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2017 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/11.2.0.2/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/11.2.0.2/runOracle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ############# Execute custom scripts ##############
 function runUserScripts {

--- a/OracleDatabase/SingleInstance/dockerfiles/11.2.0.2/setPassword.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/11.2.0.2/setPassword.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ORACLE_PWD=$1
 

--- a/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/checkDBStatus.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/checkDBStatus.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/checkSpace.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/checkSpace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2017 Oracle and/or its affiliates. All rights reserved.
@@ -18,6 +18,7 @@ if [ $AVAILABLE_SPACE_GB -lt $REQUIRED_SPACE_GB ]; then
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   echo "$script_name: ERROR - There is not enough space available in the docker container."
   echo "$script_name: The container needs at least $REQUIRED_SPACE_GB GB, but only $AVAILABLE_SPACE_GB GB are available."
+  echo "If needed, you can increase the size limit in dockerd using \`--storage-opt dm.basesize=$((REQUIRED_SPACE_GB+1))G -s devicemapper'"
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   exit 1;
 fi;

--- a/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/createDB.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2016 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/installDBBinaries.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/installDBBinaries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2016 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/installPerl.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/installPerl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2016 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/runOracle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2016 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/runUserScripts.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/runUserScripts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2017 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/setPassword.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/setPassword.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2016 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/setupLinuxEnv.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/setupLinuxEnv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2016 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/startDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/startDB.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2016 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/checkDBStatus.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/checkDBStatus.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/checkSpace.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/checkSpace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2017 Oracle and/or its affiliates. All rights reserved.
@@ -18,6 +18,7 @@ if [ $AVAILABLE_SPACE_GB -lt $REQUIRED_SPACE_GB ]; then
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   echo "$script_name: ERROR - There is not enough space available in the docker container."
   echo "$script_name: The container needs at least $REQUIRED_SPACE_GB GB, but only $AVAILABLE_SPACE_GB GB are available."
+  echo "If needed, you can increase the size limit in dockerd using \`--storage-opt dm.basesize=$((REQUIRED_SPACE_GB+1))G -s devicemapper'"
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   exit 1;
 fi;

--- a/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/createDB.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2016 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/installDBBinaries.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/installDBBinaries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2016 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/runOracle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2016 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/runUserScripts.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/runUserScripts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2017 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/setPassword.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/setPassword.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2016 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/setupLinuxEnv.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/setupLinuxEnv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2016 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/startDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/startDB.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2016 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/18.3.0/checkDBStatus.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/18.3.0/checkDBStatus.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/18.3.0/checkSpace.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/18.3.0/checkSpace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
@@ -18,6 +18,7 @@ if [ $AVAILABLE_SPACE_GB -lt $REQUIRED_SPACE_GB ]; then
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   echo "$script_name: ERROR - There is not enough space available in the docker container."
   echo "$script_name: The container needs at least $REQUIRED_SPACE_GB GB, but only $AVAILABLE_SPACE_GB GB are available."
+  echo "If needed, you can increase the size limit in dockerd using \`--storage-opt dm.basesize=$((REQUIRED_SPACE_GB+1))G -s devicemapper'"
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   exit 1;
 fi;

--- a/OracleDatabase/SingleInstance/dockerfiles/18.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/18.3.0/createDB.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/18.3.0/installDBBinaries.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/18.3.0/installDBBinaries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/18.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/18.3.0/runOracle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/18.3.0/runUserScripts.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/18.3.0/runUserScripts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/18.3.0/setPassword.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/18.3.0/setPassword.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/18.3.0/setupLinuxEnv.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/18.3.0/setupLinuxEnv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/18.3.0/startDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/18.3.0/startDB.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/18.4.0/checkDBStatus.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/18.4.0/checkDBStatus.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/18.4.0/checkSpace.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/18.4.0/checkSpace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
@@ -18,6 +18,7 @@ if [ $AVAILABLE_SPACE_GB -lt $REQUIRED_SPACE_GB ]; then
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   echo "$script_name: ERROR - There is not enough space available in the docker container."
   echo "$script_name: The container needs at least $REQUIRED_SPACE_GB GB, but only $AVAILABLE_SPACE_GB GB are available."
+  echo "If needed, you can increase the size limit in dockerd using \`--storage-opt dm.basesize=$((REQUIRED_SPACE_GB+1))G -s devicemapper'"
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   exit 1;
 fi;

--- a/OracleDatabase/SingleInstance/dockerfiles/18.4.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/18.4.0/runOracle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ############# Execute custom scripts ##############
 function runUserScripts {

--- a/OracleDatabase/SingleInstance/dockerfiles/18.4.0/setPassword.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/18.4.0/setPassword.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/checkDBStatus.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/checkDBStatus.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/checkSpace.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/checkSpace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
@@ -18,6 +18,7 @@ if [ $AVAILABLE_SPACE_GB -lt $REQUIRED_SPACE_GB ]; then
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   echo "$script_name: ERROR - There is not enough space available in the docker container."
   echo "$script_name: The container needs at least $REQUIRED_SPACE_GB GB, but only $AVAILABLE_SPACE_GB GB are available."
+  echo "If needed, you can increase the size limit in dockerd using \`--storage-opt dm.basesize=$((REQUIRED_SPACE_GB+1))G -s devicemapper'"
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   exit 1;
 fi;

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/installDBBinaries.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/installDBBinaries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runUserScripts.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runUserScripts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/setPassword.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/setPassword.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/setupLinuxEnv.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/setupLinuxEnv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/startDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/startDB.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/dockerfiles/buildDockerImage.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/buildDockerImage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # 
 # Since: April, 2016
 # Author: gerald.venzl@oracle.com

--- a/OracleDatabase/SingleInstance/samples/applypatch/12.1.0.2/patches/applyPatches.sh
+++ b/OracleDatabase/SingleInstance/samples/applypatch/12.1.0.2/patches/applyPatches.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2017 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/samples/applypatch/12.2.0.1/patches/applyPatches.sh
+++ b/OracleDatabase/SingleInstance/samples/applypatch/12.2.0.1/patches/applyPatches.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2017 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/samples/applypatch/buildPatchedDockerImage.sh
+++ b/OracleDatabase/SingleInstance/samples/applypatch/buildPatchedDockerImage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # 
 # Since: January, 2017
 # Author: gerald.venzl@oracle.com

--- a/OracleDatabase/SingleInstance/samples/customscripts/01_shellExample.sh
+++ b/OracleDatabase/SingleInstance/samples/customscripts/01_shellExample.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "Environment: $(uname -a)";

--- a/OracleDatabase/SingleInstance/tests/helperFunctions.sh
+++ b/OracleDatabase/SingleInstance/tests/helperFunctions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/tests/runAllTests.sh
+++ b/OracleDatabase/SingleInstance/tests/runAllTests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2017 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/tests/runContainerTests.sh
+++ b/OracleDatabase/SingleInstance/tests/runContainerTests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2017 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/tests/runContainerTests112.sh
+++ b/OracleDatabase/SingleInstance/tests/runContainerTests112.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/tests/runContainerTests121.sh
+++ b/OracleDatabase/SingleInstance/tests/runContainerTests121.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/tests/runContainerTests122.sh
+++ b/OracleDatabase/SingleInstance/tests/runContainerTests122.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/tests/runContainerTests183.sh
+++ b/OracleDatabase/SingleInstance/tests/runContainerTests183.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/tests/runContainerTests184.sh
+++ b/OracleDatabase/SingleInstance/tests/runContainerTests184.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.

--- a/OracleDatabase/SingleInstance/tests/runImageBuildTests.sh
+++ b/OracleDatabase/SingleInstance/tests/runImageBuildTests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # LICENSE UPL 1.0
 #
 # Copyright (c) 1982-2017 Oracle and/or its affiliates. All rights reserved.


### PR DESCRIPTION
* Use `/usr/bin/env bash` to avoid issues on distros that don't provide
  `/bin/bash` (e.g. NixOS).
* Give a hint how to increase storage-size in dockerd
  if the space-check fails.