### PR TITLE
Obtaining latest version in buildContainerImage script

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/buildContainerImage.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/buildContainerImage.sh
@@ -102,12 +102,15 @@ checkDockerVersion() {
 #### MAIN ####
 ##############
 
+# Go into dockerfiles directory
+cd $(dirname $0)
+
 # Parameters
 ENTERPRISE=0
 STANDARD=0
 EXPRESS=0
 # Obtaining the latest version to build
-VERSION="`ls -r | sed -n 2p`"
+VERSION="$(ls -1rd *.3.0 | sed -n 1p)"
 SKIPMD5=0
 declare -a BUILD_OPTS
 MIN_DOCKER_VERSION="17.09"

--- a/OracleDatabase/SingleInstance/dockerfiles/buildContainerImage.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/buildContainerImage.sh
@@ -110,7 +110,7 @@ ENTERPRISE=0
 STANDARD=0
 EXPRESS=0
 # Obtaining the latest version to build
-VERSION="$(ls -1rd *.3.0 | sed -n 1p)"
+VERSION="$(ls -1rd *.*.* | sed -n 1p)"
 SKIPMD5=0
 declare -a BUILD_OPTS
 MIN_DOCKER_VERSION="17.09"

--- a/OracleDatabase/SingleInstance/dockerfiles/buildContainerImage.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/buildContainerImage.sh
@@ -106,7 +106,8 @@ checkDockerVersion() {
 ENTERPRISE=0
 STANDARD=0
 EXPRESS=0
-VERSION="19.3.0"
+# Obtaining the latest version to build
+VERSION="`ls -r | sed -n 2p`"
 SKIPMD5=0
 declare -a BUILD_OPTS
 MIN_DOCKER_VERSION="17.09"


### PR DESCRIPTION
In the view of preparing for newer releases, latest version should be automatically populated in `VERSION` variable (not hard-coded) of buildContainerImage.sh script.

Close #1993 

Signed-off-by: abhisbyk <abhishek.by.kumar@oracle.com>