### PR TITLE
[fix] Remove org.opencontainers.image labels from all Dockefiles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,30 +135,6 @@ LABEL "provider"="Oracle"                                   \
       "port.apex"="8080"
 ```
 
-You may also chose to use the [OpenContainer `image-spec`](https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys)
-pre-defined annotation keys:
-
-* **org.opencontainers.image.created** date and time on which the image was
-  built (string, date-time as defined by [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6)).
-* **org.opencontainers.image.authors** contact details of the people or
-  organization responsible for the image (freeform string)
-* **org.opencontainers.image.url** URL to find more information on the image
-  (string)
-* **org.opencontainers.image.documentation** URL to get documentation on the
-  image (string)
-* **org.opencontainers.image.source** URL to get source code for building the
-  image (should be the URL of this repository).
-* **org.opencontainers.image.version** version of the packaged software
-* **org.opencontainers.image.vendor** Name of the distributing entity,
-  organization or individual (should be "Oracle").
-* **org.opencontainers.image.licenses** License(s) under which contained software
-  is distributed as an [SPDX License Expression](https://spdx.dev/spdx-specification-21-web-version/#h.jxpfx0ykyb60).
-* **org.opencontainers.image.title** Human-readable title of the image (string)
-* **org.opencontainers.image.description** Human-readable description of the
-  software packaged in the image (string)
-
-The use of these keys is optional and at each image authors' discretion.
-
 ### Security-related rules
 
 1. Do not require the use of the `--privileged` flag when running a container.

--- a/NoSQL/19.5-ce/Dockerfile
+++ b/NoSQL/19.5-ce/Dockerfile
@@ -3,15 +3,6 @@
 #
 FROM openjdk:14-oraclelinux7
 
-LABEL "org.opencontainers.image.authors"="Anand Chandak <anand.chandak@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/NoSQL/19.5" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.title"="Oracle NoSQL 19.5 Community Edition" \
-      "org.opencontainers.image.description"="Oracle NoSQL Database provides \
-      multi-terabyte distributed storage for key-value pairs, with scalable \
-      throughput and great performance."
-
 ENV VERSION="19.5.19" \
     KVHOME=/kv-19.5.19 \
     PACKAGE="kv-ce" \

--- a/OracleInstantClient/oraclelinux7/19/Dockerfile
+++ b/OracleInstantClient/oraclelinux7/19/Dockerfile
@@ -63,12 +63,6 @@
 
 FROM oraclelinux:7-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Database Development" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images/blob/master/OracleInstantClient/README.md" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleInstantClient" \
-      "org.opencontainers.image.title"="Oracle Instant Client" \
-      "org.opencontainers.image.description"="Oracle Client libraries and tools for accessing Oracle Database"
-
 ARG release=19
 ARG update=9
 

--- a/OracleInstantClient/oraclelinux7/21/Dockerfile
+++ b/OracleInstantClient/oraclelinux7/21/Dockerfile
@@ -64,12 +64,6 @@
 
 FROM oraclelinux:7-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Database Development" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images/blob/master/OracleInstantClient/README.md" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleInstantClient" \
-      "org.opencontainers.image.title"="Oracle Instant Client" \
-      "org.opencontainers.image.description"="Oracle Client libraries and tools for accessing Oracle Database"
-
 RUN  yum -y install oracle-instantclient-release-el7 && \
      yum -y install oracle-instantclient-basic oracle-instantclient-devel oracle-instantclient-sqlplus && \
      rm -rf /var/cache/yum

--- a/OracleInstantClient/oraclelinux8/19/Dockerfile
+++ b/OracleInstantClient/oraclelinux8/19/Dockerfile
@@ -63,12 +63,6 @@
 
 FROM oraclelinux:8-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Database Development" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images/blob/master/OracleInstantClient/README.md" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleInstantClient" \
-      "org.opencontainers.image.title"="Oracle Instant Client" \
-      "org.opencontainers.image.description"="Oracle Client libraries and tools for accessing Oracle Database"
-
 ARG release=19
 ARG update=9
 

--- a/OracleInstantClient/oraclelinux8/21/Dockerfile
+++ b/OracleInstantClient/oraclelinux8/21/Dockerfile
@@ -64,12 +64,6 @@
 
 FROM oraclelinux:8-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Database Development" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images/blob/master/OracleInstantClient/README.md" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleInstantClient" \
-      "org.opencontainers.image.title"="Oracle Instant Client" \
-      "org.opencontainers.image.description"="Oracle Client libraries and tools for accessing Oracle Database"
-
 RUN  microdnf install oracle-instantclient-release-el8 && \
      microdnf install oracle-instantclient-basic oracle-instantclient-devel oracle-instantclient-sqlplus && \
      microdnf clean all

--- a/OracleLinuxDevelopers/oraclelinux7/golang/1.13/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/golang/1.13/Dockerfile
@@ -2,12 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/golang/1.13" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with Golang 1.13 installed."
-
 RUN yum -y install oracle-golang-release-el7 && \
     yum-config-manager --disable ol7_developer_golang114 && \
     yum-config-manager --enable ol7_developer_golang113 && \

--- a/OracleLinuxDevelopers/oraclelinux7/golang/1.14/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/golang/1.14/Dockerfile
@@ -2,12 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/golang/1.14" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with Golang 1.14 installed."
-
 RUN yum -y install oracle-golang-release-el7 && \
     yum-config-manager --disable ol7_developer_golang115 && \
     yum-config-manager --enable ol7_developer_golang114 && \

--- a/OracleLinuxDevelopers/oraclelinux7/golang/1.15/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/golang/1.15/Dockerfile
@@ -2,12 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/golang/1.15" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with Golang 1.15 installed."
-
 RUN yum -y install oracle-golang-release-el7 && \
     yum -y install golang && \
     rm -rf /var/cache/yum/*

--- a/OracleLinuxDevelopers/oraclelinux7/nodejs/10-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/nodejs/10-oracledb/Dockerfile
@@ -2,13 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/nodejs/10-oracledb" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with Node.js 10 installed \
-      and Oracle Database connectivity enabled."
-
 RUN yum -y install oracle-nodejs-release-el7 oracle-release-el7 && \
     yum-config-manager --disable ol7_developer_nodejs14 && \
     yum-config-manager --enable ol7_developer_nodejs10 && \

--- a/OracleLinuxDevelopers/oraclelinux7/nodejs/10/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/nodejs/10/Dockerfile
@@ -2,12 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/nodejs/10" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with Node.js 10 installed."
-
 RUN yum -y install oracle-nodejs-release-el7 && \
     yum-config-manager --disable ol7_developer_nodejs14 && \
     yum-config-manager --enable ol7_developer_nodejs10 && \

--- a/OracleLinuxDevelopers/oraclelinux7/nodejs/12-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/nodejs/12-oracledb/Dockerfile
@@ -2,13 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/nodejs/12-oracledb" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with Node.js 12 installed \
-      and Oracle Database connectivity enabled."
-
 RUN yum -y install oracle-nodejs-release-el7 oracle-instantclient-release-el7 && \
     yum-config-manager --disable ol7_developer_nodejs14 && \
     yum-config-manager --enable ol7_developer_nodejs12 && \

--- a/OracleLinuxDevelopers/oraclelinux7/nodejs/12/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/nodejs/12/Dockerfile
@@ -2,12 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/nodejs/12" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with Node.js 12 installed."
-
 RUN yum -y install oracle-nodejs-release-el7 && \
     yum-config-manager --disable ol7_developer_nodejs14 && \
     yum-config-manager --enable ol7_developer_nodejs12 && \

--- a/OracleLinuxDevelopers/oraclelinux7/nodejs/14/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/nodejs/14/Dockerfile
@@ -2,12 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/nodejs/14" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with Node.js 14 installed."
-
 RUN yum -y install oracle-nodejs-release-el7 && \
     yum -y install nodejs && \
     rm -rf /var/cache/yum/*

--- a/OracleLinuxDevelopers/oraclelinux7/php/7.4-apache-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/php/7.4-apache-oracledb/Dockerfile
@@ -2,13 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/php/7.4-apache-oracledb" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with PHP 7.4 and Apache 2.4.6 installed \
-      and Oracle Database connectivity enabled."
-
 RUN yum -y install oracle-php-release-el7 oracle-release-el7 && \
     yum -y install httpd \
                    oracle-instantclient19.5-basic \

--- a/OracleLinuxDevelopers/oraclelinux7/php/7.4-apache/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/php/7.4-apache/Dockerfile
@@ -2,12 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/php/7.4-apache" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with PHP 7.4 and Apache 2.4.6 installed."
-
 RUN yum -y install oracle-php-release-el7 && \
     yum -y install httpd \
                    php \

--- a/OracleLinuxDevelopers/oraclelinux7/php/7.4-cli-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/php/7.4-cli-oracledb/Dockerfile
@@ -2,13 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/php/7.4-cli-oracledb" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with PHP 7.4 installed \
-      and Oracle Database connectivity enabled."
-
 RUN yum -y install oracle-php-release-el7 oracle-release-el7 && \
     yum -y install oracle-instantclient19.5-basic \
                    php-cli \

--- a/OracleLinuxDevelopers/oraclelinux7/php/7.4-cli/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/php/7.4-cli/Dockerfile
@@ -2,12 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/php/7.4-cli" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with PHP 7.4 installed."
-
 RUN yum -y install oracle-php-release-el7 && \
     yum -y install php-cli \
                    php-json \

--- a/OracleLinuxDevelopers/oraclelinux7/php/7.4-fpm-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/php/7.4-fpm-oracledb/Dockerfile
@@ -3,13 +3,6 @@
 
 FROM oraclelinux:7-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/php/7.4-fpm-oracledb" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with PHP 7.4 installed \
-      and FPM and Oracle Database connectivity enabled."
-
 RUN yum -y install oracle-php-release-el7 oracle-release-el7 && \
     yum -y install oracle-instantclient19.5-basic \
                    php-fpm \

--- a/OracleLinuxDevelopers/oraclelinux7/php/7.4-fpm/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/php/7.4-fpm/Dockerfile
@@ -3,13 +3,6 @@
 
 FROM oraclelinux:7-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/php/7.4-fpm" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with PHP 7.4 installed \
-      and FPM enabled."
-
 RUN yum -y install oracle-php-release-el7 && \
     yum -y install php-fpm \
                    php-json \

--- a/OracleLinuxDevelopers/oraclelinux7/python/3.6-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/python/3.6-oracledb/Dockerfile
@@ -2,13 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/python/3.6" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with Python 3.6 installed \
-      and Oracle Database"
-
 RUN yum -y install oracle-release-el7 oraclelinux-developer-release-el7 && \
     yum -y install python3 \
                    python3-libs \

--- a/OracleLinuxDevelopers/oraclelinux7/python/3.6/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/python/3.6/Dockerfile
@@ -2,12 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux7/python/3.6" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 7 (slim) with Python 3.6 installed."
-
 RUN yum -y install python3 \
                    python3-libs \
                    python3-pip \

--- a/OracleLinuxDevelopers/oraclelinux8/golang/1.13/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/golang/1.13/Dockerfile
@@ -2,12 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/golang/1.13" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with Golang 1.13 installed."
-
 COPY go-toolset.module /etc/dnf/modules.d/go-toolset.module
 
 RUN microdnf install go-toolset && \

--- a/OracleLinuxDevelopers/oraclelinux8/nodejs/10/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/nodejs/10/Dockerfile
@@ -2,12 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/nodejs/10" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with Node.js 10 installed."
-
 COPY nodejs.module /etc/dnf/modules.d/nodejs.module
 
 RUN microdnf install nodejs npm && \

--- a/OracleLinuxDevelopers/oraclelinux8/nodejs/12/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/nodejs/12/Dockerfile
@@ -2,12 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/nodejs/12" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with Node.js 12 installed."
-
 COPY nodejs.module /etc/dnf/modules.d/nodejs.module
 
 RUN microdnf install nodejs npm && \

--- a/OracleLinuxDevelopers/oraclelinux8/nodejs/14/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/nodejs/14/Dockerfile
@@ -2,12 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/nodejs/14" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with Node.js 14 installed."
-
 COPY nodejs.module /etc/dnf/modules.d/nodejs.module
 
 RUN microdnf install nodejs npm && \

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.2-apache/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.2-apache/Dockerfile
@@ -2,12 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/php/7.2-apache" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with PHP 7.2 and Apache 2.4.37 installed."
-
 COPY *.module /etc/dnf/modules.d/
 
 RUN microdnf install httpd \

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.2-cli/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.2-cli/Dockerfile
@@ -2,12 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/php/7.2-cli" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with PHP 7.2 installed."
-
 COPY php.module /etc/dnf/modules.d/php.module
 
 RUN microdnf install php-cli \

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.2-fpm/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.2-fpm/Dockerfile
@@ -2,13 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/php/7.2-fpm" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with PHP 7.2 installed \
-      and FPM enabled."
-
 COPY php.module /etc/dnf/modules.d/php.module
 
 RUN microdnf install php-cli \

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.3-apache/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.3-apache/Dockerfile
@@ -2,12 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/php/7.3-apache" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with PHP 7.3 and Apache 2.4.37 installed."
-
 COPY *.module /etc/dnf/modules.d/
 
 RUN microdnf install httpd \

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.3-cli/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.3-cli/Dockerfile
@@ -2,12 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/php/7.3-cli" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with PHP 7.3 installed."
-
 COPY php.module /etc/dnf/modules.d/php.module
 
 RUN microdnf install php-cli \

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.3-fpm/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.3-fpm/Dockerfile
@@ -2,13 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/php/7.3-fpm" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with PHP 7.3 installed \
-      and FPM enabled."
-
 COPY php.module /etc/dnf/modules.d/php.module
 
 RUN microdnf install php-cli \

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.4-apache/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.4-apache/Dockerfile
@@ -2,12 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/php/7.4-apache" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with PHP 7.4 and Apache 2.4.37 installed."
-
 COPY *.module /etc/dnf/modules.d/
 
 RUN microdnf install httpd \

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.4-cli/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.4-cli/Dockerfile
@@ -2,12 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/php/7.4-cli" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with PHP 7.4 installed."
-
 COPY php.module /etc/dnf/modules.d/php.module
 
 RUN microdnf install php-cli \

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.4-fpm/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.4-fpm/Dockerfile
@@ -2,13 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/php/7.4-fpm" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with PHP 7.4 installed \
-      and FPM enabled."
-
 COPY php.module /etc/dnf/modules.d/php.module
 
 RUN microdnf install php-cli \

--- a/OracleLinuxDevelopers/oraclelinux8/python/3.6/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/python/3.6/Dockerfile
@@ -2,12 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/python/3.6" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with Python 3.6 installed."
-
 COPY python36.module /etc/dnf/modules.d/python36.module
 
 RUN microdnf install python36 \

--- a/OracleLinuxDevelopers/oraclelinux8/python/3.8/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/python/3.8/Dockerfile
@@ -2,12 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:8-slim
 
-LABEL "org.opencontainers.image.authors"="Oracle Linux Product Team <ol-ovm-info_ww@oracle.com>" \
-      "org.opencontainers.image.url"="https://github.com/oracle/docker-images" \
-      "org.opencontainers.image.source"="https://github.com/oracle/docker-images/tree/master/OracleLinuxDevelopers/oraclelinux8/python/3.8" \
-      "org.opencontainers.image.vendor"="Oracle America, Inc" \
-      "org.opencontainers.image.description"="Oracle Linux 8 (slim) with Python 3.8 installed."
-
 COPY python38.module /etc/dnf/modules.d/python38.module
 
 RUN microdnf install python38 \


### PR DESCRIPTION
Because LABELs are automatically inherited and cannot be removed
by downstream images, we are removing them from our images instead.
This is to avoid a downstream image misidentifying itself as an
Oracle produced artefact.

Signed-off-by: Avi Miller <avi.miller@oracle.com>