### PR TITLE
ci: update build and push workflows to use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/build-and-push-dev-images.yml
+++ b/.github/workflows/build-and-push-dev-images.yml
@@ -146,8 +146,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ secrets.GHCR_USER }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build image - amd64
         uses: docker/build-push-action@v2

--- a/.github/workflows/build-and-push-instantclient-images.yml
+++ b/.github/workflows/build-and-push-instantclient-images.yml
@@ -67,7 +67,13 @@ jobs:
           rm "${changes}"
 
       - name: Log into GitHub Container Registry
-        run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GHCR_USER }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${GITHUB_ACTOR,,} --password-stdin
+
+      - name: Repository owner needs to be lowercase
+        id: repo-owner
+        run: |
+          REPO_OWNER=${{ github.repository_owner }}
+          echo "::set-output name=repo-owner::${REPO_OWNER,,}"
 
       - name: Build Oracle Instant Client
         run: |
@@ -75,7 +81,7 @@ jobs:
           do
             for i in ${{ steps.linux-version.outputs.ic }}
             do
-              docker build --tag ghcr.io/oracle/${o}-instantclient:${i} OracleInstantClient/${o}/${i}
+              docker build --tag ghcr.io/${{ steps.repo-owner.outputs.repo-owner }}/${o}-instantclient:${i} OracleInstantClient/${o}/${i}
             done
           done
 
@@ -85,6 +91,6 @@ jobs:
           do
             for i in ${{ steps.linux-version.outputs.ic }}
             do
-              docker push ghcr.io/oracle/${o}-instantclient:${i}
+              docker push ghcr.io/${{ steps.repo-owner.outputs.repo-owner }}/${o}-instantclient:${i}
             done
           done

--- a/.github/workflows/build-and-push-nosql-image.yml
+++ b/.github/workflows/build-and-push-nosql-image.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - 'NoSQL/19.5-ce/*'
+      - '.github/workflows/build-and-push-nosql-image.yml'
+    workflow_dispatch:
 
 env:
   IMAGE_NAME: nosql
@@ -22,13 +24,19 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Log into GitHub Container Registry
-        run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GHCR_USER }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login -u ${GITHUB_ACTOR,,} --password-stdin ghcr.io
+
+      - name: Repository owner needs to be lowercase
+        id: repo-owner
+        run: |
+          REPO_OWNER=${{ github.repository_owner }}
+          echo "::set-output name=repo-owner::${REPO_OWNER,,}"
 
       - name: Build NoSQL 19.5-ce image
         run: |
           cd NoSQL/19.5-ce
-          docker build --tag ghcr.io/oracle/$IMAGE_NAME:$TAG .
+          docker build --tag ghcr.io/${{ steps.repo-owner.outputs.repo-owner }}/$IMAGE_NAME:$TAG .
 
       - name: Push image to GitHub Container Registry
         run: |
-          docker push ghcr.io/oracle/$IMAGE_NAME:$TAG
+          docker push ghcr.io/${{ steps.repo-owner.outputs.repo-owner }}/$IMAGE_NAME:$TAG


### PR DESCRIPTION
This provides extra security by not requiring repository or org
level secrets. Includes tweaking the individual builds to still
publish to the Oracle namespace. This required updating the
permissions for each package to allow this repo to push.

Signed-off-by: Avi Miller <avi.miller@oracle.com>