### PR TITLE
Allow the initial amount of memory for databases to be configurable

### DIFF
--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -59,6 +59,7 @@ To run your Oracle Database Docker image use the **docker run** command as follo
 	-e ORACLE_SID=<your SID> \
 	-e ORACLE_PDB=<your PDB name> \
 	-e ORACLE_PWD=<your database passwords> \
+	-e ORACLE_MEM=<amount of memory to allocate> \
 	-e ORACLE_CHARACTERSET=<your character set> \
 	-v [<host mount point>:]/opt/oracle/oradata \
 	oracle/database:19.3.0-ee
@@ -70,6 +71,8 @@ To run your Oracle Database Docker image use the **docker run** command as follo
 	   -e ORACLE_SID: The Oracle Database SID that should be used (default: ORCLCDB)
 	   -e ORACLE_PDB: The Oracle Database PDB name that should be used (default: ORCLPDB1)
 	   -e ORACLE_PWD: The Oracle Database SYS, SYSTEM and PDB_ADMIN password (default: auto generated)
+	   -e ORACLE_MEM: The amount of memory in MB to allocate to Oracle. 
+	                  If you bump this up too much you might need to change your Docker settings to allocate more memory to Docker. 19c only. (default: 2048)
 	   -e ORACLE_CHARACTERSET:
 	                  The character set to use when creating the database (default: AL32UTF8)
 	   -v /opt/oracle/oradata

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
@@ -34,7 +34,6 @@ sed -i -e "s|###ORACLE_SID###|$ORACLE_SID|g" $ORACLE_BASE/dbca.rsp
 sed -i -e "s|###ORACLE_PDB###|$ORACLE_PDB|g" $ORACLE_BASE/dbca.rsp
 sed -i -e "s|###ORACLE_PWD###|$ORACLE_PWD|g" $ORACLE_BASE/dbca.rsp
 sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" $ORACLE_BASE/dbca.rsp
-sed -i -e "s|###ORACLE_MEM###|$ORACLE_MEM|g" $ORACLE_BASE/dbca.rsp
 
 # If there is greater than 8 CPUs default back to dbca memory calculations
 # dbca will automatically pick 40% of available memory for Oracle DB
@@ -42,7 +41,9 @@ sed -i -e "s|###ORACLE_MEM###|$ORACLE_MEM|g" $ORACLE_BASE/dbca.rsp
 # However, bigger environment can and should use more of the available memory
 # This is due to Github Issue #307
 if [ `nproc` -gt 8 ]; then
-   sed -i -e "s|totalMemory=2048||g" $ORACLE_BASE/dbca.rsp
+   sed -i -e "s|totalMemory=###ORACLE_MEM###||g" $ORACLE_BASE/dbca.rsp
+else
+   sed -i -e "s|###ORACLE_MEM###|$ORACLE_MEM|g" $ORACLE_BASE/dbca.rsp
 fi;
 
 # Create network related config files (sqlnet.ora, tnsnames.ora, listener.ora)

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
@@ -25,12 +25,16 @@ export ORACLE_PDB=${2:-ORCLPDB1}
 export ORACLE_PWD=${3:-"`openssl rand -base64 8`1"}
 echo "ORACLE PASSWORD FOR SYS, SYSTEM AND PDBADMIN: $ORACLE_PWD";
 
+# Total memory in MB to allocate to Oracle
+export ORACLE_MEM=${ORACLE_MEM:-2048}
+
 # Replace place holders in response file
 cp $ORACLE_BASE/$CONFIG_RSP $ORACLE_BASE/dbca.rsp
 sed -i -e "s|###ORACLE_SID###|$ORACLE_SID|g" $ORACLE_BASE/dbca.rsp
 sed -i -e "s|###ORACLE_PDB###|$ORACLE_PDB|g" $ORACLE_BASE/dbca.rsp
 sed -i -e "s|###ORACLE_PWD###|$ORACLE_PWD|g" $ORACLE_BASE/dbca.rsp
 sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" $ORACLE_BASE/dbca.rsp
+sed -i -e "s|###ORACLE_MEM###|$ORACLE_MEM|g" $ORACLE_BASE/dbca.rsp
 
 # If there is greater than 8 CPUs default back to dbca memory calculations
 # dbca will automatically pick 40% of available memory for Oracle DB

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/dbca.rsp.tmpl
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/dbca.rsp.tmpl
@@ -201,4 +201,4 @@ automaticMemoryManagement=FALSE
 # Default value : 
 # Mandatory     : NO
 #-----------------------------------------------------------------------------
-totalMemory=2048
+totalMemory=###ORACLE_MEM###


### PR DESCRIPTION
This is the PR for #1575. 

I have only added this for Oracle 19c. Let me know if this needs to be added for the other versions as well.

Also note I submitted the OCA on 13th April 2020.