### PR TITLE
Add oraclelinux:8-slim as base image for GraalVM-CE

### DIFF
--- a/GraalVM/CE/Dockerfile.ol8
+++ b/GraalVM/CE/Dockerfile.ol8
@@ -12,8 +12,8 @@ ARG GRAALVM_PKG=https://github.com/graalvm/graalvm-ce-builds/releases/download/v
 ENV LANG=en_US.UTF-8 JAVA_HOME=/opt/graalvm-ce-$JAVA_VERSION-$GRAALVM_VERSION/
 
 RUN microdnf update -y oraclelinux-release-el8 \
-    && microdnf install -y bzip2-devel ed gcc gcc-c++ gcc-gfortran gzip file fontconfig less libcurl-devel make openssl openssl-devel readline-devel tar vi which xz-devel zlib-devel \
-    && microdnf --enablerepo ol8_codeready_builder install -y glibc-static libstdc++ libstdc++-devel libstdc++-static zlib-static \
+    && microdnf install bzip2-devel ed gcc gcc-c++ gcc-gfortran gzip file fontconfig less libcurl-devel make openssl openssl-devel readline-devel tar vi which xz-devel zlib-devel findutils \
+    && microdnf --enablerepo ol8_codeready_builder install glibc-static libstdc++ libstdc++-devel libstdc++-static zlib-static \
     && microdnf clean all
 
 

--- a/GraalVM/CE/Dockerfile.ol8
+++ b/GraalVM/CE/Dockerfile.ol8
@@ -1,7 +1,5 @@
-# LICENSE UPL 1.0
-#
-# Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
-#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 FROM oraclelinux:8-slim
 
@@ -14,9 +12,9 @@ ARG GRAALVM_PKG=https://github.com/graalvm/graalvm-ce-builds/releases/download/v
 ENV LANG=en_US.UTF-8 JAVA_HOME=/opt/graalvm-ce-$JAVA_VERSION-$GRAALVM_VERSION/
 
 RUN microdnf update -y oraclelinux-release-el8 \
-    && microdnf --enablerepo ol8_appstream install -y bzip2-devel ed gcc gcc-c++ gcc-gfortran gzip file fontconfig less libcurl-devel make openssl openssl-devel readline-devel tar vi which xz-devel zlib-devel \
+    && microdnf install -y bzip2-devel ed gcc gcc-c++ gcc-gfortran gzip file fontconfig less libcurl-devel make openssl openssl-devel readline-devel tar vi which xz-devel zlib-devel \
     && microdnf --enablerepo ol8_codeready_builder install -y glibc-static libstdc++ libstdc++-devel libstdc++-static zlib-static \
-    && microdnf clean all && rm -rf /var/cache/yum
+    && microdnf clean all
 
 
 RUN fc-cache -f -v

--- a/GraalVM/CE/Dockerfile.ol8
+++ b/GraalVM/CE/Dockerfile.ol8
@@ -12,8 +12,8 @@ ARG GRAALVM_PKG=https://github.com/graalvm/graalvm-ce-builds/releases/download/v
 ENV LANG=en_US.UTF-8 JAVA_HOME=/opt/graalvm-ce-$JAVA_VERSION-$GRAALVM_VERSION/
 
 RUN microdnf update -y oraclelinux-release-el8 \
-    && microdnf install bzip2-devel ed gcc gcc-c++ gcc-gfortran gzip file fontconfig less libcurl-devel make openssl openssl-devel readline-devel tar vi which xz-devel zlib-devel findutils \
-    && microdnf --enablerepo ol8_codeready_builder install glibc-static libstdc++ libstdc++-devel libstdc++-static zlib-static \
+    && microdnf --enablerepo ol8_codeready_builder install bzip2-devel ed gcc gcc-c++ gcc-gfortran gzip file fontconfig less libcurl-devel make openssl openssl-devel readline-devel tar \
+    vi which xz-devel zlib-devel findutils glibc-static libstdc++ libstdc++-devel libstdc++-static zlib-static \
     && microdnf clean all
 
 

