### PR TITLE
Adding OpenContainer image-spec labels to OracleLinuxDeveloper images

### DIFF
--- a/OracleLinuxDevelopers/oraclelinux7/golang/1.13/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/golang/1.13/Dockerfile
@@ -2,8 +2,11 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/golang/1.13" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with Golang 1.13 installed."
 
 RUN yum -y install oracle-golang-release-el7 && \
     yum-config-manager --disable ol7_developer_golang114 && \

--- a/OracleLinuxDevelopers/oraclelinux7/golang/1.14/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/golang/1.14/Dockerfile
@@ -2,8 +2,11 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/golang/1.14" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with Golang 1.14 installed."
 
 RUN yum -y install oracle-golang-release-el7 && \
     yum-config-manager --disable ol7_developer_golang115 && \

--- a/OracleLinuxDevelopers/oraclelinux7/golang/1.15/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/golang/1.15/Dockerfile
@@ -2,8 +2,11 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/golang/1.15" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with Golang 1.15 installed."
 
 RUN yum -y install oracle-golang-release-el7 && \
     yum -y install golang && \

--- a/OracleLinuxDevelopers/oraclelinux7/nodejs/10-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/nodejs/10-oracledb/Dockerfile
@@ -2,8 +2,12 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/nodejs/10-oracledb" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with Node.js 10 installed \
+      and Oracle Datbase connectivity enabled."
 
 RUN yum -y install oracle-nodejs-release-el7 oracle-release-el7 && \
     yum-config-manager --disable ol7_developer_nodejs12 && \

--- a/OracleLinuxDevelopers/oraclelinux7/nodejs/10-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/nodejs/10-oracledb/Dockerfile
@@ -7,7 +7,7 @@ LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info
       "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/nodejs/10-oracledb" \
       "org.opencontainers.image.vendor"="Oracle America, Inc" \
       "org.opencontainers.image.description"="Oracle Linux 7 (slim) with Node.js 10 installed \
-      and Oracle Datbase connectivity enabled."
+      and Oracle Database connectivity enabled."
 
 RUN yum -y install oracle-nodejs-release-el7 oracle-release-el7 && \
     yum-config-manager --disable ol7_developer_nodejs12 && \

--- a/OracleLinuxDevelopers/oraclelinux7/nodejs/10/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/nodejs/10/Dockerfile
@@ -2,8 +2,11 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/nodejs/10" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with Node.js 10 installed."
 
 RUN yum -y install oracle-nodejs-release-el7 && \
     yum-config-manager --disable ol7_developer_nodejs12 && \

--- a/OracleLinuxDevelopers/oraclelinux7/nodejs/12-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/nodejs/12-oracledb/Dockerfile
@@ -7,7 +7,7 @@ LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info
       "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/nodejs/12-oracledb" \
       "org.opencontainers.image.vendor"="Oracle America, Inc" \
       "org.opencontainers.image.description"="Oracle Linux 7 (slim) with Node.js 12 installed \
-      and Oracle Datbase connectivity enabled."
+      and Oracle Database connectivity enabled."
 
 RUN yum -y install oracle-nodejs-release-el7 oracle-release-el7 && \
     yum -y install nodejs node-oracledb-node12 && \

--- a/OracleLinuxDevelopers/oraclelinux7/nodejs/12-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/nodejs/12-oracledb/Dockerfile
@@ -2,8 +2,12 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/nodejs/12-oracledb" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with Node.js 12 installed \
+      and Oracle Datbase connectivity enabled."
 
 RUN yum -y install oracle-nodejs-release-el7 oracle-release-el7 && \
     yum -y install nodejs node-oracledb-node12 && \

--- a/OracleLinuxDevelopers/oraclelinux7/nodejs/12/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/nodejs/12/Dockerfile
@@ -2,8 +2,11 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/nodejs/12" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with Node.js 12 installed."
 
 RUN yum -y install oracle-nodejs-release-el7 && \
     yum -y install nodejs && \

--- a/OracleLinuxDevelopers/oraclelinux7/php/7.4-apache-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/php/7.4-apache-oracledb/Dockerfile
@@ -2,8 +2,12 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/php/7.4-apache-oracledb" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with PHP 7.4 and Apache 2.4.6 installed \
+      and Oracle Database connectivity enabled."
 
 RUN yum -y install oracle-php-release-el7 oracle-release-el7 && \
     yum -y install httpd \

--- a/OracleLinuxDevelopers/oraclelinux7/php/7.4-apache/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/php/7.4-apache/Dockerfile
@@ -2,8 +2,11 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/php/7.4-apache" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with PHP 7.4 and Apache 2.4.6 installed."
 
 RUN yum -y install oracle-php-release-el7 && \
     yum -y install httpd \

--- a/OracleLinuxDevelopers/oraclelinux7/php/7.4-cli-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/php/7.4-cli-oracledb/Dockerfile
@@ -2,8 +2,12 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/php/7.4-cli-oracledb" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with PHP 7.4 installed \
+      and Oracle Database connectivity enabled."
 
 RUN yum -y install oracle-php-release-el7 oracle-release-el7 && \
     yum -y install oracle-instantclient19.5-basic \

