### PR TITLE
To Deploy kubernetes pods of OracleDatabase only on nodes in a particular nodepool having label "pool"

### DIFF
--- a/OracleDatabase/SingleInstance/helm-charts/oracle-db/templates/deployment.yaml
+++ b/OracleDatabase/SingleInstance/helm-charts/oracle-db/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
         fsGroup: 54321
     {{- if .Values.availabilityDomain }}
       nodeSelector:
+      {{- if .Values.pool}}
+        pool: {{ .Values.pool }}
+      {{- end }}
         failure-domain.beta.kubernetes.io/zone: "{{ .Values.availabilityDomain }}"
     {{- end }}
       containers:

--- a/OracleDatabase/SingleInstance/helm-charts/oracle-db/templates/deployment.yaml
+++ b/OracleDatabase/SingleInstance/helm-charts/oracle-db/templates/deployment.yaml
@@ -31,13 +31,15 @@ spec:
       securityContext:
         runAsUser: 54321
         fsGroup: 54321
-    {{- if .Values.availabilityDomain }}
+      {{- if or .Values.availabilityDomain .Values.nodeLables}}
       nodeSelector:
-      {{- if .Values.pool}}
-        pool: {{ .Values.pool }}
+      {{- range $key, $value := .Values.nodeLables }}
+        {{ $key }}: {{ $value | quote }}
       {{- end }}
+      {{- if .Values.availabilityDomain }}
         failure-domain.beta.kubernetes.io/zone: "{{ .Values.availabilityDomain }}"
-    {{- end }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: oracle-db
           image: {{ .Values.image }}

--- a/OracleDatabase/SingleInstance/helm-charts/oracle-db/templates/deployment.yaml
+++ b/OracleDatabase/SingleInstance/helm-charts/oracle-db/templates/deployment.yaml
@@ -31,9 +31,9 @@ spec:
       securityContext:
         runAsUser: 54321
         fsGroup: 54321
-    {{- if or .Values.availabilityDomain .Values.nodeLables}}
+    {{- if or .Values.availabilityDomain .Values.nodeLabels}}
       nodeSelector:
-      {{- range $key, $value := .Values.nodeLables }}
+      {{- range $key, $value := .Values.nodeLabels }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- if .Values.availabilityDomain }}

--- a/OracleDatabase/SingleInstance/helm-charts/oracle-db/templates/deployment.yaml
+++ b/OracleDatabase/SingleInstance/helm-charts/oracle-db/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       securityContext:
         runAsUser: 54321
         fsGroup: 54321
-      {{- if or .Values.availabilityDomain .Values.nodeLables}}
+    {{- if or .Values.availabilityDomain .Values.nodeLables}}
       nodeSelector:
       {{- range $key, $value := .Values.nodeLables }}
         {{ $key }}: {{ $value | quote }}
@@ -39,7 +39,7 @@ spec:
       {{- if .Values.availabilityDomain }}
         failure-domain.beta.kubernetes.io/zone: "{{ .Values.availabilityDomain }}"
       {{- end }}
-      {{- end }}
+    {{- end }}
       containers:
         - name: oracle-db
           image: {{ .Values.image }}

--- a/OracleDatabase/SingleInstance/helm-charts/oracle-db/values.yaml
+++ b/OracleDatabase/SingleInstance/helm-charts/oracle-db/values.yaml
@@ -47,7 +47,7 @@ imagePullPolicy: Always
 imagePullSecrets:
 
 ## Deploy only on nodes having required labels .
-## Format label_name : label_value . eg pool : sidb
+## Format label_name : label_value . eg pool: sidb
 ## Leave empty if there is no such requirement
-nodeLables:
+nodeLabels:
 #  pool: sidb

--- a/OracleDatabase/SingleInstance/helm-charts/oracle-db/values.yaml
+++ b/OracleDatabase/SingleInstance/helm-charts/oracle-db/values.yaml
@@ -49,3 +49,4 @@ imagePullSecrets:
 ## Deploy only on nodes in a particular nodepool having label "pool"
 ## Leave empty if there is no such requirement
 pool:
+

--- a/OracleDatabase/SingleInstance/helm-charts/oracle-db/values.yaml
+++ b/OracleDatabase/SingleInstance/helm-charts/oracle-db/values.yaml
@@ -46,6 +46,8 @@ imagePullPolicy: Always
 ## container registry login/password
 imagePullSecrets:
 
-## Deploy only on nodes in a particular nodepool having label "pool"
+## Deploy only on nodes having required labels .
+## Format label_name : label_value . eg pool : sidb
 ## Leave empty if there is no such requirement
-pool:
+nodeLables:
+#  pool: sidb

--- a/OracleDatabase/SingleInstance/helm-charts/oracle-db/values.yaml
+++ b/OracleDatabase/SingleInstance/helm-charts/oracle-db/values.yaml
@@ -49,4 +49,3 @@ imagePullSecrets:
 ## Deploy only on nodes in a particular nodepool having label "pool"
 ## Leave empty if there is no such requirement
 pool:
-

--- a/OracleDatabase/SingleInstance/helm-charts/oracle-db/values.yaml
+++ b/OracleDatabase/SingleInstance/helm-charts/oracle-db/values.yaml
@@ -46,3 +46,6 @@ imagePullPolicy: Always
 ## container registry login/password
 imagePullSecrets:
 
+## Deploy only on nodes in a particular nodepool having label "pool"
+## Leave empty if there is no such requirement
+pool:


### PR DESCRIPTION
To Deploy Kubernetes pods of OracleDatabase only on nodes in a particular NodePool having label "pool" , Added label "pool" under nodeSelector in OracleDatabase/SingleInstance/helm-charts/oracle-db/templates/deployment.yaml