### PR TITLE
Developer images: improve build action.

### DIFF
--- a/.github/workflows/build-and-push-dev-images.yml
+++ b/.github/workflows/build-and-push-dev-images.yml
@@ -1,13 +1,15 @@
 name: Build and publish Oracle Linux developer container images to GitHub Container Registry
 
 # Builds are triggered either by:
-#   - a push on the master branch with changes in this file or in the
-#     OracleLinuxDevelopers directory.
+#   - a push on the master branch with changes in this file.
 #     All container images will be (re)built.
+#   - a push on the master branch with changes the OracleLinuxDevelopers
+#     directory.
+#     Affected container images will be (re)built.
 #   - a manual trigger of the workflow using the API.
 #     Subset of OL version / language can be specified; default is to build
 #     all images.
-# Images are build for both amd64 and arm64 architectures, except for
+# Images are built for both amd64 and arm64 architectures, except for
 #   - oracledb images (not available on arm)
 #   - php and nodejs on OL7 (packages not available)
 on:
@@ -34,14 +36,21 @@ env:
   lang: 'golang, nodejs, php, python'
 
 jobs:
-  build-matrix:
-    name: Build os/language matrix
+  prepare:
+    name: Create build matrix
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
+      skip_build: ${{ steps.build-matrix.outputs.skip_build }}
+      repository_owner: ${{ steps.repository_owner.outputs.repository_owner }}
+      date_stamp: ${{ steps.date_stamp.outputs.date_stamp }}
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+        with:
+          # We need "some" commit history to check for changed files
+          fetch-depth: 32
 
       - name: Build matrix
         id: build-matrix
@@ -49,17 +58,39 @@ jobs:
         run: |
           ol_list=$(echo "${{ github.event.inputs.ol || env.ol}}" | sed -e 's/[ ,]\+/ /g')
           lang_list=$(echo "${{ github.event.inputs.lang || env.lang}}" | sed -e 's/[ ,]\+/ /g')
+          changes=$(mktemp)
+          # workflow is only in the workflow_dispatch event payload
+          workflow="${{ github.event.workflow }}"
+          if [[ -z ${workflow} ]]; then
+            # Push event - retrieve list of changed files
+            git diff --name-only '${{ github.event.before }}..${{ github.event.after }}' > "${changes}"
+            if grep -q build-and-push-dev-images.yml "${changes}"; then
+              echo "PUSH: Action updated, rebuilding all images"
+              build_all=1
+            else
+              echo "PUSH: Rebuilding changed images only"
+              build_all=0
+            fi
+          else
+            echo "MANUAL: Rebuilding based on parameters"
+            build_all=1
+          fi
           matrix=$(
             for ol in ${ol_list}; do
-              pushd "${ol}" >/dev/null
+            pushd "${ol}" >/dev/null
                 for lang in ${lang_list}; do
-                  pushd "${lang}" >/dev/null
-                    for tag in *; do
+                pushd "${lang}" >/dev/null
+                    for dockerfile in */Dockerfile; do
+                      tag=$(dirname "${dockerfile}")
                       arch="linux/amd64"
+                      multi=0
                       if [[ ! ${tag} =~ oracledb && ! ( ${ol} = "oraclelinux7" && ${lang} =~ ^(nodejs|php)$ ) ]]; then
                         arch="${arch},linux/arm64"
+                        multi=1
                       fi
-                      echo "${ol};${lang};${tag};${arch}"
+                      if [[ ${build_all} -eq 1 ]] || grep -q "${ol}/${lang}/${tag}" "${changes}"; then
+                        echo "${ol};${lang};${tag};${arch};${multi}"
+                      fi
                     done
                   popd >/dev/null
                 done
@@ -68,16 +99,35 @@ jobs:
               split("\n") |
               .[:-1] |
               map(split(";")) |
-              map({"ol": .[0], "lang": .[1], "tag": .[2], "arch": .[3]}) |
-              { "include": .}'
+              map({"ol": .[0], "lang": .[1], "tag": .[2], "arch": .[3], "multi": (.[4] == "1")})'
           )
+          rm "${changes}"
+          if [[ ${matrix} == "[]" ]]; then
+            # Empty array -- change didn't impact any image
+            skip_build=true
+          else
+            skip_build=false
+            matrix=$(jq --compact-output '{ "include": .}' <<<"${matrix}")
+          fi
           echo "::set-output name=matrix::${matrix}"
