### PR TITLE
DB crash when container is killed/stopped before DB is ready .

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
@@ -58,7 +58,7 @@ ENV ORACLE_BASE=/opt/oracle \
     SLIMMING=$SLIMMING \
     ENABLE_ARCHIVELOG=false \
     ARCHIVELOG_DIR_NAME=archive_logs \
-    DB_CHECKPOINT_FILE=".db_ready"
+    CHECKPOINT_FILE=".db_exist"
 
 # Use second ENV so that variable get substituted
 ENV PATH=$ORACLE_HOME/bin:$ORACLE_HOME/OPatch/:/usr/sbin:$PATH \

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
@@ -57,7 +57,8 @@ ENV ORACLE_BASE=/opt/oracle \
     RELINK_BINARY_FILE="relinkOracleBinary.sh" \
     SLIMMING=$SLIMMING \
     ENABLE_ARCHIVELOG=false \
-    ARCHIVELOG_DIR_NAME=archive_logs
+    ARCHIVELOG_DIR_NAME=archive_logs \
+    DB_CHECKPOINT_FILE=".db_ready"
 
 # Use second ENV so that variable get substituted
 ENV PATH=$ORACLE_HOME/bin:$ORACLE_HOME/OPatch/:/usr/sbin:$PATH \

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
@@ -58,7 +58,7 @@ ENV ORACLE_BASE=/opt/oracle \
     SLIMMING=$SLIMMING \
     ENABLE_ARCHIVELOG=false \
     ARCHIVELOG_DIR_NAME=archive_logs \
-    CHECKPOINT_FILE=".db_exist"
+    CHECKPOINT_FILE=".db_created"
 
 # Use second ENV so that variable get substituted
 ENV PATH=$ORACLE_HOME/bin:$ORACLE_HOME/OPatch/:/usr/sbin:$PATH \

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -173,8 +173,11 @@ else
   # Create database
   $ORACLE_BASE/$CREATE_DB_FILE $ORACLE_SID $ORACLE_PDB $ORACLE_PWD || exit 1;
 
-  # Create a checkfile if database exists
-  touch $ORACLE_BASE/oradata/$ORACLE_SID/$CHECKPOINT_FILE
+  $ORACLE_BASE/$CHECK_DB_FILE
+  if [ $? -eq 0 ]; then
+    # Create a checkfile if database exists
+    touch $ORACLE_BASE/oradata/$ORACLE_SID/$CHECKPOINT_FILE
+  fi
 
   # Move database operational files to oradata
   moveFiles;

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -167,7 +167,7 @@ else
   rm -f $ORACLE_HOME/network/admin/listener.ora
   rm -f $ORACLE_HOME/network/admin/tnsnames.ora
    
-  # Remove incomplete database files
+  # Clean up incomplete database
   rm -rf $ORACLE_BASE/oradata/$ORACLE_SID
 
   # Create database

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -148,7 +148,7 @@ export ORACLE_CHARACTERSET=${ORACLE_CHARACTERSET:-AL32UTF8}
 . "$ORACLE_BASE/$RELINK_BINARY_FILE"
 
 # Check whether database already exists
-if [ -f $ORACLE_BASE/oradata/$ORACLE_SID/$DB_CHECKPOINT_FILE ]; then
+if [ -f $ORACLE_BASE/oradata/$ORACLE_SID/$CHECKPOINT_FILE ]; then
    symLinkFiles;
    
    # Make sure audit file destination exists
@@ -173,6 +173,9 @@ else
   # Create database
   $ORACLE_BASE/$CREATE_DB_FILE $ORACLE_SID $ORACLE_PDB $ORACLE_PWD || exit 1;
 
+  # Create a checkfile if database exists
+  touch $ORACLE_BASE/oradata/$ORACLE_SID/$CHECKPOINT_FILE
+
   # Move database operational files to oradata
   moveFiles;
 
@@ -189,8 +192,6 @@ if [ $? -eq 0 ]; then
   echo "DATABASE IS READY TO USE!"
   echo "#########################"
 
-  # Create a checkfile if database exists
-  touch $ORACLE_BASE/oradata/$ORACLE_SID/$DB_CHECKPOINT_FILE
   # Execute startup script for extensions
   $ORACLE_BASE/$USER_SCRIPTS_FILE $ORACLE_BASE/scripts/extensions/startup
   # Execute custom provided startup scripts

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -148,7 +148,7 @@ export ORACLE_CHARACTERSET=${ORACLE_CHARACTERSET:-AL32UTF8}
 . "$ORACLE_BASE/$RELINK_BINARY_FILE"
 
 # Check whether database already exists
