### PR TITLE
Modify help text displayed during helm install

### DIFF
--- a/OracleDatabase/SingleInstance/helm-charts/oracle-db/templates/NOTES.txt
+++ b/OracleDatabase/SingleInstance/helm-charts/oracle-db/templates/NOTES.txt
@@ -18,11 +18,13 @@ ORCLPDB1=(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=<ip-address>)(PORT=<port>))
 Application details
 ====================
 IP and port can be found using the following:
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
-  export NODE_XDB_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[1].nodePort}" services {{ template "fullname" . }})
 {{- if .Values.loadBalService }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].port}" services {{ template "fullname" . }})
+  export NODE_XDB_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[1].port}" services {{ template "fullname" . }})
   export NODE_IP=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.status.loadBalancer.ingress[0].ip}" services {{ template "fullname" . }})
 {{- else}}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_XDB_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[1].nodePort}" services {{ template "fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
 {{- end }}
 echo listener at $NODE_IP:$NODE_PORT

--- a/OracleDatabase/SingleInstance/helm-charts/oracle-db/templates/NOTES.txt
+++ b/OracleDatabase/SingleInstance/helm-charts/oracle-db/templates/NOTES.txt
@@ -18,10 +18,13 @@ ORCLPDB1=(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=<ip-address>)(PORT=<port>))
 Application details
 ====================
 IP and port can be found using the following:
-
-export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
-export NODE_XDB_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[1].nodePort}" services {{ template "fullname" . }})
-export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_XDB_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[1].nodePort}" services {{ template "fullname" . }})
+{{- if .Values.loadBalService }}
+  export NODE_IP=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.status.loadBalancer.ingress[0].ip}" services {{ template "fullname" . }})
+{{- else}}
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+{{- end }}
 echo listener at $NODE_IP:$NODE_PORT
 echo XDB at $NODE_IP:$NODE_XDB_PORT
 

--- a/OracleDatabase/SingleInstance/helm-charts/oracle-db/templates/NOTES.txt
+++ b/OracleDatabase/SingleInstance/helm-charts/oracle-db/templates/NOTES.txt
@@ -19,13 +19,13 @@ Application details
 ====================
 IP and port can be found using the following:
 {{- if .Values.loadBalService }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].port}" services {{ template "fullname" . }})
-  export NODE_XDB_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[1].port}" services {{ template "fullname" . }})
-  export NODE_IP=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.status.loadBalancer.ingress[0].ip}" services {{ template "fullname" . }})
+export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].port}" services {{ template "fullname" . }})
+export NODE_XDB_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[1].port}" services {{ template "fullname" . }})
+export NODE_IP=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.status.loadBalancer.ingress[0].ip}" services {{ template "fullname" . }})
 {{- else}}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
-  export NODE_XDB_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[1].nodePort}" services {{ template "fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+export NODE_XDB_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[1].nodePort}" services {{ template "fullname" . }})
+export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
 {{- end }}
 echo listener at $NODE_IP:$NODE_PORT
 echo XDB at $NODE_IP:$NODE_XDB_PORT


### PR DESCRIPTION
Help text displays <nodeport-ip> as $NODE_IP even when loadBalService is set to true in values.yaml . #1974 
Modified the same to display <loadBalancer-ip> as $NODE_IP when loadBalService is set to true in values.yaml 