### PR TITLE
Fix user script mount issues related to extensions

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -172,7 +172,9 @@ else
 
   # Move database operational files to oradata
   moveFiles;
-   
+
+  # Execute setup script for extensions
+  $ORACLE_BASE/$USER_SCRIPTS_FILE $ORACLE_BASE/scripts/extensions/setup
   # Execute custom provided setup scripts
   $ORACLE_BASE/$USER_SCRIPTS_FILE $ORACLE_BASE/scripts/setup
 fi;
@@ -183,7 +185,9 @@ if [ $? -eq 0 ]; then
   echo "#########################"
   echo "DATABASE IS READY TO USE!"
   echo "#########################"
-  
+
+  # Execute startup script for extensions
+  $ORACLE_BASE/$USER_SCRIPTS_FILE $ORACLE_BASE/scripts/extensions/startup
   # Execute custom provided startup scripts
   $ORACLE_BASE/$USER_SCRIPTS_FILE $ORACLE_BASE/scripts/startup
   

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/setupLinuxEnv.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/setupLinuxEnv.sh
@@ -15,6 +15,8 @@
 # ------------------------------------------------------------
 mkdir -p $ORACLE_BASE/scripts/setup && \
 mkdir $ORACLE_BASE/scripts/startup && \
+mkdir -p $ORACLE_BASE/scripts/extensions/setup && \
+mkdir $ORACLE_BASE/scripts/extensions/startup && \
 ln -s $ORACLE_BASE/scripts /docker-entrypoint-initdb.d && \
 mkdir $ORACLE_BASE/oradata && \
 mkdir -p $ORACLE_HOME && \

--- a/OracleDatabase/SingleInstance/extensions/k8s/Dockerfile
+++ b/OracleDatabase/SingleInstance/extensions/k8s/Dockerfile
@@ -48,7 +48,7 @@ RUN if test -e "$ORACLE_BASE/$RUN_FILE.orig"; then EXTN='extended'; else EXTN='o
 # Copy updated scripts for k8s support 
 COPY  --chown=oracle:dba $RUN_FILE $START_FILE $STARTUP_FILE $SHUT_DB_FILE $LOCKING_SCRIPT $CHECK_DB_LOCK_FILE $ORACLE_BASE/
 RUN   mv "$ORACLE_BASE/$RUN_FILE" "$ORACLE_BASE/$RUN_FILE.$EXTENSION_NAME"
-COPY  --chown=oracle:dba $SWAP_LOCK_FILE $ORACLE_BASE/scripts/setup/
+COPY  --chown=oracle:dba $SWAP_LOCK_FILE $ORACLE_BASE/scripts/extensions/setup/
 
 # Set perms and append a call to main runOracle
 RUN if test -e "$ORACLE_BASE/$RUN_FILE.extended"; then \

--- a/OracleDatabase/SingleInstance/extensions/k8s/startDB.sh
+++ b/OracleDatabase/SingleInstance/extensions/k8s/startDB.sh
@@ -36,7 +36,7 @@ EOF
 done
 
 # startup can get into a wait mode here
-$ORACLE_BASE/scripts/setup/$SWAP_LOCK_FILE
+$ORACLE_BASE/scripts/extensions/setup/$SWAP_LOCK_FILE
 
 # Start Listener
 lsnrctl start

--- a/OracleDatabase/SingleInstance/extensions/patching/Dockerfile
+++ b/OracleDatabase/SingleInstance/extensions/patching/Dockerfile
@@ -49,11 +49,11 @@ ARG EXTENSION_NAME="patching"
 COPY --from=patching $ORACLE_BASE $ORACLE_BASE
 
 # Copy script to run datapatch
