### PR TITLE
Proper cleanup of datafiles

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
@@ -58,7 +58,7 @@ ENV ORACLE_BASE=/opt/oracle \
     SLIMMING=$SLIMMING \
     ENABLE_ARCHIVELOG=false \
     ARCHIVELOG_DIR_NAME=archive_logs \
-    CHECKPOINT_FILE=".created"
+    CHECKPOINT_FILE_EXTN=".created"
 
 # Use second ENV so that variable get substituted
 ENV PATH=$ORACLE_HOME/bin:$ORACLE_HOME/OPatch/:/usr/sbin:$PATH \

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
@@ -58,7 +58,7 @@ ENV ORACLE_BASE=/opt/oracle \
     SLIMMING=$SLIMMING \
     ENABLE_ARCHIVELOG=false \
     ARCHIVELOG_DIR_NAME=archive_logs \
-    CHECKPOINT_FILE=".db_created"
+    CHECKPOINT_FILE=".created"
 
 # Use second ENV so that variable get substituted
 ENV PATH=$ORACLE_HOME/bin:$ORACLE_HOME/OPatch/:/usr/sbin:$PATH \

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/relinkOracleBinary.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/relinkOracleBinary.sh
@@ -23,7 +23,7 @@ if [ "${LIB_EDITION}" == "std" ]; then
 fi
 
 # If datafiles already exists
-if [ -d $ORACLE_BASE/oradata/$ORACLE_SID ]; then
+if [ -f $ORACLE_BASE/oradata/$ORACLE_SID/$CHECKPOINT_FILE ]; then
     datafiles_edition=$(ls $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/.docker_* | rev | cut -d_ -f1 | rev)
     if [ "${ORACLE_EDITION}" != "" ] && [ "${ORACLE_EDITION,,}" != $datafiles_edition ]; then
         echo "The datafiles being used were created with $datafiles_edition edition software home. Please pass -e ORACLE_EDITION=$datafiles_edition to the docker run cmd.";

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/relinkOracleBinary.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/relinkOracleBinary.sh
@@ -23,7 +23,7 @@ if [ "${LIB_EDITION}" == "std" ]; then
 fi
 
 # If datafiles already exists
-if [ -f $ORACLE_BASE/oradata/$ORACLE_SID/$CHECKPOINT_FILE ]; then
+if [ -f $ORACLE_BASE/oradata/.${ORACLE_SID}${CHECKPOINT_FILE} ]; then
     datafiles_edition=$(ls $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/.docker_* | rev | cut -d_ -f1 | rev)
     if [ "${ORACLE_EDITION}" != "" ] && [ "${ORACLE_EDITION,,}" != $datafiles_edition ]; then
         echo "The datafiles being used were created with $datafiles_edition edition software home. Please pass -e ORACLE_EDITION=$datafiles_edition to the docker run cmd.";

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/relinkOracleBinary.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/relinkOracleBinary.sh
@@ -23,7 +23,7 @@ if [ "${LIB_EDITION}" == "std" ]; then
 fi
 
 # If datafiles already exists
-if [ -f $ORACLE_BASE/oradata/.${ORACLE_SID}${CHECKPOINT_FILE} ]; then
+if [ -f $ORACLE_BASE/oradata/.${ORACLE_SID}${CHECKPOINT_FILE_EXTN} ]; then
     datafiles_edition=$(ls $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/.docker_* | rev | cut -d_ -f1 | rev)
     if [ "${ORACLE_EDITION}" != "" ] && [ "${ORACLE_EDITION,,}" != $datafiles_edition ]; then
         echo "The datafiles being used were created with $datafiles_edition edition software home. Please pass -e ORACLE_EDITION=$datafiles_edition to the docker run cmd.";

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -169,6 +169,8 @@ else
    
   # Clean up incomplete database
   rm -rf $ORACLE_BASE/oradata/$ORACLE_SID
+  rm -rf /etc/oratab
+  rm -rf /opt/oracle/cfgtoollogs
 
   # Create database
   $ORACLE_BASE/$CREATE_DB_FILE $ORACLE_SID $ORACLE_PDB $ORACLE_PWD || exit 1;

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -171,6 +171,7 @@ else
   rm -rf $ORACLE_BASE/oradata/$ORACLE_SID
   cp /etc/oratab oratab.old
   sed "/$ORACLE_SID/d" oratab.old > /etc/oratab