+          echo "::set-output name=skip_build::${skip_build}"
 
-  build-images:
-    name: Build and push images
-    needs: build-matrix
+      - name: Lowercase repository owner
+        id: repository_owner
+        run: |
+          echo "::set-output name=repository_owner::$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+
+      - name: Date stamp
+        id: date_stamp
+        run: |
+          echo "::set-output name=date_stamp::$(date +'%Y%m%d')"
+
+  build-image:
+    name: Build image
+    needs: prepare
+    if: ${{ needs.prepare.outputs.skip_build == 'false' }}
     strategy:
-      matrix: ${{fromJson(needs.build-matrix.outputs.matrix)}}
+      matrix: ${{fromJson(needs.prepare.outputs.matrix)}}
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
@@ -99,10 +149,35 @@ jobs:
           username: ${{ secrets.GHCR_USER }}
           password: ${{ secrets.GHCR_TOKEN }}
 
-      - name: Build and push image
+      - name: Build image - amd64
         uses: docker/build-push-action@v2
         with:
           context: OracleLinuxDevelopers/${{ matrix.ol }}/${{ matrix.lang }}/${{ matrix.tag }}
-          platforms: ${{ matrix.arch }}
+          platforms: linux/amd64
           push: true
-          tags: "ghcr.io/${{ github.repository_owner }}/${{ matrix.ol }}-${{ matrix.lang }}:${{ matrix.tag }}"
+          tags: |
+            "ghcr.io/${{ needs.prepare.outputs.repository_owner }}/${{ matrix.ol }}-${{ matrix.lang }}:${{ matrix.tag }}-${{ needs.prepare.outputs.date_stamp }}${{ matrix.multi && '-amd64' || '' }}"
+            "ghcr.io/${{ needs.prepare.outputs.repository_owner }}/${{ matrix.ol }}-${{ matrix.lang }}:${{ matrix.tag }}${{ matrix.multi && '-amd64' || '' }}"
+
+      - name: Build image - arm64
+        uses: docker/build-push-action@v2
+        if: matrix.multi
+        with:
+          context: OracleLinuxDevelopers/${{ matrix.ol }}/${{ matrix.lang }}/${{ matrix.tag }}
+          platforms: linux/arm64
+          push: true
+          tags: |
+            "ghcr.io/${{ needs.prepare.outputs.repository_owner }}/${{ matrix.ol }}-${{ matrix.lang }}:${{ matrix.tag }}-${{ needs.prepare.outputs.date_stamp }}-arm64"
+            "ghcr.io/${{ needs.prepare.outputs.repository_owner }}/${{ matrix.ol }}-${{ matrix.lang }}:${{ matrix.tag }}-arm64"
+
+      - name: Manifest
+        if: matrix.multi
+        run: |
+          docker buildx imagetools create --tag \
+            "ghcr.io/${{ needs.prepare.outputs.repository_owner }}/${{ matrix.ol }}-${{ matrix.lang }}:${{ matrix.tag }}-${{ needs.prepare.outputs.date_stamp }}" \
+            "ghcr.io/${{ needs.prepare.outputs.repository_owner }}/${{ matrix.ol }}-${{ matrix.lang }}:${{ matrix.tag }}-${{ needs.prepare.outputs.date_stamp }}-amd64" \
+            "ghcr.io/${{ needs.prepare.outputs.repository_owner }}/${{ matrix.ol }}-${{ matrix.lang }}:${{ matrix.tag }}-${{ needs.prepare.outputs.date_stamp }}-arm64"
+          docker buildx imagetools create --tag \
+            "ghcr.io/${{ needs.prepare.outputs.repository_owner }}/${{ matrix.ol }}-${{ matrix.lang }}:${{ matrix.tag }}" \
+            "ghcr.io/${{ needs.prepare.outputs.repository_owner }}/${{ matrix.ol }}-${{ matrix.lang }}:${{ matrix.tag }}-amd64" \
+            "ghcr.io/${{ needs.prepare.outputs.repository_owner }}/${{ matrix.ol }}-${{ matrix.lang }}:${{ matrix.tag }}-arm64"


### PR DESCRIPTION
- Only rebuild chenged images.
- Improved tagging:
  - Add a datestamp to the images to avoid tagless images on update
  - Tag all parts of multi-arch images (manifest and images)

Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>