### PR TITLE
fix(database): cgroup v2 compatibility

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.1.0.2/runOracle.sh
@@ -86,16 +86,20 @@ EOF
 ###################################
 
 # Check whether container has enough memory
+if [[ -f /sys/fs/cgroup/cgroup.controllers ]]; then
+   memory=$(cat /sys/fs/cgroup/memory.max)
+else
+   memory=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+fi
+
 # Github issue #219: Prevent integer overflow,
-# only check if memory digits are less than 11 (single GB range and below) 
-if [ `cat /sys/fs/cgroup/memory/memory.limit_in_bytes | wc -c` -lt 11 ]; then
-   if [ `cat /sys/fs/cgroup/memory/memory.limit_in_bytes` -lt 2147483648 ]; then
-      echo "Error: The container doesn't have enough memory allocated."
-      echo "A database container needs at least 2 GB of memory."
-      echo "You currently only have $((`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`/1024/1024/1024)) GB allocated to the container."
-      exit 1;
-   fi;
-fi;
+# only check if memory digits are less than 11 (single GB range and below)
+if [[ ${memory} != "max" && ${#memory} -lt 11 && ${memory} -lt 2147483648 ]]; then
+   echo "Error: The container doesn't have enough memory allocated."
+   echo "A database container needs at least 2 GB of memory."
+   echo "You currently only have $((memory/1024/1024)) MB allocated to the container."
+   exit 1;
+fi
 
 # Check that hostname doesn't container any "_"
 # Github issue #711

--- a/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/runOracle.sh
@@ -86,16 +86,20 @@ EOF
 ###################################
 
 # Check whether container has enough memory
+if [[ -f /sys/fs/cgroup/cgroup.controllers ]]; then
+   memory=$(cat /sys/fs/cgroup/memory.max)
+else
+   memory=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+fi
+
 # Github issue #219: Prevent integer overflow,
-# only check if memory digits are less than 11 (single GB range and below) 
-if [ `cat /sys/fs/cgroup/memory/memory.limit_in_bytes | wc -c` -lt 11 ]; then
-   if [ `cat /sys/fs/cgroup/memory/memory.limit_in_bytes` -lt 2147483648 ]; then
-      echo "Error: The container doesn't have enough memory allocated."
-      echo "A database container needs at least 2 GB of memory."
-      echo "You currently only have $((`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`/1024/1024/1024)) GB allocated to the container."
-      exit 1;
-   fi;
-fi;
+# only check if memory digits are less than 11 (single GB range and below)
+if [[ ${memory} != "max" && ${#memory} -lt 11 && ${memory} -lt 2147483648 ]]; then
+   echo "Error: The container doesn't have enough memory allocated."
+   echo "A database container needs at least 2 GB of memory."
+   echo "You currently only have $((memory/1024/1024)) MB allocated to the container."
+   exit 1;
+fi
 
 # Check that hostname doesn't container any "_"
 # Github issue #711

--- a/OracleDatabase/SingleInstance/dockerfiles/18.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/18.3.0/runOracle.sh
@@ -86,16 +86,20 @@ EOF
 ###################################
 
 # Check whether container has enough memory
+if [[ -f /sys/fs/cgroup/cgroup.controllers ]]; then
+   memory=$(cat /sys/fs/cgroup/memory.max)
+else
+   memory=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+fi
+
 # Github issue #219: Prevent integer overflow,
-# only check if memory digits are less than 11 (single GB range and below) 
-if [ `cat /sys/fs/cgroup/memory/memory.limit_in_bytes | wc -c` -lt 11 ]; then
-   if [ `cat /sys/fs/cgroup/memory/memory.limit_in_bytes` -lt 2147483648 ]; then
-      echo "Error: The container doesn't have enough memory allocated."
-      echo "A database container needs at least 2 GB of memory."
-      echo "You currently only have $((`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`/1024/1024/1024)) GB allocated to the container."
-      exit 1;
-   fi;
-fi;
+# only check if memory digits are less than 11 (single GB range and below)
+if [[ ${memory} != "max" && ${#memory} -lt 11 && ${memory} -lt 2147483648 ]]; then
+   echo "Error: The container doesn't have enough memory allocated."
+   echo "A database container needs at least 2 GB of memory."
+   echo "You currently only have $((memory/1024/1024)) MB allocated to the container."
+   exit 1;
+fi
 
 # Check that hostname doesn't container any "_"
 # Github issue #711

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -88,7 +88,7 @@ EOF
 
 # Check whether container has enough memory
 if [[ -f /sys/fs/cgroup/cgroup.controllers ]]; then
-   memory=$(cat /sys/fs/cgroup/memory.high)
+   memory=$(cat /sys/fs/cgroup/memory.max)
 else
    memory=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 fi

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -87,16 +87,20 @@ EOF
 ###################################
 
 # Check whether container has enough memory
+if [[ -f /sys/fs/cgroup/cgroup.controllers ]]; then
+   memory=$(cat /sys/fs/cgroup/memory.high)
+else
+   memory=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+fi
+
 # Github issue #219: Prevent integer overflow,
-# only check if memory digits are less than 11 (single GB range and below) 
-if [ `cat /sys/fs/cgroup/memory/memory.limit_in_bytes | wc -c` -lt 11 ]; then
-   if [ `cat /sys/fs/cgroup/memory/memory.limit_in_bytes` -lt 2147483648 ]; then
-      echo "Error: The container doesn't have enough memory allocated."
-      echo "A database container needs at least 2 GB of memory."
-      echo "You currently only have $((`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`/1024/1024/1024)) GB allocated to the container."
-      exit 1;
-   fi;
-fi;
+# only check if memory digits are less than 11 (single GB range and below)
+if [[ ${memory} != "max" && ${#memory} -lt 11 && ${memory} -lt 2147483648 ]]; then
+   echo "Error: The container doesn't have enough memory allocated."
+   echo "A database container needs at least 2 GB of memory."
+   echo "You currently only have $((memory/1024/1024)) MB allocated to the container."
+   exit 1;
+fi
 
 # Check that hostname doesn't container any "_"
 # Github issue #711


### PR DESCRIPTION
The memory check in the runOracle script takes the cgroup version into
account.

Fixes #1939

Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>