### PR TITLE
added Checksum.* on gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.sh eol=lf
 *.conf eol=lf
+Checksum.* eol=lf


### PR DESCRIPTION
Added eol=lf on Checksum.* files because md5check command is sensitive to crlf endings, when runned from windows machines