### PR TITLE
ant jar path changed to Weblogic's oracle_common

### DIFF
--- a/OracleWebCenterSites/dockerfiles/12.2.1.4/wcs-wls-docker-install/Manifest.txt
+++ b/OracleWebCenterSites/dockerfiles/12.2.1.4/wcs-wls-docker-install/Manifest.txt
@@ -1,3 +1,8 @@
 Manifest-Version: 1.0
-Class-Path: /u01/oracle/wcsites/common/bin/config-silent-wcsites/config-silent-wcsites.jar /u01/oracle/wcsites/webcentersites/sites-home/lib/groovy-2.5.6.jar /u01/oracle/oracle_common/modules/oracle.jdbc/ojdbc8.jar /u01/oracle/oracle_common/modules/thirdparty/features/groovy-all.jar
+Class-Path: /u01/oracle/wcsites/common/bin/config-silent-wcsites/config-silent-wcsites.jar
+  /u01/oracle/oracle_common/modules/thirdparty/org.apache.ant/1.10.5.0.0/apache-ant-1.10.5/lib/ant.jar
+  /u01/oracle/oracle_common/modules/thirdparty/org.apache.ant/1.10.5.0.0/apache-ant-1.10.5/lib/ant-junit.jar
+  /u01/oracle/oracle_common/modules/thirdparty/org.apache.ant/1.10.5.0.0/apache-ant-1.10.5/lib/ant-launcher.jar
+  /u01/oracle/oracle_common/modules/oracle.jdbc/ojdbc8.jar
+  /u01/oracle/oracle_common/modules/thirdparty/features/groovy-all.jar
 Main-Class: com.oracle.wcsites.install.InstallScript


### PR DESCRIPTION
This transaction consists wcs-wls-docker-install installer (jar) Manifest file changes. The wcs-wls-docker-install.jar is the one that does the RCU and the ConfigWizard step for Oracle WebCenter Sites.
Ant jars need to be referred from Weblogic's oracle_common libraries as it's no longer shipped with Sites product.