--- a/GraalVM/CE/Dockerfile.ol8
+++ b/GraalVM/CE/Dockerfile.ol8
@@ -1,0 +1,37 @@
+# LICENSE UPL 1.0
+#
+# Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+#
+
+FROM oraclelinux:8-slim
+
+# Note: If you are behind a web proxy, set the build variables for the build:
+#       E.g.:  docker build --build-arg "https_proxy=..." --build-arg "http_proxy=..." --build-arg "no_proxy=..." ...
+
+ARG GRAALVM_VERSION=20.0.0
+ARG JAVA_VERSION=java8
+ARG GRAALVM_PKG=https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$GRAALVM_VERSION/graalvm-ce-$JAVA_VERSION-linux-amd64-$GRAALVM_VERSION.tar.gz 
+ENV LANG=en_US.UTF-8 JAVA_HOME=/opt/graalvm-ce-$JAVA_VERSION-$GRAALVM_VERSION/
+
+RUN microdnf update -y oraclelinux-release-el8 \
+    && microdnf --enablerepo ol8_appstream install -y bzip2-devel ed gcc gcc-c++ gcc-gfortran gzip file fontconfig less libcurl-devel make openssl openssl-devel readline-devel tar vi which xz-devel zlib-devel \
+    && microdnf --enablerepo ol8_codeready_builder install -y glibc-static libstdc++ libstdc++-devel libstdc++-static zlib-static \
+    && microdnf clean all && rm -rf /var/cache/yum
+
+
+RUN fc-cache -f -v
+
+ADD gu-wrapper.sh /usr/local/bin/gu
+RUN set -eux && curl --fail --silent --location --retry 3 ${GRAALVM_PKG} | gunzip | tar x -C /opt/ \
+    # Set alternative links
+    && mkdir -p "/usr/java" \
+    && ln -sfT "$JAVA_HOME" /usr/java/default \
+    && ln -sfT "$JAVA_HOME" /usr/java/latest \
+    && for bin in "$JAVA_HOME/bin/"*; do \
+    base="$(basename "$bin")"; \
+    [ ! -e "/usr/bin/$base" ]; \
+    alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
+    done \
+    && chmod +x /usr/local/bin/gu
+
+CMD java -version

--- a/GraalVM/CE/Dockerfile.ol8-java11
+++ b/GraalVM/CE/Dockerfile.ol8-java11
@@ -1,0 +1,44 @@
+# LICENSE UPL 1.0
+#
+# Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+#
+
+FROM oraclelinux:8-slim
+
+# Note: If you are behind a web proxy, set the build variables for the build:
+#       E.g.:  docker build --build-arg "https_proxy=..." --build-arg "http_proxy=..." --build-arg "no_proxy=..." ...
+
+ARG GRAALVM_VERSION=20.0.0
+ARG JAVA_VERSION=java11
+ARG GRAALVM_PKG=https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$GRAALVM_VERSION/graalvm-ce-$JAVA_VERSION-GRAALVM_ARCH-$GRAALVM_VERSION.tar.gz 
+ARG TARGETPLATFORM="linux/amd64"
+
+ENV LANG=en_US.UTF-8 JAVA_HOME=/opt/graalvm-ce-$JAVA_VERSION-$GRAALVM_VERSION/
+
+RUN microdnf update -y oraclelinux-release-el8 \
+    && microdnf --enablerepo ol8_appstream install -y bzip2-devel ed gcc gcc-c++ gcc-gfortran gzip file fontconfig less libcurl-devel make openssl openssl-devel readline-devel tar vi which xz-devel zlib-devel \
+    && microdnf --enablerepo ol8_codeready_builder install -y glibc-static libstdc++ libstdc++-devel libstdc++-static zlib-static \
+    && microdnf clean all && rm -rf /var/cache/yum
+
+RUN fc-cache -f -v
+
+ADD gu-wrapper.sh /usr/local/bin/gu
+RUN set -eux \
+    && if [ "$TARGETPLATFORM" == "linux/amd64" ]; then GRAALVM_PKG=${GRAALVM_PKG/GRAALVM_ARCH/linux-amd64}; fi \
+    && if [ "$TARGETPLATFORM" == "linux/arm64" ]; then GRAALVM_PKG=${GRAALVM_PKG/GRAALVM_ARCH/linux-aarch64}; fi \
+    && curl --fail --silent --location --retry 3 ${GRAALVM_PKG} \
+    | gunzip | tar x -C /opt/ \
+
+    # Set alternative links
+    && mkdir -p "/usr/java" \
+    && ln -sfT "$JAVA_HOME" /usr/java/default \
+    && ln -sfT "$JAVA_HOME" /usr/java/latest \
+    && for bin in "$JAVA_HOME/bin/"*; do \
+    base="$(basename "$bin")"; \
+    [ ! -e "/usr/bin/$base" ]; \
+    alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
+    done \
+
+    && chmod +x /usr/local/bin/gu
+
+CMD java -version

--- a/GraalVM/CE/Dockerfile.ol8-java11
+++ b/GraalVM/CE/Dockerfile.ol8-java11
@@ -1,7 +1,5 @@
-# LICENSE UPL 1.0
-#
-# Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
-#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 FROM oraclelinux:8-slim
 
