### PR TITLE
Support to turn on archive log mode in the database

### DIFF
--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -68,6 +68,7 @@ To run your Oracle Database image use the `docker run` command as follows:
     -e INIT_PGA_SIZE=<your database PGA memory in MB> \
     -e ORACLE_EDITION=<your database edition> \
     -e ORACLE_CHARACTERSET=<your character set> \
+    -e ENABLE_ARCHIVELOG=true \
     -v [<host mount point>:]/opt/oracle/oradata \
     oracle/database:19.3.0-ee
     
@@ -89,6 +90,8 @@ To run your Oracle Database image use the `docker run` command as follows:
                       Supported 19.3 onwards.
        -e ORACLE_CHARACTERSET:
                       The character set to use when creating the database (default: AL32UTF8).
+       -e ENABLE_ARCHIVELOG:
+                      To enable archive log mode in the database (default: false) 
        -v /opt/oracle/oradata
                       The data volume to use for the database.
                       Has to be writable by the Unix "oracle" (uid: 54321) user inside the container!

--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -91,7 +91,8 @@ To run your Oracle Database image use the `docker run` command as follows:
        -e ORACLE_CHARACTERSET:
                       The character set to use when creating the database (default: AL32UTF8).
        -e ENABLE_ARCHIVELOG:
-                      To enable archive log mode in the database (default: false) 
+                      To enable archive log mode when creating the database (default: false).
+                      Supported 19.3 onwards.
        -v /opt/oracle/oradata
                       The data volume to use for the database.
                       Has to be writable by the Unix "oracle" (uid: 54321) user inside the container!
@@ -138,6 +139,12 @@ On the first startup of the container a random password will be generated for th
 The password for those accounts can be changed via the `docker exec` command. **Note**, the container has to be running:
 
     docker exec <container name> ./setPassword.sh <your password>
+
+#### Enabling archive log mode while creating the database
+
+Archive mode can be enabled during the first time when database is created by setting ENABLE_ARCHIVELOG to `true` and passing it to `docker run` command. Archive logs are stored at the directory location: `/opt/oracle/oradata/$ORACLE_SID/archive_logs` inside the container.
+
+In case this parameter is set `true` and passed to `docker run` command while reusing existing datafiles, even though this parameter would be visible as set to `true` in the container environment, this would not be set inside the database. The value used at the time of database creation will be used.
 
 #### Running Oracle Database 18c Express Edition in a container
 

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
@@ -55,7 +55,8 @@ ENV ORACLE_BASE=/opt/oracle \
     USER_SCRIPTS_FILE="runUserScripts.sh" \
     INSTALL_DB_BINARIES_FILE="installDBBinaries.sh" \
     RELINK_BINARY_FILE="relinkOracleBinary.sh" \
-    SLIMMING=$SLIMMING
+    SLIMMING=$SLIMMING \
+    ENABLE_ARCHIVELOG=false
 
 # Use second ENV so that variable get substituted
 ENV PATH=$ORACLE_HOME/bin:$ORACLE_HOME/OPatch/:/usr/sbin:$PATH \

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
@@ -72,7 +72,7 @@ DIAG_ADR_ENABLED = off
 
 # Start LISTENER and run DBCA
 lsnrctl start &&
-dbca -silent -createDatabase -responseFile $ORACLE_BASE/dbca.rsp ||
+dbca -silent -createDatabase -enableArchive $ENABLE_ARCHIVELOG -archiveLogDest $ORACLE_BASE/oradata/$ORACLE_SID/archive_logs -responseFile $ORACLE_BASE/dbca.rsp ||
  cat /opt/oracle/cfgtoollogs/dbca/$ORACLE_SID/$ORACLE_SID.log ||
  cat /opt/oracle/cfgtoollogs/dbca/$ORACLE_SID.log
 

--- a/OracleDatabase/SingleInstance/helm-charts/oracle-db/README.md
+++ b/OracleDatabase/SingleInstance/helm-charts/oracle-db/README.md
@@ -80,6 +80,7 @@ The following tables lists the configurable parameters of the Oracle  Database c
 | image                                | Image to pull                              | container-registry.oracle.com/database/enterprise:19.3.0.0 |
 | imagePullPolicy                      | Image pull policy                          | Always                                                     |
 | imagePullSecrets                     | container registry login/password          |                                                            |
+| enable_archive                       | Set true to enable archive mode in database| false                                                      |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/OracleDatabase/SingleInstance/helm-charts/oracle-db/README.md
+++ b/OracleDatabase/SingleInstance/helm-charts/oracle-db/README.md
@@ -80,7 +80,7 @@ The following tables lists the configurable parameters of the Oracle  Database c
 | image                                | Image to pull                              | container-registry.oracle.com/database/enterprise:19.3.0.0 |
 | imagePullPolicy                      | Image pull policy                          | Always                                                     |
 | imagePullSecrets                     | container registry login/password          |                                                            |
-| enable_archive                       | Set true to enable archive mode in database| false                                                      |
+| enable_archivelog                    | Set true to enable archive log mode when creating the database | false                                                      |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/OracleDatabase/SingleInstance/helm-charts/oracle-db/templates/_helpers.tpl
+++ b/OracleDatabase/SingleInstance/helm-charts/oracle-db/templates/_helpers.tpl
@@ -40,7 +40,7 @@ env:
   - name: ORACLE_EDITION
     value: {{ default "enterprise" .Values.oracle_edition | quote }}
   - name: ENABLE_ARCHIVELOG
-    value: {{ default false .Values.enable_archive | quote}}
+    value: {{ default false .Values.enable_archivelog | quote}}
 {{- end }}
 {{/* oracle db labels */}}
 {{- define "oracle-db-labels" }}

--- a/OracleDatabase/SingleInstance/helm-charts/oracle-db/templates/_helpers.tpl
+++ b/OracleDatabase/SingleInstance/helm-charts/oracle-db/templates/_helpers.tpl
@@ -39,6 +39,8 @@ env:
     value: {{ default "ORCLPDB1" .Values.oracle_characterset | quote }}
   - name: ORACLE_EDITION
     value: {{ default "enterprise" .Values.oracle_edition | quote }}
+  - name: ENABLE_ARCHIVELOG
+    value: {{ default false .Values.enable_archive | quote}}
 {{- end }}
 {{/* oracle db labels */}}
 {{- define "oracle-db-labels" }}

--- a/OracleDatabase/SingleInstance/helm-charts/oracle-db/values.yaml
+++ b/OracleDatabase/SingleInstance/helm-charts/oracle-db/values.yaml
@@ -20,6 +20,9 @@ oracle_characterset: AL32UTF8
 ## The database edition (default: enterprise)
 oracle_edition: enterprise
 
+## Enable archiveLogMode in the database
+enable_archive: false
+
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 persistence:

--- a/OracleDatabase/SingleInstance/helm-charts/oracle-db/values.yaml
+++ b/OracleDatabase/SingleInstance/helm-charts/oracle-db/values.yaml
@@ -20,8 +20,8 @@ oracle_characterset: AL32UTF8
 ## The database edition (default: enterprise)
 oracle_edition: enterprise
 
-## Enable archiveLogMode in the database
-enable_archive: false
+## Enable archive log mode when creating the database
+enable_archivelog: false
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/


### PR DESCRIPTION
Enable support to turn on archive log mode in the database while creating the container or deploying using 19c docker image.
Raised issue #1902 for this PR.
Close #1902 

Signed-off-by: abhisbyk <abhishek.by.kumar@oracle.com>