### PR TITLE
[docs] The org.opencontainers.image labels need to be mandatory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,10 +94,61 @@ the image owner to implement it.
 1. All images must provide a `CMD` or `ENTRYPOINT`. If your image is designed
 to be extended, then this should output documentation on how to extend the
 image to be useful.
-1. Use `LABEL` instructions for additional information such as ports and volumes.
-The following are common label instructions that should be present in all images where applicable:
 
-Additional product-specific labels are listed below:
+### Security-related rules
+
+1. Do not require the use of the `--privileged` flag when running a container.
+1. Do not run an SSH daemon (`sshd`) inside a container.
+1. Do not use host networking mode (`--net=host`) for a container.
+1. Do not hard-code any passwords. If passwords are required, generate them
+on container startup using `openssl rand` or accept a password argument during
+container startup (via `-e`).
+
+### Label rules
+
+The following [OpenContainer `image-spec`](https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys)
+pre-defined annotation keys are **mandatory** and must be provided by every image
+using the `LABEL` directive:
+
+* **org.opencontainers.image.authors** contact details of the people or
+  organization responsible for the image (freeform string)
+* **org.opencontainers.image.url** URL to find more information on the image
+  (string)
+* **org.opencontainers.image.source** URL to get source code for building the
+  image (should be the URL of this repository).
+* **org.opencontainers.image.title** Human-readable title of the image (string)
+* **org.opencontainers.image.description** Human-readable description of the
+  software packaged in the image (string)
+
+This is to ensure that each image provides product-specific values that replace
+the `oraclelinux:7-slim` (or other) base image, as shown here:
+
+```dockerfile
+LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
+      "org.opencontainers.image.url"="https://github.com/oracle/container-images" \
+      "org.opencontainers.image.source"="https://github.com/oracle/container-images/tree/dist-amd64/7-slim" \
+      "org.opencontainers.image.vendor"="Oracle America, Inc" \
+      "org.opencontainers.image.title"="Oracle Linux 7 (slim)" \
+      "org.opencontainers.image.description"="Oracle Linux is an open-source \
+      operating system available under the GNU General Public License (GPLv2) and \
+      is suitable for both general purpose or Oracle workloads."
+```
+
+The following keys are optional and may be provided at the authors discretion:
+
+* **org.opencontainers.image.created** date and time on which the image was
+  built (string, date-time as defined by [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6)).
+* **org.opencontainers.image.documentation** URL to get documentation on the
+  image (string)
+* **org.opencontainers.image.vendor** Name of the distributing entity,
+  organization or individual (should be "Oracle").
+* **org.opencontainers.image.version** version of the packaged software
+* **org.opencontainers.image.licenses** License(s) under which contained software
+  is distributed as an [SPDX License Expression](https://spdx.dev/spdx-specification-21-web-version/#h.jxpfx0ykyb60).
+
+#### Additional product-specific labels
+
+The following are common label instructions that should be present in all images where applicable:
 
 <!-- markdownlint-disable MD033 -->
 | Label   | Value | Applicability |
@@ -134,39 +185,6 @@ LABEL "provider"="Oracle"                                   \
       "port.oemexpress"="5500"                                          \
       "port.apex"="8080"
 ```
-
-You may also chose to use the [OpenContainer `image-spec`](https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys)
-pre-defined annotation keys:
-
-* **org.opencontainers.image.created** date and time on which the image was
-  built (string, date-time as defined by [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6)).
-* **org.opencontainers.image.authors** contact details of the people or
-  organization responsible for the image (freeform string)
-* **org.opencontainers.image.url** URL to find more information on the image
-  (string)
-* **org.opencontainers.image.documentation** URL to get documentation on the
-  image (string)
-* **org.opencontainers.image.source** URL to get source code for building the
-  image (should be the URL of this repository).
-* **org.opencontainers.image.version** version of the packaged software
-* **org.opencontainers.image.vendor** Name of the distributing entity,
-  organization or individual (should be "Oracle").
-* **org.opencontainers.image.licenses** License(s) under which contained software
-  is distributed as an [SPDX License Expression](https://spdx.dev/spdx-specification-21-web-version/#h.jxpfx0ykyb60).
-* **org.opencontainers.image.title** Human-readable title of the image (string)
-* **org.opencontainers.image.description** Human-readable description of the
-  software packaged in the image (string)
-
-The use of these keys is optional and at each image authors' discretion.
-
-### Security-related rules
-
-1. Do not require the use of the `--privileged` flag when running a container.
-1. Do not run an SSH daemon (`sshd`) inside a container.
-1. Do not use host networking mode (`--net=host`) for a container.
-1. Do not hard-code any passwords. If passwords are required, generate them
-on container startup using `openssl rand` or accept a password argument during
-container startup (via `-e`).
 
 ### Documentation rules
 


### PR DESCRIPTION
The `oraclelinux:7-slim` and `oraclelinux:8-slim` images are now
shipping with these labels. If a product does not provide more
specific values, then it will appear to products that consume
these labels as "Oracle Linux" and not a more specific product image.

This is being noticed in particular for images that are published to
GitHub Container Registry that does consume these tags.

Signed-off-by: Avi Miller <avi.miller@oracle.com>