### PR TITLE
Fix setup and startup script location for Oracle Database XE 18.4.0

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/18.4.0/Dockerfile.xe
+++ b/OracleDatabase/SingleInstance/dockerfiles/18.4.0/Dockerfile.xe
@@ -25,9 +25,9 @@ FROM oraclelinux:7-slim
 LABEL "provider"="Oracle"                                               \
       "issues"="https://github.com/oracle/docker-images/issues"         \
       "volume.data"="/opt/oracle/oradata"                               \
-      "volume.setup.location1"="/opt/oracle/scripts/setup"              \
+      "volume.setup.location1"="/u01/app/oracle/scripts/setup"              \
       "volume.setup.location2"="/docker-entrypoint-initdb.d/setup"      \
-      "volume.startup.location1"="/opt/oracle/scripts/startup"          \
+      "volume.startup.location1"="/u01/app/oracle/scripts/startup"          \
       "volume.startup.location2"="/docker-entrypoint-initdb.d/startup"  \
       "port.listener"="1521"                                            \
       "port.oemexpress"="5500"                                          \


### PR DESCRIPTION
According to documentation it should be /u01/app/oracle/scripts/. Closes #1662.