### PR TITLE
[bug] Fix oraclelinux7-nodejs:12-oracledb Dockerfile

### DIFF
--- a/OracleLinuxDevelopers/oraclelinux7/nodejs/12-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/nodejs/12-oracledb/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
@@ -9,9 +9,10 @@ LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info
       "org.opencontainers.image.description"="Oracle Linux 7 (slim) with Node.js 12 installed \
       and Oracle Database connectivity enabled."
 
-RUN yum -y install oracle-nodejs-release-el7 oracle-release-el7 && \
+RUN yum -y install oracle-nodejs-release-el7 oracle-instantclient-release-el7 && \
     yum-config-manager --disable ol7_developer_nodejs14 && \
     yum-config-manager --enable ol7_developer_nodejs12 && \
+    yum -y install nodejs node-oracledb-node12 && \
     rm -rf /var/cache/yum/*
 
 ENV NODE_PATH=/usr/lib/node_modules


### PR DESCRIPTION
Switch to using the new Oracle Instant Client repo by installing
the oracle-instantclient-release-el7 package and actually install
nodejs and the node-oracledb-node12 packages.

Fixes #1837.

Signed-off-by: Avi Miller <avi.miller@oracle.com>