### PR TITLE
[dev] Add Ruby 2.6 and 2.7 images for Oracle Linux 7 and 8

### DIFF
--- a/.github/workflows/build-and-push-dev-images.yml
+++ b/.github/workflows/build-and-push-dev-images.yml
@@ -27,13 +27,13 @@ on:
         required: false
       lang:
         description: List of languages to build
-        default: 'golang, nodejs, php, python'
+        default: 'golang, nodejs, php, python, ruby'
         required: false
 
 # Default values for the builds triggered by the push event
 env:
   ol: 'oraclelinux7, oraclelinux8'
-  lang: 'golang, nodejs, php, python'
+  lang: 'golang, nodejs, php, python, ruby'
 
 jobs:
   prepare:
@@ -84,7 +84,7 @@ jobs:
                       tag=$(dirname "${dockerfile}")
                       arch="linux/amd64"
                       multi=0
-                      if [[ ! ${tag} =~ oracledb && ! ( ${ol} = "oraclelinux7" && ${lang} =~ ^(nodejs|php)$ ) ]]; then
+                      if [[ ! ${tag} =~ oracledb && ! ( ${ol} = "oraclelinux7" && ${lang} =~ ^(nodejs|php|ruby)$ ) ]]; then
                         arch="${arch},linux/arm64"
                         multi=1
                       fi

--- a/OracleLinuxDevelopers/oraclelinux7/ruby/2.6/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/ruby/2.6/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+FROM oraclelinux:7-slim
+
+RUN yum -y install oracle-softwarecollection-release-el7 && \
+    yum -y install rh-ruby26 \
+                   rh-ruby26-ruby-devel \
+                   rh-ruby26-rubygem-rake \
+                   rh-ruby26-rubygem-bundler \
+                   gcc make && \
+    rm -rf /var/cache/yum
+
+# Enable the SCL via environment modification
+ENV PATH=/opt/rh/rh-ruby26/root/usr/local/bin:/opt/rh/rh-ruby26/root/usr/bin${PATH:+:${PATH}} \
+    LD_LIBRARY_PATH=/opt/rh/rh-ruby26/root/usr/local/lib64:/opt/rh/rh-ruby26/root/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}} \
+    MANPATH=/opt/rh/rh-ruby26/root/usr/local/share/man:/opt/rh/rh-ruby26/root/usr/share/man:${MANPATH} \
+    PKG_CONFIG_PATH=/opt/rh/rh-ruby26/root/usr/local/lib64/pkgconfig:/opt/rh/rh-ruby26/root/usr/lib64/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}} \
+    XDG_DATA_DIRS=/opt/rh/rh-ruby26/root/usr/local/share:/opt/rh/rh-ruby26/root/usr/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}
+
+CMD ["irb"]

--- a/OracleLinuxDevelopers/oraclelinux7/ruby/2.7-nodejs/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/ruby/2.7-nodejs/Dockerfile
@@ -1,0 +1,28 @@
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+FROM oraclelinux:7-slim
+
+RUN yum -y install oracle-softwarecollection-release-el7 && \
+    yum -y install rh-ruby27 \
+                   rh-ruby27-ruby-devel \
+                   rh-ruby27-rubygem-rake \
+                   rh-ruby27-rubygem-bundler \
+                   rh-nodejs14 \
+                   rh-nodejs14-npm \
+                   gcc make && \
+    rm -rf /var/cache/yum
+
+# Enable the Ruby 2.7 SCL via environment modification
+ENV PATH=/opt/rh/rh-ruby27/root/usr/local/bin:/opt/rh/rh-ruby27/root/usr/bin${PATH:+:${PATH}} \
+    LD_LIBRARY_PATH=/opt/rh/rh-ruby27/root/usr/local/lib64:/opt/rh/rh-ruby27/root/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}} \
+    MANPATH=/opt/rh/rh-ruby27/root/usr/local/share/man:/opt/rh/rh-ruby27/root/usr/share/man:${MANPATH} \
+    PKG_CONFIG_PATH=/opt/rh/rh-ruby27/root/usr/local/lib64/pkgconfig:/opt/rh/rh-ruby27/root/usr/lib64/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}} \
+    XDG_DATA_DIRS=/opt/rh/rh-ruby27/root/usr/local/share:/opt/rh/rh-ruby27/root/usr/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}
+
+# Enable the Node.js SCL via environmental modification
+ENV PATH=/opt/rh/rh-nodejs14/root/usr/bin${PATH:+:${PATH}} \
+    LD_LIBRARY_PATH=/opt/rh/rh-nodejs14/root/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}} \
+    PYTHONPATH=/opt/rh/rh-nodejs14/root/usr/lib/python2.7/site-packages${PYTHONPATH:+:${PYTHONPATH}} \
+    MANPATH=/opt/rh/rh-nodejs14/root/usr/share/man:${MANPATH}
+
+CMD ["irb"]