--- a/OracleLinuxDevelopers/oraclelinux7/php/7.4-cli/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/php/7.4-cli/Dockerfile
@@ -2,8 +2,11 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/php/7.4-cli" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with PHP 7.4 installed."
 
 RUN yum -y install oracle-php-release-el7 && \
     yum -y install php-cli \

--- a/OracleLinuxDevelopers/oraclelinux7/php/7.4-fpm-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/php/7.4-fpm-oracledb/Dockerfile
@@ -3,8 +3,12 @@
 
 FROM oraclelinux:7-slim
 
-LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/php/7.4-fpm-oracledb" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with PHP 7.4 installed \
+      and FPM and Oracle Database connectivity enabled."
 
 RUN yum -y install oracle-php-release-el7 oracle-release-el7 && \
     yum -y install oracle-instantclient19.5-basic \

--- a/OracleLinuxDevelopers/oraclelinux7/php/7.4-fpm/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/php/7.4-fpm/Dockerfile
@@ -3,8 +3,12 @@
 
 FROM oraclelinux:7-slim
 
-LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/php/7.4-fpm" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with PHP 7.4 installed \
+      and FPM enabled."
 
 RUN yum -y install oracle-php-release-el7 && \
     yum -y install php-fpm \

--- a/OracleLinuxDevelopers/oraclelinux7/python/3.6-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/python/3.6-oracledb/Dockerfile
@@ -2,12 +2,19 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/python/3.6" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with Python 3.6 installed \
+      and Oracle Database"
+
 RUN yum -y install oracle-release-el7 oraclelinux-developer-release-el7 && \
     yum -y install python3 \
                    python3-libs \
                    python3-pip \
                    python3-setuptools \
                    python36-cx_Oracle && \
-    rm -rf /var/cache/yum/* && \
+    rm -rf /var/cache/yum/*
 
 CMD ["/bin/python3","--version"]

--- a/OracleLinuxDevelopers/oraclelinux7/python/3.6/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/python/3.6/Dockerfile
@@ -2,6 +2,12 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/python/3.6" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with Python 3.6 installed."
+
 RUN yum -y install python3 \
                    python3-libs \
                    python3-pip \

--- a/OracleLinuxDevelopers/oraclelinux8/golang/1.13/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/golang/1.13/Dockerfile
@@ -2,8 +2,11 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/golang/1.13" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with Golang 1.13 installed."
 
 COPY go-toolset.module /etc/dnf/modules.d/go-toolset.module
 

--- a/OracleLinuxDevelopers/oraclelinux8/nodejs/10/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/nodejs/10/Dockerfile
@@ -2,8 +2,11 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/nodejs/10" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with Node.js 10 installed."
 
 COPY nodejs.module /etc/dnf/modules.d/nodejs.module
 

--- a/OracleLinuxDevelopers/oraclelinux8/nodejs/12/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/nodejs/12/Dockerfile
@@ -2,8 +2,11 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/nodejs/12" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with Node.js 12 installed."
 
 COPY nodejs.module /etc/dnf/modules.d/nodejs.module
 

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.2-apache/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.2-apache/Dockerfile
@@ -2,8 +2,11 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/php/7.2-apache" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with PHP 7.2 and Apache 2.4.37 installed."
 
 COPY *.module /etc/dnf/modules.d/
 

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.2-cli/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.2-cli/Dockerfile
@@ -2,8 +2,11 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/php/7.2-cli" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with PHP 7.2 installed."
 
 COPY php.module /etc/dnf/modules.d/php.module
 

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.2-fpm/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.2-fpm/Dockerfile
@@ -2,8 +2,12 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/php/7.2-fpm" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with PHP 7.2 installed \
+      and FPM enabled."
 
 COPY php.module /etc/dnf/modules.d/php.module
 

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.3-apache/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.3-apache/Dockerfile
@@ -2,8 +2,11 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/php/7.3-apache" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with PHP 7.3 and Apache 2.4.37 installed."
 
 COPY *.module /etc/dnf/modules.d/
 

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.3-cli/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.3-cli/Dockerfile
@@ -2,8 +2,11 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/php/7.3-cli" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with PHP 7.3 installed."
 
 COPY php.module /etc/dnf/modules.d/php.module
 

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.3-fpm/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.3-fpm/Dockerfile
@@ -2,8 +2,12 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/php/7.3-fpm" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with PHP 7.3 installed \
+      and FPM enabled."
 
 COPY php.module /etc/dnf/modules.d/php.module
 

--- a/OracleLinuxDevelopers/oraclelinux8/python/3.6/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/python/3.6/Dockerfile
@@ -2,8 +2,11 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/python/3.6" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with Python 3.6 installed."
 
 COPY python36.module /etc/dnf/modules.d/python36.module
 

--- a/OracleLinuxDevelopers/oraclelinux8/python/3.8/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/python/3.8/Dockerfile
@@ -2,8 +2,11 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/python/3.8" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with Python 3.8 installed."
 
 COPY python38.module /etc/dnf/modules.d/python38.module
 


### PR DESCRIPTION
These labels are used by GitHub Container Registry as well as third-party registry and orchestration tools.

Also fixes a typo bug in `oraclelinux7/python/3.6-oracledb/Dockerfile`.

Signed-off-by: Avi Miller <avi.miller@oracle.com>