### PR TITLE
[fix] GHCR does not support GITHUB_TOKEN so workarounds are required

### DIFF
--- a/.github/workflows/build-and-push-dev-images.yml
+++ b/.github/workflows/build-and-push-dev-images.yml
@@ -105,4 +105,4 @@ jobs:
           context: OracleLinuxDevelopers/${{ matrix.ol }}/${{ matrix.lang }}/${{ matrix.tag }}
           platforms: ${{ matrix.arch }}
           push: true
-          tags: "ghcr.io/${{ secrets.GHCR_USER }}/${{ matrix.ol }}-${{ matrix.lang }}:${{ matrix.tag }}"
+          tags: "ghcr.io/${{ github.repository_owner }}/${{ matrix.ol }}-${{ matrix.lang }}:${{ matrix.tag }}"


### PR DESCRIPTION
Currently we're using a Personal Access Token to push images to
GitHub Container Registry, but we want the images to be pushed to the
right namespace.

Signed-off-by: Avi Miller <avi.miller@oracle.com>