-if [ -d $ORACLE_BASE/oradata/$ORACLE_SID ]; then
+if [ -f $ORACLE_BASE/oradata/$ORACLE_SID/$DB_CHECKPOINT_FILE ]; then
    symLinkFiles;
    
    # Make sure audit file destination exists
@@ -167,6 +167,9 @@ else
   rm -f $ORACLE_HOME/network/admin/listener.ora
   rm -f $ORACLE_HOME/network/admin/tnsnames.ora
    
+  # Remove ORACLE_SID folder to remove datafiles , if it exists
+  rm -rf $ORACLE_BASE/oradata/$ORACLE_SID
+
   # Create database
   $ORACLE_BASE/$CREATE_DB_FILE $ORACLE_SID $ORACLE_PDB $ORACLE_PWD || exit 1;
 
@@ -186,6 +189,8 @@ if [ $? -eq 0 ]; then
   echo "DATABASE IS READY TO USE!"
   echo "#########################"
 
+  # Create a checkfile if database exists
+  touch $ORACLE_BASE/oradata/$ORACLE_SID/$DB_CHECKPOINT_FILE
   # Execute startup script for extensions
   $ORACLE_BASE/$USER_SCRIPTS_FILE $ORACLE_BASE/scripts/extensions/startup
   # Execute custom provided startup scripts

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -167,7 +167,7 @@ else
   rm -f $ORACLE_HOME/network/admin/listener.ora
   rm -f $ORACLE_HOME/network/admin/tnsnames.ora
    
-  # Remove ORACLE_SID folder to remove datafiles , if it exists
+  # Remove incomplete database files
   rm -rf $ORACLE_BASE/oradata/$ORACLE_SID
 
   # Create database

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -173,10 +173,10 @@ else
   # Create database
   $ORACLE_BASE/$CREATE_DB_FILE $ORACLE_SID $ORACLE_PDB $ORACLE_PWD || exit 1;
 
-  # Check whether database successfully created
+  # Check whether database is successfully created
   $ORACLE_BASE/$CHECK_DB_FILE
   if [ $? -eq 0 ]; then
-    # Create a checkfile if database exists
+    # Create a checkpoint file if database is successfully created
     touch $ORACLE_BASE/oradata/$ORACLE_SID/$CHECKPOINT_FILE
   fi
 

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -173,6 +173,7 @@ else
   # Create database
   $ORACLE_BASE/$CREATE_DB_FILE $ORACLE_SID $ORACLE_PDB $ORACLE_PWD || exit 1;
 
+  # Check whether database successfully created
   $ORACLE_BASE/$CHECK_DB_FILE
   if [ $? -eq 0 ]; then
     # Create a checkfile if database exists

--- a/OracleDatabase/SingleInstance/extensions/k8s/Dockerfile
+++ b/OracleDatabase/SingleInstance/extensions/k8s/Dockerfile
@@ -57,4 +57,4 @@ RUN if test -e "$ORACLE_BASE/$RUN_FILE.extended"; then \
     if ! grep "$RUN_FILE.$EXTENSION_NAME" "$ORACLE_BASE/$RUN_FILE"; then \
         sed  -i "1i . $ORACLE_BASE/$RUN_FILE.$EXTENSION_NAME" "$ORACLE_BASE/$RUN_FILE"; \
     fi && \
-    chmod ug+x $ORACLE_BASE/*.sh $ORACLE_BASE/scripts/extensions/setup/ $ORACLE_BASE/*.py && sync
+    chmod ug+x $ORACLE_BASE/*.sh $ORACLE_BASE/scripts/extensions/setup/*.sh $ORACLE_BASE/*.py && sync

--- a/OracleDatabase/SingleInstance/extensions/k8s/Dockerfile
+++ b/OracleDatabase/SingleInstance/extensions/k8s/Dockerfile
@@ -57,4 +57,4 @@ RUN if test -e "$ORACLE_BASE/$RUN_FILE.extended"; then \
     if ! grep "$RUN_FILE.$EXTENSION_NAME" "$ORACLE_BASE/$RUN_FILE"; then \
         sed  -i "1i . $ORACLE_BASE/$RUN_FILE.$EXTENSION_NAME" "$ORACLE_BASE/$RUN_FILE"; \
     fi && \
-    chmod ug+x $ORACLE_BASE/*.sh $ORACLE_BASE/*.py && sync
+    chmod ug+x $ORACLE_BASE/*.sh $ORACLE_BASE/scripts/extensions/setup/ $ORACLE_BASE/*.py && sync


### PR DESCRIPTION
If one of the database pods which is initialising database , is killed/stopped before it's ready , the other pods try to create the database and result in Pod Crash  #1969 
Solved this by creating a checkpoint file and checking if it is present before creating or starting database. 