### PR TITLE
Fixes excessive audit logs for sys healthchecks #1651

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/checkDBStatus.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/checkDBStatus.sh
@@ -18,10 +18,10 @@ ORAENV_ASK=NO
 source oraenv
 
 # Check Oracle at least one PDB has open_mode "READ WRITE" and store it in status
-status=`sqlplus -s / as sysdba << EOF
+status=`sqlplus -s HEALTHCHECK/HEALTHCHECK << EOF
    set heading off;
    set pagesize 0;
-   SELECT DISTINCT open_mode FROM v\\$pdbs WHERE open_mode = '$OPEN_MODE';
+   SELECT DISTINCT open_mode FROM v\\$database WHERE open_mode = '$OPEN_MODE';
    exit;
 EOF`
 

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/checkDBStatus.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/checkDBStatus.sh
@@ -18,10 +18,10 @@ ORAENV_ASK=NO
 source oraenv
 
 # Check Oracle at least one PDB has open_mode "READ WRITE" and store it in status
-status=`sqlplus -s HEALTHCHECK/HEALTHCHECK << EOF
+status=`sqlplus -s / << EOF
    set heading off;
    set pagesize 0;
-   SELECT DISTINCT open_mode FROM v\\$database WHERE open_mode = '$OPEN_MODE';
+   SELECT DISTINCT open_mode FROM v\\$pdbs WHERE open_mode = '$OPEN_MODE';
    exit;
 EOF`
 

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
@@ -87,16 +87,18 @@ echo "$ORACLE_PDB=
   )" >> $ORACLE_HOME/network/admin/tnsnames.ora
 
 # Remove second control file, fix local_listener, make PDB auto open, enable EM global port
-# Create HEALTHCHECK user
+# Create externally mapped oracle user for health check
 sqlplus / as sysdba << EOF
    ALTER SYSTEM SET control_files='$ORACLE_BASE/oradata/$ORACLE_SID/control01.ctl' scope=spfile;
    ALTER SYSTEM SET local_listener='';
    ALTER PLUGGABLE DATABASE $ORACLE_PDB SAVE STATE;
    EXEC DBMS_XDB_CONFIG.SETGLOBALPORTENABLED (TRUE);
 
-   alter session set "_oracle_script" = true;
-   create user HEALTHCHECK identified by HEALTHCHECK;
-   grant create session, select any dictionary to HEALTHCHECK;
+   ALTER SESSION SET "_oracle_script" = true;
+   CREATE USER OPS\$oracle IDENTIFIED EXTERNALLY;
+   GRANT CREATE SESSION TO OPS\$oracle;
+   GRANT SELECT ON sys.v_\$pdbs TO OPS\$oracle;
+   ALTER USER OPS\$oracle SET container_data=all for sys.v_\$pdbs container = current;
 
    exit;
 EOF

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
@@ -87,11 +87,17 @@ echo "$ORACLE_PDB=
   )" >> $ORACLE_HOME/network/admin/tnsnames.ora
 
 # Remove second control file, fix local_listener, make PDB auto open, enable EM global port
+# Create HEALTHCHECK user
 sqlplus / as sysdba << EOF
    ALTER SYSTEM SET control_files='$ORACLE_BASE/oradata/$ORACLE_SID/control01.ctl' scope=spfile;
    ALTER SYSTEM SET local_listener='';
    ALTER PLUGGABLE DATABASE $ORACLE_PDB SAVE STATE;
    EXEC DBMS_XDB_CONFIG.SETGLOBALPORTENABLED (TRUE);
+
+   alter session set "_oracle_script" = true;
+   create user HEALTHCHECK identified by HEALTHCHECK;
+   grant create session, select any dictionary to HEALTHCHECK;
+
    exit;
 EOF
 


### PR DESCRIPTION
My proposition for solving https://github.com/oracle/docker-images/issues/1651:
Create new externally mapped `oracle` user for health checks who only connects and executes following: `SELECT DISTINCT open_mode FROM v$database`.
User creations happens on DB initial creation

Signed-off-by: Andrzej  Pauli andrzej.pauli@gmail.com