### PR TITLE
double quotes removed from param literal

### DIFF
--- a/OracleWebCenterSites/dockerfiles/12.2.1.4/install.file
+++ b/OracleWebCenterSites/dockerfiles/12.2.1.4/install.file
@@ -7,5 +7,4 @@ Response File Version=1.0.0.0.0
 
 DECLINE_SECURITY_UPDATES=true
 SECURITY_UPDATES_VIA_MYORACLESUPPORT=false
-
-INSTALL_TYPE="WebCenter Sites - With Examples"
+INSTALL_TYPE=WebCenter Sites - With Examples


### PR DESCRIPTION
This is a fix for a internally reported bug.

(Removing internal bug references)