### PR TITLE
Changes for creating 12.2.1.3.2 docker image that will work with OpenShift

### DIFF
--- a/OracleCoherence/README.md
+++ b/OracleCoherence/README.md
@@ -83,6 +83,31 @@ Follow this procedure for Coherence 12.2.1.3.0 and earlier Coherence versions.
 
 6. The image is built with a shell script as its ENTRYPOINT that allows the image to be run using the normal Docker run command. See the [Image Usage](00.imageusage) documentation.
 
+### For Coherence 12.2.1.3.2 follow this process
+
+1. Checkout the GitHub Oracle Docker Images repository
+
+	`$ git clone git@github.com:oracle/docker-images.git`
+
+2. Go to the **OracleCoherence/dockerfiles/12.2.1.3.2** folder
+
+        $ cd OracleCoherence/dockerfiles/12.2.1.3.2
+
+3. [Download](https://www.oracle.com/middleware/technologies/coherence-downloads.html) and drop the Coherence distribution file of your choice into this folder. The build script supports either building an image from either the Standalone Installer, **fmw_12.2.1.3.0_coherence_Disk1_1of1.zip** or the Quick Installer **fmw_12.2.1.3.0_coherence_quick_Disk1_1of1.zip**
+
+4. Download [Coherence 12.2.1.3.2 cumulative patch file](https://updates.oracle.com/Orion/PatchDetails/process_form?patch_num=29204496) into this folder
+
+5. Execute the build script `buildDockerImage.sh`.
+
+        $ cd ..
+        $ sh buildDockerImage.sh -v 12.2.1.3.2
+
+    or if your Docker client requires commands to be run as root you can run
+
+        $ sudo sh buildDockerImage.sh -v 12.2.1.3.2
+
+6. The resulting image file will be called oracle/coherence:${version}-${distribution}, for example if the Standalone installer is used the image will be `oracle/coherence:12.2.1.3.2-standalone`
+
 ## Documentation
 Documentation covering the different aspects of running Oracle Coherence in Docker containers is covered in the [docs](docs) section.
 

--- a/OracleCoherence/dockerfiles/12.2.1.3.2/Dockerfile.quickinstall
+++ b/OracleCoherence/dockerfiles/12.2.1.3.2/Dockerfile.quickinstall
@@ -1,0 +1,114 @@
+# LICENSE UPL 1.0
+#
+# ORACLE DOCKERFILES PROJECT
+# --------------------------
+# This is the Dockerfile for Coherence 12.2.1 Quick Install Distribution
+# 
+# REQUIRED BASE IMAGE TO BUILD THIS IMAGE
+# ---------------------------------------
+# This Dockerfile requires the base image oracle/serverjre:8
+# (see https://github.com/oracle/docker-images/tree/master/OracleJava)
+#
+# REQUIRED FILES TO BUILD THIS IMAGE
+# ----------------------------------
+# (1) fmw_12.2.1.3.0_coherence_quick_Disk1_1of1.zip
+#
+#     Download the Quick installer from http://www.oracle.com/technetwork/middleware/coherence/downloads/index.html
+#
+# (2) p29204496_122130_Generic.zip
+#
+#      Download file Coherence 12.2.1.3.2 Cumulative Patch from https://updates.oracle.com/Orion/PatchDetails/process_form?patch_num=29204496
+#
+# HOW TO BUILD THIS IMAGE
+# -----------------------
+# Put all downloaded files in the same directory as this Dockerfile
+# Run: 
+#      $ sh buildDockerImage.sh -q
+#
+# or if your Docker client requires root access you can run:
+#      $ sudo sh buildDockerImage.sh -q
+#
+
+# Pull base image
+# ---------------
+FROM oracle/serverjre:8 AS builder
+
+# Maintainer
+# ----------
+MAINTAINER Patrick Fry <patrick.fry@oracle.com>
+
+# Environment variables required for this build (do NOT change)
+ENV FMW_PKG=fmw_12.2.1.3.0_coherence_quick_Disk1_1of1.zip \
+    FMW_JAR=fmw_12.2.1.3.0_coherence_quick.jar \
+    ORACLE_HOME=/u01/oracle/oracle_home \
+    PATH=$PATH:/usr/java/default/bin:/u01/oracle/oracle_home/oracle_common/common/bin \
+    PATCH_PKG="p29204496_122130_Generic.zip" \
+    COHERENCE_HOME=/u01/oracle/oracle_home/coherence \
+    CONFIG_JVM_ARGS="-Djava.security.egd=file:/dev/./urandom"
+
+RUN mkdir -p /u01 && \
+   useradd -b /u01 -d /u01/oracle -m -s /bin/bash -u 1000 -g 0 oracle
+
+# Copy files required to build this image
+COPY $FMW_PKG install.file oraInst.loc /u01/
+COPY $PATCH_PKG /u01/
+
+RUN chmod a+xr /u01 && \
+    chown -R oracle:root /u01
+
+USER oracle
+
+# Install and configure Oracle Coherence
+# Setup required packages (unzip), filesystem, and oracle user
+RUN cd /u01 && $JAVA_HOME/bin/jar xf /u01/$FMW_PKG && cd - && \
+    cd /u01 && $JAVA_HOME/bin/jar xf /u01/$PATCH_PKG && cd - && \
+    $JAVA_HOME/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME && \
+    cd /u01/122132 && $ORACLE_HOME/OPatch/opatch apply -silent && cd - && \
+    rm -rf /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file /u01/122132 /u01/$PATCH_PKG
+
+USER root
+
+COPY start.sh                      /start.sh
+COPY extend-cache-config.xml       $COHERENCE_HOME/conf/extend-cache-config.xml
+
+RUN chgrp -R root /u01 && \
+    chmod -R g=u /u01 && \
+    chmod 755 /start.sh && \
+    chgrp -R root /start.sh && \
+    chmod -R g=u /start.sh
+
+# ---------------------------------------------------------------------------
+# Final stage image containing the installed Oracle Home
+FROM oracle/serverjre:8
+
+ENV ORACLE_HOME=/u01/oracle/oracle_home \
+    PATH=$PATH:/usr/java/default/bin:/u01/oracle/oracle_home/oracle_common/common/bin \
+    CONFIG_JVM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
+    COHERENCE_HOME=/u01/oracle/oracle_home/coherence
+
+# Create the oracle user with the uid 1000
+# Allow the start script to dynamically modify the /etc/passwd file when
+# running in environments that create a dynamic user
+# see: https://docs.okd.io/latest/creating_images/guidelines.html
+RUN mkdir -p /u01 && \
+    mkdir -p /logs && \
+    chgrp -R root /logs && \
+    chmod -R g=u /logs && \
+    useradd -b /u01 -d /u01/oracle -m -s /bin/bash -u 1000 -g 0 oracle && \
+    chmod g=u /etc/passwd && \
+    chgrp -R root /u01 && \
+    chmod -R g=u /u01
+
+# The directories copied below are created with the owner oracle and the group 0 (root)
+# This ensures that the image is compatible with OpenShift which runs containers with a
+# random user that is a member of the root group regardless of the user configured in
+# this Dockerfile.
+# see: https://docs.okd.io/latest/creating_images/guidelines.html
+COPY --from=builder --chown=oracle:root /u01/oracle    /u01/oracle
+COPY --from=builder --chown=oracle:root /start.sh      /start.sh
+
+# The oracle user was added with the uid 1000. We use the uid here rather than the username
+# for OpenShift best practice - see https://docs.okd.io/latest/creating_images/guidelines.html
+USER 1000
+
+ENTRYPOINT ["/start.sh"]

--- a/OracleCoherence/dockerfiles/12.2.1.3.2/Dockerfile.standalone
+++ b/OracleCoherence/dockerfiles/12.2.1.3.2/Dockerfile.standalone
@@ -1,0 +1,114 @@
+# LICENSE UPL 1.0
+#
+# ORACLE DOCKERFILES PROJECT
+# --------------------------
+# This is the Dockerfile for Coherence 12.2.1 Standalone Distribution
+# 
+# REQUIRED BASE IMAGE TO BUILD THIS IMAGE
+# ---------------------------------------
+# This Dockerfile requires the base image oracle/serverjre:8
+# (see https://github.com/oracle/docker-images/tree/master/OracleJava)
+#
+# REQUIRED FILES TO BUILD THIS IMAGE
+# ----------------------------------
+# (1) fmw_12.2.1.3.0_coherence_Disk1_1of1.zip
+#
+#     Download the Standalone installer from http://www.oracle.com/technetwork/middleware/coherence/downloads/index.html
+#
+# (2) p29204496_122130_Generic.zip
+#
+#      Download file Coherence 12.2.1.3.2 Cumulative Patch from https://updates.oracle.com/Orion/PatchDetails/process_form?patch_num=29204496
+#
+# HOW TO BUILD THIS IMAGE
+# -----------------------
+# Put all downloaded files in the same directory as this Dockerfile
+# Run: 
+#      $ sh buildDockerImage.sh -s
+#
+# or if your Docker client requires root access you can run:
+#      $ sudo sh buildDockerImage.sh -s
+#
+
+# Pull base image
+# ---------------
+FROM oracle/serverjre:8 AS builder
+
+# Maintainer
+# ----------
+MAINTAINER Patrick Fry <patrick.fry@oracle.com>
+
+# Environment variables required for this build (do NOT change)
+ENV FMW_PKG=fmw_12.2.1.3.0_coherence_Disk1_1of1.zip \
+    FMW_JAR=fmw_12.2.1.3.0_coherence.jar \
+    ORACLE_HOME=/u01/oracle/oracle_home \
+    PATH=$PATH:/usr/java/default/bin:/u01/oracle/oracle_home/oracle_common/common/bin \
+    PATCH_PKG="p29204496_122130_Generic.zip" \
+    COHERENCE_HOME=/u01/oracle/oracle_home/coherence \
+    CONFIG_JVM_ARGS="-Djava.security.egd=file:/dev/./urandom"
+
+RUN mkdir -p /u01 && \
+   useradd -b /u01 -d /u01/oracle -m -s /bin/bash -u 1000 -g 0 oracle
+
+# Copy files required to build this image
+COPY $FMW_PKG install.file oraInst.loc /u01/
+COPY $PATCH_PKG /u01/
+
+RUN chmod a+xr /u01 && \
+    chown -R oracle:root /u01
+
+USER oracle
+
+# Install and configure Oracle JDK
+# Setup required packages (unzip), filesystem, and oracle user
+RUN cd /u01 && $JAVA_HOME/bin/jar xf /u01/$FMW_PKG && cd - && \
+    cd /u01 && $JAVA_HOME/bin/jar xf /u01/$PATCH_PKG && cd - && \
+    $JAVA_HOME/bin/java -jar /u01/$FMW_JAR -silent -responseFile /u01/install.file -invPtrLoc /u01/oraInst.loc -jreLoc $JAVA_HOME -ignoreSysPrereqs -force -novalidation ORACLE_HOME=$ORACLE_HOME && \
+    cd /u01/122132 && $ORACLE_HOME/OPatch/opatch apply -silent && cd - && \
+    rm -rf /u01/$FMW_JAR /u01/$FMW_PKG /u01/oraInst.loc /u01/install.file /u01/122132 /u01/$PATCH_PKG
+
+USER root
+
+COPY start.sh                      /start.sh
+COPY extend-cache-config.xml       $COHERENCE_HOME/conf/extend-cache-config.xml
+
+RUN chgrp -R root /u01 && \
+    chmod -R g=u /u01 && \
+    chmod 755 /start.sh && \
+    chgrp -R root /start.sh && \
+    chmod -R g=u /start.sh
+
+# ---------------------------------------------------------------------------
+# Final stage image containing the installed Oracle Home
+FROM oracle/serverjre:8
+
+ENV ORACLE_HOME=/u01/oracle/oracle_home \
+    PATH=$PATH:/usr/java/default/bin:/u01/oracle/oracle_home/oracle_common/common/bin \
+    CONFIG_JVM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
+    COHERENCE_HOME=/u01/oracle/oracle_home/coherence
+
+# Create the oracle user with the uid 1000
+# Allow the start script to dynamically modify the /etc/passwd file when
+# running in environments that create a dynamic user
+# see: https://docs.okd.io/latest/creating_images/guidelines.html
+RUN mkdir -p /u01 && \
+    mkdir -p /logs && \
+    chgrp -R root /logs && \
+    chmod -R g=u /logs && \
+    useradd -b /u01 -d /u01/oracle -m -s /bin/bash -u 1000 -g 0 oracle && \
+    chmod g=u /etc/passwd && \
+    chgrp -R root /u01 && \
+    chmod -R g=u /u01
+
+# The directories copied below are created with the owner oracle and the group 0 (root)
+# This ensures that the image is compatible with OpenShift which runs containers with a
+# random user that is a member of the root group regardless of the user configured in
+# this Dockerfile.
+# see: https://docs.okd.io/latest/creating_images/guidelines.html
+COPY --from=builder --chown=oracle:root /u01/oracle    /u01/oracle
+COPY --from=builder --chown=oracle:root /start.sh      /start.sh
+
+# The oracle user was added with the uid 1000. We use the uid here rather than the username
+# for OpenShift best practice - see https://docs.okd.io/latest/creating_images/guidelines.html
+USER 1000
+
+ENTRYPOINT ["/start.sh"]

--- a/OracleCoherence/dockerfiles/12.2.1.3.2/extend-cache-config.xml
+++ b/OracleCoherence/dockerfiles/12.2.1.3.2/extend-cache-config.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0"?>
+
+<!--
+This XML document is a default Coherence Cache Configuration deployment descriptor that should be
+customized (or replaced) for your particular caching and deployment requirements.
+
+This configuration is usable in servers, proxies, clustered clients, and non-clustered extend clients.
+
+When used from within a server such a DefaultCacheServer, the server will automatically host a storage enabled cache
+service as well as a proxy service to allow extend clients to access the caches.  Clients using the configuration are
+storage disabled by default.
+
+This configuration defines a number of inter-related cache schemes:
+
+ - server      - this scheme defines the storage tier for all caches
+ - thin-direct - this scheme is for use by cluster members to access the caches hosted by the "server" scheme
+ - near-direct - this scheme adds near caching to "thin-direct"
+ - thin-remote - conceptually similar to "thin-direct" but for use by extend clients
+ - near-remote - conceptually similar to "near-direct" but for use by extend clients
+
+The default scheme for caches is "near-direct".  This default can be overridden via two system properties.  The
+"coherence.profile" system property controls the first portion of the scheme name and defines the approach used for
+in-process caching, i.e. "near" (on-demand) or "thin" (none).  The "coherence.client" system property controls how a
+client connects to the cluster, i.e. "direct" (cluster member) or "remote" (extend client).
+
+Note: System properties defined within this cache configuration are specific to this configuration and are not
+meaningful to other cache configurations unless similarly defined there.
+-->
+<cache-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xmlns="http://xmlns.oracle.com/coherence/coherence-cache-config"
+              xsi:schemaLocation="http://xmlns.oracle.com/coherence/coherence-cache-config coherence-cache-config.xsd">
+  <caching-scheme-mapping>
+    <cache-mapping>
+      <cache-name>*</cache-name>
+      <scheme-name>${coherence.profile near}-${coherence.client direct}</scheme-name>
+    </cache-mapping>
+  </caching-scheme-mapping>
+
+  <caching-schemes>
+    <!-- near caching scheme for clustered clients -->
+    <near-scheme>
+      <scheme-name>near-direct</scheme-name>
+      <front-scheme>
+        <local-scheme>
+          <high-units>{front-limit-entries 10000}</high-units>
+        </local-scheme>
+      </front-scheme>
+      <back-scheme>
+        <distributed-scheme>
+          <scheme-ref>thin-direct</scheme-ref>
+        </distributed-scheme>
+      </back-scheme>
+    </near-scheme>
+
+    <!-- near caching scheme for extend clients -->
+    <near-scheme>
+      <scheme-name>near-remote</scheme-name>
+      <scheme-ref>near-direct</scheme-ref>
+      <back-scheme>
+        <remote-cache-scheme>
+          <scheme-ref>thin-remote</scheme-ref>
+        </remote-cache-scheme>
+      </back-scheme>
+    </near-scheme>
+
+    <!-- remote caching scheme for accessing the proxy from extend clients -->
+    <remote-cache-scheme>
+      <scheme-name>thin-remote</scheme-name>
+      <service-name>RemoteCache</service-name>
+      <proxy-service-name>Proxy</proxy-service-name>
+    </remote-cache-scheme>
+
+    <!-- partitioned caching scheme for clustered clients -->
+    <distributed-scheme>
+      <scheme-name>thin-direct</scheme-name>
+      <scheme-ref>server</scheme-ref>
+      <local-storage system-property="coherence.distributed.localstorage">false</local-storage>
+      <autostart>false</autostart>
+    </distributed-scheme>
+
+    <!-- partitioned caching scheme for servers -->
+    <distributed-scheme>
+      <scheme-name>server</scheme-name>
+      <service-name>PartitionedCache</service-name>
+      <local-storage system-property="coherence.distributed.localstorage">true</local-storage>
+      <backing-map-scheme>
+        <local-scheme>
+          <high-units>{back-limit-bytes 0B}</high-units>
+        </local-scheme>
+      </backing-map-scheme>
+      <autostart>true</autostart>
+    </distributed-scheme>
+
+    <!-- proxy scheme that allows extend clients to connect to the cluster over TCP/IP -->
+    <proxy-scheme>
+      <service-name>Proxy</service-name>
+      <acceptor-config>
+        <tcp-acceptor>
+          <local-address>
+            <address system-property="coherence.extend.address"/>
+            <port system-property="coherence.extend.port"/>
+          </local-address>
+        </tcp-acceptor>
+      </acceptor-config>
+      <autostart>true</autostart>
+    </proxy-scheme>
+  </caching-schemes>
+</cache-config>

--- a/OracleCoherence/dockerfiles/12.2.1.3.2/install.file
+++ b/OracleCoherence/dockerfiles/12.2.1.3.2/install.file
@@ -1,0 +1,13 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# 
+# Copyright (c) 2016, 2019 Oracle and/or its affiliates. All rights reserved.
+[ENGINE]
+
+#DO NOT CHANGE THIS.
+Response File Version=1.0.0.0.0
+
+[GENERIC]
+
+DECLINE_AUTO_UPDATES=true
+ORACLE_HOME=/u01/oracle/oracle_home
+INSTALL_TYPE=Typical

--- a/OracleCoherence/dockerfiles/12.2.1.3.2/oraInst.loc
+++ b/OracleCoherence/dockerfiles/12.2.1.3.2/oraInst.loc
@@ -1,0 +1,2 @@
+inventory_loc=/u01/oracle/.inventory
+inst_group=oracle

--- a/OracleCoherence/dockerfiles/12.2.1.3.2/p29204496_122130_Generic.download
+++ b/OracleCoherence/dockerfiles/12.2.1.3.2/p29204496_122130_Generic.download
@@ -1,0 +1,8 @@
+# Download this file from the following address:
+#
+# https://support.oracle.com
+#
+# 1) Download the ZIP file "Patch" for Coherence 12.2.1.3
+# 2) Put the ZIP file in the same location as this .download file
+# 
+975fb81ad50af1231c456fb171e47185 p29204496_122130_Generic.zip

--- a/OracleCoherence/dockerfiles/12.2.1.3.2/start.sh
+++ b/OracleCoherence/dockerfiles/12.2.1.3.2/start.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env sh
+
+#!/bin/sh -e -x -u
+
+trap "echo TRAPed signal" HUP INT QUIT KILL TERM
+
+main() {
+#   Support running as an arbitrary user. See OpenShift best practice https://docs.okd.io/latest/creating_images/guidelines.html
+    if ! whoami &> /dev/null; then
+      if [ -w /etc/passwd ]; then
+        echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
+      fi
+    fi
+
+    COMMAND=server
+    SCRIPT_NAME=$(basename "${0}")
+    MAIN_CLASS="com.tangosol.net.DefaultCacheServer"
+
+    case "${1}" in
+        server) COMMAND=${1}; shift ;;
+        console) COMMAND=${1}; shift ;;
+        queryplus) COMMAND=queryPlus; shift ;;
+        help) COMMAND=${1}; shift ;;
+    esac
+
+    case ${COMMAND} in
+        server) server ;;
+        console) console ;;
+        queryPlus) queryPlus ;;
+        help) usage; exit ;;
+        *) server ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Display the help text for this script
+# ---------------------------------------------------------------------------
+usage() {
+    echo "Usage: ${SCRIPT_NAME} [type] [args]"
+    echo ""
+    echo "type: - the type of process to run, must be one of:"
+    echo "    server  - runs a storage enabled DefaultCacheServer"
+    echo "              (server is the default if type is omitted)"
+    echo "    console - runs a storage disabled Coherence console"
+    echo "    query   - runs a storage disabled QueryPlus session"
+    echo "    help    - displays this usage text"
+    echo ""
+    echo "args: - any subsequent arguments are passed as program args to the main class"
+    echo ""
+    echo "Environment Variables: The following environment variables affect the script operation"
+    echo ""
+    echo "JAVA_OPTS       - this environment variable adds Java options to the start command,"
+    echo "                  for example memory and other system properties"
+    echo ""
+    echo "COH_WKA         - Sets the WKA address to use to discover a Coherence cluster."
+    echo ""
+    echo "COH_EXTEND_PORT - If set the Extend Proxy Service will listen on this port instead"
+    echo "                  of the default ephemeral port."
+    echo ""
+    echo "Any jar files added to the /lib folder will be pre-pended to the classpath."
+    echo "The /conf folder is on the classpath so any files in this folder can be loaded by the process."
+    echo ""
+}
+
+server() {
+    PROPS=""
+    CLASSPATH=""
+    MAIN_CLASS="com.tangosol.net.DefaultCacheServer"
+    start
+}
+
+console() {
+    PROPS="-Dcoherence.localstorage=false"
+    CLASSPATH=""
+    MAIN_CLASS="com.tangosol.net.CacheFactory"
+    start
+}
+
+queryPlus() {
+    PROPS="-Dcoherence.localstorage=false"
+    CLASSPATH=""
+    MAIN_CLASS="com.tangosol.coherence.dslquery.QueryPlus"
+    start
+}
+
+start() {
+
+    if [ "${COH_WKA}" != "" ]
+    then
+       PROPS="${PROPS} -Dcoherence.wka=${COH_WKA}"
+    fi
+
+    if [ "${COH_EXTEND_PORT}" != "" ]
+    then
+       PROPS="${PROPS} -Dcoherence.cacheconfig=extend-cache-config.xml -Dcoherence.extend.port=${COH_EXTEND_PORT}"
+    fi
+
+    CLASSPATH="/conf:/lib/*:${CLASSPATH}:${COHERENCE_HOME}/conf:${COHERENCE_HOME}/lib/coherence.jar"
+
+    CMD="${JAVA_HOME}/bin/java -cp ${CLASSPATH} ${PROPS} ${JAVA_OPTS} ${MAIN_CLASS} ${COH_MAIN_ARGS}"
+
+    echo "Starting Coherence ${COMMAND} using ${CMD}"
+
+    exec ${CMD}
+}
+
+main "$@"

