### PR TITLE
Removes oracle-database-xe.rpm from Docker Image

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/18.4.0/Dockerfile.xe
+++ b/OracleDatabase/SingleInstance/dockerfiles/18.4.0/Dockerfile.xe
@@ -53,6 +53,7 @@ RUN chmod ug+x $INSTALL_DIR/*.sh && \
     yum -y install openssl oracle-database-preinstall-18c && \
     yum -y localinstall $INSTALL_FILE_1 && \
     rm -rf /var/cache/yum && \
+    rm -rf /var/tmp/yum-* && \
     mkdir -p $ORACLE_BASE/scripts/setup && \
     mkdir $ORACLE_BASE/scripts/startup && \
     ln -s $ORACLE_BASE/scripts /docker-entrypoint-initdb.d && \


### PR DESCRIPTION
If I build an Oracle XE Docker Image by calling
```
% ./buildDockerImage.sh -v 18.4.0 -x
```
and then run the image in interactive mode
```
% docker run -it oracle/database:18.4.0-xe /bin/bash
```
I will see that the rather large `oracle-database-xe-18c-1.0-1.x86_64.rpm` is saved in the container:
```
# ls -lah /var/tmp/yum-root-6gKIob/
total 2.4G
drwx------ 2 root root 4.0K Mar 12 12:15 .
drwxrwxrwt 1 root root 4.0K Mar 12 12:35 ..
-rw-r--r-- 1 root root 2.4G Jan 21 15:53 oracle-database-xe-18c-1.0-1.x86_64.rpm
```
This PR deletes the folder `/var/tmp/yum-*`.