### PR TITLE
Option to skip datapatch for read-only/standby databases

### DIFF
--- a/OracleDatabase/SingleInstance/extensions/patching/Dockerfile
+++ b/OracleDatabase/SingleInstance/extensions/patching/Dockerfile
@@ -40,7 +40,8 @@ RUN chmod ug+x $PATCH_DIR/*.sh && \
 ## New stage for minimal layer size
 FROM ${BASE_IMAGE}
 ENV DATAPATCH_FILE="runDatapatch.sh" \
-    LSPATCHES_FILE="savePatchSummary.sh"
+    LSPATCHES_FILE="savePatchSummary.sh" \
+    SKIP_DATAPATCH=false
 
 # Extn name
 ARG EXTENSION_NAME="patching"

--- a/OracleDatabase/SingleInstance/extensions/patching/runDatapatch.sh
+++ b/OracleDatabase/SingleInstance/extensions/patching/runDatapatch.sh
@@ -11,6 +11,10 @@
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
 
+if [ "${SKIP_DATAPATCH}" = "true" ]; then
+  exit 0;
+fi
+
 # LSPATCHES_FILE will have the patch summary of the datafiles.
 DBCONFIG_DIR="${ORACLE_BASE}/oradata/dbconfig/${ORACLE_SID}"
 LSPATCHES_FILE="${DBCONFIG_DIR}/${ORACLE_SID}.lspatches"

--- a/OracleDatabase/SingleInstance/extensions/patching/runDatapatch.sh
+++ b/OracleDatabase/SingleInstance/extensions/patching/runDatapatch.sh
@@ -12,6 +12,7 @@
 #
 
 if [ "${SKIP_DATAPATCH}" = "true" ]; then
+  echo "Skipping Datapatch"
   exit 0;
 fi
 


### PR DESCRIPTION
Added a env variable SKIP_DATAPATCH which if set to true , skips datapatch .