--- a/OracleCoherence/dockerfiles/buildDockerImage.sh
+++ b/OracleCoherence/dockerfiles/buildDockerImage.sh
@@ -69,9 +69,9 @@ else
 # If neither -s or -q were specified then determine which image we are building
 # by which installer is present. If both the Standard and Quick installers are
 # present then the Standard installer will be used.
-  if [ -f "fmw_${VERSION}_coherence_Disk1_1of1.zip" ]; then
+  if [ -f fmw_*_coherence_Disk1_1of1.zip ]; then
     DISTRIBUTION="standalone"
-  elif [ -f "fmw_${VERSION}_coherence_quick_Disk1_1of1.zip" ]; then
+  elif [ -f fmw_*_coherence_quick_Disk1_1of1.zip ]; then
     DISTRIBUTION="quickinstall"
   else
     echo "A valid distribution type argument has not been provided and no installer file can be found."


### PR DESCRIPTION
This fix will address https://github.com/oracle/docker-images/issues/1523

The current scheme of creating 12.2.1.3.2 image by using Coherence 12.2.1.3.0 base image and then patching it with Coherence cumulative patch, bloats the size of the image. 

Creation is now handled by Dockerfiles specialized for this in a separate 12.2.1.3.2 directory and include fixes for running on OpenShift.