### PR TITLE
Allow install of the oracle-xe-18c rpm with podman

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/18.4.0/Dockerfile.xe
+++ b/OracleDatabase/SingleInstance/dockerfiles/18.4.0/Dockerfile.xe
@@ -59,6 +59,7 @@ RUN chmod ug+x $INSTALL_DIR/*.sh && \
     $INSTALL_DIR/$CHECK_SPACE_FILE && \
     cd $INSTALL_DIR && \
     yum -y install openssl oracle-database-preinstall-18c && \
+    sed -i -e 's/\(oracle\s\+hard\s\+nofile\)/# \1/' /etc/security/limits.d/oracle-database-preinstall-18c.conf && \
     yum -y localinstall $INSTALL_FILE_1 && \
     rm -rf /var/cache/yum && \
     rm -rf /var/tmp/yum-* && \


### PR DESCRIPTION
With podman 2.0.5 on OL8 (not tested in other configurations), the Oracle 18.4.0 XE will fail while installing `oracle-database-xe-18c-1.0-1.x86_64.rpm` with the following error message:

```
su: cannot open session: Permission denied
[SEVERE] The su command is not configured properly or the oracle user does not have the required privileges to install the Oracle database. If you are running in a Docker environment, ensure to set the environment variable ORACLE_DOCKER_INSTALL=true and try again.
```
The rpm script comment out `oracle   hard   memlock    134217728` in `/etc/security/limits.d/oracle-database-preinstall-18c.conf`, but apparently we need to also comment out `oracle   hard   nofile    65536`.

Strictly speaking it is most probably a bug in the rpm, but we can fix this in `Dockerfile.xe` before instaling the rpm.

--
Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>