### PR TITLE
Add --exit to runOracle script

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -196,7 +196,8 @@ fi;
 
 # Check whether database is up and running
 $ORACLE_BASE/$CHECK_DB_FILE
-if [ $? -eq 0 ]; then
+result=$?
+if [ $result -eq 0 ]; then
   echo "#########################"
   echo "DATABASE IS READY TO USE!"
   echo "#########################"
@@ -214,6 +215,10 @@ else
   echo "########### E R R O R ###############" 
   echo "#####################################"
 fi;
+
+if [ "$1" = --exit ]; then
+   exit $result
+fi
 
 # Tail on alert log and wait (otherwise container will exit)
 echo "The following output is now a tail of the alert.log:"


### PR DESCRIPTION
This would allow me to create a pre-started Oracle container so I could take advantage of faster start times, such as:

```Dockerfile
FROM my-oracle:ee-19.3.0

ENV ORACLE_PWD=sys

RUN exec $ORACLE_BASE/$RUN_FILE --exit
```

Then:

```
$ docker build -t my-pre-started-oracle .
$ docker push my-pre-started-oracle
$ docker run -p [...] my-pre-started-oracle
```

This would come very in handy for my CI environment, as it drops the start time from 45 minutes to less than 3.