### PR TITLE
Build action for Developer images

### DIFF
--- a/.github/workflows/build-and-push-dev-images.yml
+++ b/.github/workflows/build-and-push-dev-images.yml
@@ -1,0 +1,68 @@
+name: Build and publish Oracle Linux developer container images to GitHub Container Registry
+
+# Builds are triggered either by:
+#   - a push on the master branch with changes in this file or in the
+#     OracleLinuxDevelopers directory.
+#     All container images will be (re)built.
+#   - a manual trigger of the workflow using the API.
+#     Subset of OL version / language can be specified; default is to build
+#     all images.
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'OracleLinuxDevelopers/**'
+      - '.github/workflows/build-and-push-dev-images.yml'
+  workflow_dispatch:
+    inputs:
+      ol:
+        description: List of ol versions to build
+        default: 'oraclelinux7, oraclelinux8'
+        required: false
+      lang:
+        description: List of languages to build
+        default: 'golang, nodejs, php, python'
+        required: false
+
+# Default values for the builds triggered by the push event
+env:
+  ol: 'oraclelinux7, oraclelinux8'
+  lang: 'golang, nodejs, php, python'
+
+jobs:
+  build-matrix:
+    name: Build os/language matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+    steps:
+      - name: Build matrix
+        id: build-matrix
+        run: |
+          ol=$(echo "${{ github.event.inputs.ol || env.ol}}" | jq -R -s -c 'split("[ ,\n]+";"")[:-1]')
+          lang=$(echo "${{ github.event.inputs.lang || env.lang}}" | jq -R -s -c 'split("[ ,\n]+";"")[:-1]')
+          echo "Setting matrix to ol: ${ol}, lang: ${lang}"
+          echo "::set-output name=matrix::{\"ol\":${ol}, \"lang\":${lang}}"
+
+  build-images:
+    name: Build container images
+    needs: build-matrix
+    strategy:
+      matrix: ${{fromJson(needs.build-matrix.outputs.matrix)}}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Log into GitHub Container Registry
+        run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GHCR_USER }} --password-stdin
+
+      - name: Build images
+        working-directory: OracleLinuxDevelopers/${{ matrix.ol }}/${{ matrix.lang }}
+        run: |
+          for tag in *; do
+            echo "Building ${{ matrix.ol }}-${{ matrix.lang }}:${tag}"
+            docker build --tag "ghcr.io/${{ secrets.GHCR_USER }}/${{ matrix.ol }}-${{ matrix.lang }}:${tag}" "${tag}"
+            docker push "ghcr.io/${{ secrets.GHCR_USER }}/${{ matrix.ol }}-${{ matrix.lang }}:${tag}"
+          done

--- a/.github/workflows/build-and-push-dev-images.yml
+++ b/.github/workflows/build-and-push-dev-images.yml
@@ -7,6 +7,9 @@ name: Build and publish Oracle Linux developer container images to GitHub Contai
 #   - a manual trigger of the workflow using the API.
 #     Subset of OL version / language can be specified; default is to build
 #     all images.
+# Images are build for both amd64 and arm64 architectures, except for
+#   - oracledb images (not available on arm)
+#   - php and nodejs on OL7 (packages not available)
 on:
   push:
     branches:
@@ -37,32 +40,69 @@ jobs:
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
       - name: Build matrix
         id: build-matrix
+        working-directory: OracleLinuxDevelopers
         run: |
-          ol=$(echo "${{ github.event.inputs.ol || env.ol}}" | jq -R -s -c 'split("[ ,\n]+";"")[:-1]')
-          lang=$(echo "${{ github.event.inputs.lang || env.lang}}" | jq -R -s -c 'split("[ ,\n]+";"")[:-1]')
-          echo "Setting matrix to ol: ${ol}, lang: ${lang}"
-          echo "::set-output name=matrix::{\"ol\":${ol}, \"lang\":${lang}}"
+          ol_list=$(echo "${{ github.event.inputs.ol || env.ol}}" | sed -e 's/[ ,]\+/ /g')
+          lang_list=$(echo "${{ github.event.inputs.lang || env.lang}}" | sed -e 's/[ ,]\+/ /g')
+          matrix=$(
+            for ol in ${ol_list}; do
+              pushd "${ol}" >/dev/null
+                for lang in ${lang_list}; do
+                  pushd "${lang}" >/dev/null
+                    for tag in *; do
+                      arch="linux/amd64"
+                      if [[ ! ${tag} =~ oracledb && ! ( ${ol} = "oraclelinux7" && ${lang} =~ ^(nodejs|php)$ ) ]]; then
+                        arch="${arch},linux/arm64"
+                      fi
+                      echo "${ol};${lang};${tag};${arch}"
+                    done
+                  popd >/dev/null
+                done
+              popd >/dev/null
+            done | jq --slurp --raw-input --compact-output '
+              split("\n") |
+              .[:-1] |
+              map(split(";")) |
+              map({"ol": .[0], "lang": .[1], "tag": .[2], "arch": .[3]}) |
+              { "include": .}'
+          )
+          echo "::set-output name=matrix::${matrix}"
 
   build-images:
-    name: Build container images
+    name: Build and push images
     needs: build-matrix
     strategy:
       matrix: ${{fromJson(needs.build-matrix.outputs.matrix)}}
+      fail-fast: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Log into GitHub Container Registry
-        run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GHCR_USER }} --password-stdin
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
 
-      - name: Build images
-        working-directory: OracleLinuxDevelopers/${{ matrix.ol }}/${{ matrix.lang }}
-        run: |
-          for tag in *; do
-            echo "Building ${{ matrix.ol }}-${{ matrix.lang }}:${tag}"
-            docker build --tag "ghcr.io/${{ secrets.GHCR_USER }}/${{ matrix.ol }}-${{ matrix.lang }}:${tag}" "${tag}"
-            docker push "ghcr.io/${{ secrets.GHCR_USER }}/${{ matrix.ol }}-${{ matrix.lang }}:${tag}"
-          done
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log into GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USER }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v2
+        with:
+          context: OracleLinuxDevelopers/${{ matrix.ol }}/${{ matrix.lang }}/${{ matrix.tag }}
+          platforms: ${{ matrix.arch }}
+          push: true
+          tags: "ghcr.io/${{ secrets.GHCR_USER }}/${{ matrix.ol }}-${{ matrix.lang }}:${{ matrix.tag }}"


### PR DESCRIPTION
This PR adds a GitHub Action to build push to GHCR the Developper container images.

Build is triggered either manually or when the action or the images source are pushed to the master branch.

Manual update allows us to trigger a re-build when the base containers or packages are updated.

--
Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>