+  rm -f oratab.old
   rm -rf $ORACLE_BASE/cfgtoollogs/dbca/$ORACLE_SID
   rm -rf $ORACLE_BASE/admin/$ORACLE_SID
 

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -169,8 +169,10 @@ else
    
   # Clean up incomplete database
   rm -rf $ORACLE_BASE/oradata/$ORACLE_SID
-  rm -rf /etc/oratab
-  rm -rf /opt/oracle/cfgtoollogs
+  cp /etc/oratab oratab.old
+  sed "/$ORACLE_SID/d" oratab.old > /etc/oratab
+  rm -rf $ORACLE_BASE/cfgtoollogs/dbca/$ORACLE_SID
+  rm -rf $ORACLE_BASE/admin/$ORACLE_SID
 
   # Create database
   $ORACLE_BASE/$CREATE_DB_FILE $ORACLE_SID $ORACLE_PDB $ORACLE_PWD || exit 1;

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -148,7 +148,7 @@ export ORACLE_CHARACTERSET=${ORACLE_CHARACTERSET:-AL32UTF8}
 . "$ORACLE_BASE/$RELINK_BINARY_FILE"
 
 # Check whether database already exists
-if [ -f $ORACLE_BASE/oradata/$ORACLE_SID/$CHECKPOINT_FILE ]; then
+if [ -f $ORACLE_BASE/oradata/.${ORACLE_SID}${CHECKPOINT_FILE} ]; then
    symLinkFiles;
    
    # Make sure audit file destination exists
@@ -166,12 +166,12 @@ else
   rm -f $ORACLE_HOME/network/admin/sqlnet.ora
   rm -f $ORACLE_HOME/network/admin/listener.ora
   rm -f $ORACLE_HOME/network/admin/tnsnames.ora
-   
+
   # Clean up incomplete database
   rm -rf $ORACLE_BASE/oradata/$ORACLE_SID
-  cp /etc/oratab oratab.old
-  sed "/$ORACLE_SID/d" oratab.old > /etc/oratab
-  rm -f oratab.old
+  cp /etc/oratab oratab.bkp
+  sed "/$ORACLE_SID/d" oratab.bkp > /etc/oratab
+  rm -f oratab.bkp
   rm -rf $ORACLE_BASE/cfgtoollogs/dbca/$ORACLE_SID
   rm -rf $ORACLE_BASE/admin/$ORACLE_SID
 
@@ -182,7 +182,7 @@ else
   $ORACLE_BASE/$CHECK_DB_FILE
   if [ $? -eq 0 ]; then
     # Create a checkpoint file if database is successfully created
-    touch $ORACLE_BASE/oradata/$ORACLE_SID/$CHECKPOINT_FILE
+    touch $ORACLE_BASE/oradata/.${ORACLE_SID}${CHECKPOINT_FILE}
   fi
 
   # Move database operational files to oradata

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -148,7 +148,7 @@ export ORACLE_CHARACTERSET=${ORACLE_CHARACTERSET:-AL32UTF8}
 . "$ORACLE_BASE/$RELINK_BINARY_FILE"
 
 # Check whether database already exists
-if [ -f $ORACLE_BASE/oradata/.${ORACLE_SID}${CHECKPOINT_FILE} ]; then
+if [ -f $ORACLE_BASE/oradata/.${ORACLE_SID}${CHECKPOINT_FILE_EXTN} ]; then
    symLinkFiles;
    
    # Make sure audit file destination exists
@@ -182,7 +182,7 @@ else
   $ORACLE_BASE/$CHECK_DB_FILE
   if [ $? -eq 0 ]; then
     # Create a checkpoint file if database is successfully created
-    touch $ORACLE_BASE/oradata/.${ORACLE_SID}${CHECKPOINT_FILE}
+    touch $ORACLE_BASE/oradata/.${ORACLE_SID}${CHECKPOINT_FILE_EXTN}
   fi
 
   # Move database operational files to oradata


### PR DESCRIPTION
When a container starts with ORACLE_SID whose database installation is incomplete , clean up the datafiles 
Removed SID entry in oratab .
Removed $ORACLE_BASE/cfgtoollogs/dbca/$ORACLE_SID
Removed $ORACLE_BASE/admin/$ORACLE_SID
Removed $ORACLE_BASE/oradata/$ORACLE_SID

Changed location of checkpoint file .