--- a/OracleLinuxDevelopers/oraclelinux7/ruby/2.7/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/ruby/2.7/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+FROM oraclelinux:7-slim
+
+RUN yum -y install oracle-softwarecollection-release-el7 && \
+    yum -y install rh-ruby27 \
+                   rh-ruby27-ruby-devel \
+                   rh-ruby27-rubygem-rake \
+                   rh-ruby27-rubygem-bundler \
+                   gcc make && \
+    rm -rf /var/cache/yum
+
+# Enable the SCL via environment modification
+ENV PATH=/opt/rh/rh-ruby27/root/usr/local/bin:/opt/rh/rh-ruby27/root/usr/bin${PATH:+:${PATH}} \
+    LD_LIBRARY_PATH=/opt/rh/rh-ruby27/root/usr/local/lib64:/opt/rh/rh-ruby27/root/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}} \
+    MANPATH=/opt/rh/rh-ruby27/root/usr/local/share/man:/opt/rh/rh-ruby27/root/usr/share/man:${MANPATH} \
+    PKG_CONFIG_PATH=/opt/rh/rh-ruby27/root/usr/local/lib64/pkgconfig:/opt/rh/rh-ruby27/root/usr/lib64/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}} \
+    XDG_DATA_DIRS=/opt/rh/rh-ruby27/root/usr/local/share:/opt/rh/rh-ruby27/root/usr/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}
+
+CMD ["irb"]

--- a/OracleLinuxDevelopers/oraclelinux8/ruby/2.6/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/ruby/2.6/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+FROM oraclelinux:8-slim
+
+COPY ruby.module  /etc/dnf/modules.d/ruby.module
+
+RUN microdnf install ruby \
+                     ruby-libs \
+                     ruby-devel \
+                     ruby-irb \
+                     rubygems \
+                     rubygem-rake \
+                     rubygem-bundler \
+                     gcc make \
+    && microdnf clean all
+
+CMD ["irb"]

--- a/OracleLinuxDevelopers/oraclelinux8/ruby/2.6/ruby.module
+++ b/OracleLinuxDevelopers/oraclelinux8/ruby/2.6/ruby.module
@@ -1,0 +1,5 @@
+[ruby]
+name=ruby
+stream=2.6
+profiles=common
+state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/ruby/2.7/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/ruby/2.7/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+FROM oraclelinux:8-slim
+
+COPY ruby.module  /etc/dnf/modules.d/ruby.module
+
+RUN microdnf install ruby \
+                     ruby-libs \
+                     ruby-devel \
+                     ruby-irb \
+                     rubygems \
+                     rubygem-rake \
+                     rubygem-bundler \
+                     gcc make \
+    && microdnf clean all
+
+CMD ["irb"]

--- a/OracleLinuxDevelopers/oraclelinux8/ruby/2.7/ruby.module
+++ b/OracleLinuxDevelopers/oraclelinux8/ruby/2.7/ruby.module
@@ -1,0 +1,5 @@
+[ruby]
+name=ruby
+stream=2.7
+profiles=common
+state=enabled


### PR DESCRIPTION
The Oracle Linux 7 images use Ruby from the Software Collections
Library while the Oracle Linux 8 images use the Ruby module from
the AppStream repo.

All images come with both rake and gem preinstalled.

Image sizes are really nice and small:

```
oraclelinux7-ruby:2.6   157MB
oraclelinux7-ruby:2.7   158MB
oraclelinux8-ruby:2.6   136MB
oraclelinux8-ruby:2.7   137MB
```

Note that we haven't (yet) released the `rh-ruby26` and `rh-ruby27`
SCLs for `aarch64` for Oracle Linux 7 yet, so the workflow will 
skip that combination for now. Once they're released, we 
can enable the build.

If you'd like to test the images, I've made the two packages built by my 
GitHub Action test run public:

<https://github.com/users/Djelibeybi/packages/container/package/oraclelinux7-ruby>
<https://github.com/users/Djelibeybi/packages/container/package/oraclelinux8-ruby>

This resolves #1842 because "Just Enough Image" is the goal for these base images. 
Ping @crush-157 so he can provide feedback as the original requester.

Signed-off-by: Avi Miller <avi.miller@oracle.com>