### PR TITLE
ldconfig no longer needed

### DIFF
--- a/OracleLinuxDevelopers/oraclelinux7/python/3.6-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/python/3.6-oracledb/Dockerfile
@@ -9,8 +9,5 @@ RUN yum -y install oracle-release-el7 oraclelinux-developer-release-el7 && \
                    python3-setuptools \
                    python36-cx_Oracle && \
     rm -rf /var/cache/yum/* && \
-    # Enable Oracle Instant Client libraries
-    echo "/usr/lib/oracle/18.3/client64/lib" > /etc/ld.so.conf.d/oracle-instantclient.conf && \
-    /sbin/ldconfig
 
 CMD ["/bin/python3","--version"]


### PR DESCRIPTION
As of Oracle instant client 19, ldconfig is automatically run during RPM install. latest cx_Oracle 8, pulls in instant client 19 via   

Requires: libclntsh.so >= 19.1