@@ -16,9 +14,9 @@ ARG TARGETPLATFORM
 ENV LANG=en_US.UTF-8 JAVA_HOME=/opt/graalvm-ce-$JAVA_VERSION-$GRAALVM_VERSION/
 
 RUN microdnf update -y oraclelinux-release-el8 \
-    && microdnf --enablerepo ol8_appstream install -y bzip2-devel ed gcc gcc-c++ gcc-gfortran gzip file fontconfig less libcurl-devel make openssl openssl-devel readline-devel tar vi which xz-devel zlib-devel \
+    && microdnf install -y bzip2-devel ed gcc gcc-c++ gcc-gfortran gzip file fontconfig less libcurl-devel make openssl openssl-devel readline-devel tar vi which xz-devel zlib-devel \
     && microdnf --enablerepo ol8_codeready_builder install -y glibc-static libstdc++ libstdc++-devel libstdc++-static zlib-static \
-    && microdnf clean all && rm -rf /var/cache/yum
+    && microdnf clean all
 
 RUN fc-cache -f -v
 

--- a/GraalVM/CE/Dockerfile.ol8-java11
+++ b/GraalVM/CE/Dockerfile.ol8-java11
@@ -11,7 +11,7 @@ FROM oraclelinux:8-slim
 ARG GRAALVM_VERSION=20.0.0
 ARG JAVA_VERSION=java11
 ARG GRAALVM_PKG=https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$GRAALVM_VERSION/graalvm-ce-$JAVA_VERSION-GRAALVM_ARCH-$GRAALVM_VERSION.tar.gz 
-ARG TARGETPLATFORM="linux/amd64"
+ARG TARGETPLATFORM
 
 ENV LANG=en_US.UTF-8 JAVA_HOME=/opt/graalvm-ce-$JAVA_VERSION-$GRAALVM_VERSION/
 

--- a/GraalVM/CE/Dockerfile.ol8-java11
+++ b/GraalVM/CE/Dockerfile.ol8-java11
@@ -14,8 +14,8 @@ ARG TARGETPLATFORM
 ENV LANG=en_US.UTF-8 JAVA_HOME=/opt/graalvm-ce-$JAVA_VERSION-$GRAALVM_VERSION/
 
 RUN microdnf update -y oraclelinux-release-el8 \
-    && microdnf install bzip2-devel ed gcc gcc-c++ gcc-gfortran gzip file fontconfig less libcurl-devel make openssl openssl-devel readline-devel tar vi which xz-devel zlib-devel findutils\
-    && microdnf --enablerepo ol8_codeready_builder install glibc-static libstdc++ libstdc++-devel libstdc++-static zlib-static \
+    && microdnf --enablerepo ol8_codeready_builder install bzip2-devel ed gcc gcc-c++ gcc-gfortran gzip file fontconfig less libcurl-devel make openssl openssl-devel readline-devel tar \
+    vi which xz-devel zlib-devel findutils glibc-static libstdc++ libstdc++-devel libstdc++-static zlib-static \
     && microdnf clean all
 
 RUN fc-cache -f -v

--- a/GraalVM/CE/Dockerfile.ol8-java11
+++ b/GraalVM/CE/Dockerfile.ol8-java11
@@ -14,8 +14,8 @@ ARG TARGETPLATFORM
 ENV LANG=en_US.UTF-8 JAVA_HOME=/opt/graalvm-ce-$JAVA_VERSION-$GRAALVM_VERSION/
 
 RUN microdnf update -y oraclelinux-release-el8 \
-    && microdnf install -y bzip2-devel ed gcc gcc-c++ gcc-gfortran gzip file fontconfig less libcurl-devel make openssl openssl-devel readline-devel tar vi which xz-devel zlib-devel \
-    && microdnf --enablerepo ol8_codeready_builder install -y glibc-static libstdc++ libstdc++-devel libstdc++-static zlib-static \
+    && microdnf install bzip2-devel ed gcc gcc-c++ gcc-gfortran gzip file fontconfig less libcurl-devel make openssl openssl-devel readline-devel tar vi which xz-devel zlib-devel findutils\
+    && microdnf --enablerepo ol8_codeready_builder install glibc-static libstdc++ libstdc++-devel libstdc++-static zlib-static \
     && microdnf clean all
 
 RUN fc-cache -f -v


### PR DESCRIPTION
This PR is based on the discussion #1528 about using OL8 as base image for GraalVM-CE

Signed-off-by: Mohammed Aboullaite <aboullaite.mohammed@gmail.com>