-COPY --chown=oracle:dba $DATAPATCH_FILE $ORACLE_BASE/scripts/extensions/startup
+COPY --chown=oracle:dba $DATAPATCH_FILE $ORACLE_BASE/scripts/extensions/startup/
 RUN chmod ug+x $ORACLE_BASE/scripts/startup/*.sh && sync
 
 # Copy script to run lspatches
-COPY --chown=oracle:dba $LSPATCHES_FILE $ORACLE_BASE/scripts/extensions/setup
+COPY --chown=oracle:dba $LSPATCHES_FILE $ORACLE_BASE/scripts/extensions/setup/
 RUN chmod ug+x $ORACLE_BASE/scripts/setup/*.sh && sync
 
 # backup origin runOracle

--- a/OracleDatabase/SingleInstance/extensions/patching/Dockerfile
+++ b/OracleDatabase/SingleInstance/extensions/patching/Dockerfile
@@ -50,7 +50,7 @@ COPY --from=patching $ORACLE_BASE $ORACLE_BASE
 
 # Copy script to run datapatch
 COPY --chown=oracle:dba $DATAPATCH_FILE $ORACLE_BASE/scripts/extensions/startup/
-RUN chmod ug+x $ORACLE_BASE/scripts/extensinons/startup/*.sh && sync
+RUN chmod ug+x $ORACLE_BASE/scripts/extensions/startup/*.sh && sync
 
 # Copy script to run lspatches
 COPY --chown=oracle:dba $LSPATCHES_FILE $ORACLE_BASE/scripts/extensions/setup/

--- a/OracleDatabase/SingleInstance/extensions/patching/Dockerfile
+++ b/OracleDatabase/SingleInstance/extensions/patching/Dockerfile
@@ -50,11 +50,11 @@ COPY --from=patching $ORACLE_BASE $ORACLE_BASE
 
 # Copy script to run datapatch
 COPY --chown=oracle:dba $DATAPATCH_FILE $ORACLE_BASE/scripts/extensions/startup/
-RUN chmod ug+x $ORACLE_BASE/scripts/startup/*.sh && sync
+RUN chmod ug+x $ORACLE_BASE/scripts/extensinons/startup/*.sh && sync
 
 # Copy script to run lspatches
 COPY --chown=oracle:dba $LSPATCHES_FILE $ORACLE_BASE/scripts/extensions/setup/
-RUN chmod ug+x $ORACLE_BASE/scripts/setup/*.sh && sync
+RUN chmod ug+x $ORACLE_BASE/scripts/extensions/setup/*.sh && sync
 
 # backup origin runOracle
 RUN if test -e "$ORACLE_BASE/$RUN_FILE.orig"; then EXTN='extended'; else EXTN='orig'; fi ; \

--- a/OracleDatabase/SingleInstance/extensions/patching/Dockerfile
+++ b/OracleDatabase/SingleInstance/extensions/patching/Dockerfile
@@ -49,11 +49,11 @@ ARG EXTENSION_NAME="patching"
 COPY --from=patching $ORACLE_BASE $ORACLE_BASE
 
 # Copy script to run datapatch
-COPY --chown=oracle:dba $DATAPATCH_FILE $ORACLE_BASE/scripts/startup
+COPY --chown=oracle:dba $DATAPATCH_FILE $ORACLE_BASE/scripts/extensions/startup
 RUN chmod ug+x $ORACLE_BASE/scripts/startup/*.sh && sync
 
 # Copy script to run lspatches
-COPY --chown=oracle:dba $LSPATCHES_FILE $ORACLE_BASE/scripts/setup
+COPY --chown=oracle:dba $LSPATCHES_FILE $ORACLE_BASE/scripts/extensions/setup
 RUN chmod ug+x $ORACLE_BASE/scripts/setup/*.sh && sync
 
 # backup origin runOracle


### PR DESCRIPTION
If users mount `/opt/oracle/scripts/setup` and` /opt/oracle/scripts/startup` directories from host machine while creating the container from the extended image (either using patching or k8s extension), some scripts which are already present in those locations (kept there while extending the base docker image) are overwritten.

So created new directories `/opt/oracle/scripts/extensions/setup` and `/opt/oracle/scripts/extensions/startup` to place the scripts while extending the base image. Now, It doesn't get overwritten even if user mount the directories mentioned above.