### PR TITLE
setPassword script fix

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
@@ -56,7 +56,8 @@ ENV ORACLE_BASE=/opt/oracle \
     INSTALL_DB_BINARIES_FILE="installDBBinaries.sh" \
     RELINK_BINARY_FILE="relinkOracleBinary.sh" \
     SLIMMING=$SLIMMING \
-    ENABLE_ARCHIVELOG=false
+    ENABLE_ARCHIVELOG=false \
+    ARCHIVELOG_DIR_NAME=archive_logs
 
 # Use second ENV so that variable get substituted
 ENV PATH=$ORACLE_HOME/bin:$ORACLE_HOME/OPatch/:/usr/sbin:$PATH \

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
@@ -75,7 +75,7 @@ export ARCHIVELOG_DIR=$ORACLE_BASE/oradata/$ORACLE_SID/$ARCHIVELOG_DIR_NAME
 
 # Start LISTENER and run DBCA
 lsnrctl start &&
-dbca -silent -createDatabase -enableArchive $ENABLE_ARCHIVELOG -archiveLogDest $ARCHIVELOG_DIR_NAME -responseFile $ORACLE_BASE/dbca.rsp ||
+dbca -silent -createDatabase -enableArchive $ENABLE_ARCHIVELOG -archiveLogDest $ARCHIVELOG_DIR -responseFile $ORACLE_BASE/dbca.rsp ||
  cat /opt/oracle/cfgtoollogs/dbca/$ORACLE_SID/$ORACLE_SID.log ||
  cat /opt/oracle/cfgtoollogs/dbca/$ORACLE_SID.log
 

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
@@ -70,9 +70,12 @@ DEDICATED_THROUGH_BROKER_LISTENER=ON
 DIAG_ADR_ENABLED = off
 " > $ORACLE_HOME/network/admin/listener.ora
 
+# Directory for storing archive logs
+export ARCHIVELOG_DIR=$ORACLE_BASE/oradata/$ORACLE_SID/$ARCHIVELOG_DIR_NAME
+
 # Start LISTENER and run DBCA
 lsnrctl start &&
-dbca -silent -createDatabase -enableArchive $ENABLE_ARCHIVELOG -archiveLogDest $ORACLE_BASE/oradata/$ORACLE_SID/archive_logs -responseFile $ORACLE_BASE/dbca.rsp ||
+dbca -silent -createDatabase -enableArchive $ENABLE_ARCHIVELOG -archiveLogDest $ARCHIVELOG_DIR_NAME -responseFile $ORACLE_BASE/dbca.rsp ||
  cat /opt/oracle/cfgtoollogs/dbca/$ORACLE_SID/$ORACLE_SID.log ||
  cat /opt/oracle/cfgtoollogs/dbca/$ORACLE_SID.log
 

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/setPassword.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/setPassword.sh
@@ -12,7 +12,7 @@
 
 ORACLE_PWD=$1
 ORACLE_SID="`grep $ORACLE_HOME /etc/oratab | cut -d: -f1`"
-ORACLE_PDB="`ls -dl $ORACLE_BASE/oradata/$ORACLE_SID/*/ | grep -v pdbseed | awk '{print $9}' | cut -d/ -f6`"
+ORACLE_PDB="`ls -dl $ORACLE_BASE/oradata/$ORACLE_SID/*/ | grep -v -e pdbseed -e archive_logs | awk '{print $9}' | cut -d/ -f6`"
 ORAENV_ASK=NO
 source oraenv
 

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/setPassword.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/setPassword.sh
@@ -12,7 +12,7 @@
 
 ORACLE_PWD=$1
 ORACLE_SID="`grep $ORACLE_HOME /etc/oratab | cut -d: -f1`"
-ORACLE_PDB="`ls -dl $ORACLE_BASE/oradata/$ORACLE_SID/*/ | grep -v -e pdbseed -e archive_logs | awk '{print $9}' | cut -d/ -f6`"
+ORACLE_PDB="`ls -dl $ORACLE_BASE/oradata/$ORACLE_SID/*/ | grep -v -e pdbseed -e $ARCHIVELOG_DIR_NAME | awk '{print $9}' | cut -d/ -f6`"
 ORAENV_ASK=NO
 source oraenv
 


### PR DESCRIPTION
If archive_log mode is turned on after providing the ENABLE_ARCHIVELOG=true at docker run command, the inclusion of archive_logs directory in $ORACLE_BASE/oradata/$ORACLE_SID/ directory creates problem in ORACLE_PDB determining logic in the setPassword script. So, fixing this logic.

close #1942 

Signed-off-by: abhisbyk <abhishek.by.kumar@oracle.com>