### PR TITLE
Updated Dockerfiles with the April 2020 CPU releases

### DIFF
--- a/OracleJava/java-11/Dockerfile
+++ b/OracleJava/java-11/Dockerfile
@@ -41,8 +41,8 @@ ENV LANG en_US.UTF-8
 # Environment variables for the builder image.  
 # Required to validate that you are using the correct file
 
-ENV JAVA_PKG=jdk-11.0.6_linux-x64_bin.tar.gz \
-	JAVA_SHA256=a11bac55a96493556f349eead956b94d32f6a71031373771dca4cc72b89a82b4 \
+ENV JAVA_PKG=jdk-11.0.7_linux-x64_bin.tar.gz \
+	JAVA_SHA256=a7334a400fe9a9dbb329e299ca5ebab6ec969b5659a3a72fe0d6f981dbca0224 \
 	JAVA_HOME=/usr/java/jdk-11
 
 ##
@@ -59,7 +59,7 @@ FROM oraclelinux:7-slim
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
-ENV JAVA_VERSION=11.0.6 \
+ENV JAVA_VERSION=11.0.7 \
 	JAVA_HOME=/usr/java/jdk-11
 
 ENV	PATH $JAVA_HOME/bin:$PATH	

--- a/OracleJava/java-8/Dockerfile
+++ b/OracleJava/java-8/Dockerfile
@@ -42,8 +42,8 @@ ENV LANG en_US.UTF-8
 # Environment variables for the builder image.  
 # Required to validate that you are using the correct file
 
-ENV JAVA_PKG=server-jre-8u241-linux-x64.tar.gz \
-	JAVA_SHA256=d2ae0d694eb1a1f6e87678028ff5a74e2b4ea3011ca687016e7611bed1e82d0e \
+ENV JAVA_PKG=server-jre-8u251-linux-x64.tar.gz \
+	JAVA_SHA256=af737e1315e2b211b88f24ee632d24c192e0b3a802625f367ae1b80a00fd4546 \
 	JAVA_HOME=/usr/java/jdk-8
 
 COPY $JAVA_PKG /tmp/jdk.tgz
@@ -60,7 +60,7 @@ FROM oraclelinux:7-slim
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
-ENV JAVA_VERSION=1.8.0_241 \
+ENV JAVA_VERSION=1.8.0_251 \
 	JAVA_HOME=/usr/java/jdk-8 
 	
 ENV	PATH $JAVA_HOME/bin:$PATH


### PR DESCRIPTION
Updated 8u241 to 8u251 and 11.0.6 to 11.0.7 which released as part of the April 2020.