### PR TITLE
Option to provide image name and tag while generating docker image

### DIFF
--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -25,12 +25,13 @@ Before you build the image make sure that you have provided the installation bin
 
     [oracle@localhost dockerfiles]$ ./buildContainerImage.sh -h
     
-    Usage: buildContainerImage.sh -v [version] [-e | -s | -x] [-i] [-o] [container build option]
+    Usage: buildContainerImage.sh -v [version] -t [image_name:tag] [-e | -s | -x] [-i] [-o] [container build option]
     Builds a container image for Oracle Database.
     
     Parameters:
        -v: version to build
            Choose one of: 11.2.0.2  12.1.0.2  12.2.0.1  18.3.0  18.4.0  19.3.0  
+       -t: image_name:tag for the generated docker image
        -e: creates image based on 'Enterprise Edition'
        -s: creates image based on 'Standard Edition 2'
        -x: creates image based on 'Express Edition'


### PR DESCRIPTION
Adding option to buildContainerImage.sh for providing image_name:tag of the generated image.

Signed-off-by: abhisbyk <abhishek.by.kumar@oracle.com>