### PR TITLE
ci: update build and push workflows to use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/build-and-push-dev-images.yml
+++ b/.github/workflows/build-and-push-dev-images.yml
@@ -146,8 +146,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ secrets.GHCR_USER }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build image - amd64
         uses: docker/build-push-action@v2

--- a/.github/workflows/build-and-push-instantclient-images.yml
+++ b/.github/workflows/build-and-push-instantclient-images.yml
@@ -67,7 +67,8 @@ jobs:
           rm "${changes}"
 
       - name: Log into GitHub Container Registry
-        run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GHCR_USER }} --password-stdin
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login -u "${GITHUB_ACTOR,,}" --password-stdin ghcr.io
 
       - name: Build Oracle Instant Client
         run: |
@@ -75,7 +76,7 @@ jobs:
           do
             for i in ${{ steps.linux-version.outputs.ic }}
             do
-              docker build --tag ghcr.io/oracle/${o}-instantclient:${i} OracleInstantClient/${o}/${i}
+              docker build --tag "ghcr.io/${{ github.repository_owner }}/${o}-instantclient:${i}" OracleInstantClient/${o}/${i}
             done
           done
 
@@ -85,6 +86,6 @@ jobs:
           do
             for i in ${{ steps.linux-version.outputs.ic }}
             do
-              docker push ghcr.io/oracle/${o}-instantclient:${i}
+              docker push "ghcr.io/${{ github.repository_owner }}/${o}-instantclient:${i}"
             done
           done

--- a/.github/workflows/build-and-push-nosql-image.yml
+++ b/.github/workflows/build-and-push-nosql-image.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - 'NoSQL/19.5-ce/*'
+      - '.github/workflows/build-and-push-nosql-image.yml'
+    workflow_dispatch:
 
 env:
   IMAGE_NAME: nosql
@@ -14,21 +16,19 @@ env:
 jobs:
   push:
     name: Build and push NoSQL 19.5-ce image
-
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
-
     steps:
       - uses: actions/checkout@v2
 
       - name: Log into GitHub Container Registry
-        run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GHCR_USER }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login -u "${GITHUB_ACTOR,,}" --password-stdin ghcr.io
 
       - name: Build NoSQL 19.5-ce image
         run: |
           cd NoSQL/19.5-ce
-          docker build --tag ghcr.io/oracle/$IMAGE_NAME:$TAG .
+          docker build --tag "ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME:$TAG" .
 
       - name: Push image to GitHub Container Registry
         run: |
-          docker push ghcr.io/oracle/$IMAGE_NAME:$TAG
+          docker push "ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME:$TAG"

--- a/NoSQL/19.5-ce/Dockerfile
+++ b/NoSQL/19.5-ce/Dockerfile
@@ -3,6 +3,8 @@
 #
 FROM openjdk:14-oraclelinux7
 
+LABEL org.opencontainers.image.source = "https://github.com/oracle/docker-images"
+
 ENV VERSION="19.5.19" \
     KVHOME=/kv-19.5.19 \
     PACKAGE="kv-ce" \


### PR DESCRIPTION
This provides extra security by not requiring repository or org
level secrets. Includes tweaking the individual builds to still
publish to the Oracle namespace.

Signed-off-by: Avi Miller <avi.miller@oracle.com>