### PR TITLE
Adding support for additional init parameters in 19c

### DIFF
--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -74,6 +74,7 @@ To run your Oracle Database image use the `docker run` command as follows:
     -e ORACLE_EDITION=<your database edition> \
     -e ORACLE_CHARACTERSET=<your character set> \
     -e ENABLE_ARCHIVELOG=true \
+    -e INIT_PARAMS=<additional database init parameters of format "key1=value1,key2=value2..."> \
     -v [<host mount point>:]/opt/oracle/oradata \
     oracle/database:19.3.0-ee
     

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
@@ -62,7 +62,9 @@ ENV ORACLE_BASE=/opt/oracle \
     CLONE_DB=false \
     # Env var below should be in <HOST>:<PORT>/<SERVICE_NAME> format
     PRIMARY_DB_CONN_STR="" \
-    CHECKPOINT_FILE_EXTN=".created"
+    CHECKPOINT_FILE_EXTN=".created" \
+    # Database Init Parameters: should be a string of format "<key1>=<value1>,<key2>=<value2> ..."
+    INIT_PARAMS=""
 
 # Use second ENV so that variable get substituted
 ENV PATH=$ORACLE_HOME/bin:$ORACLE_HOME/OPatch/:/usr/sbin:$PATH \

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
@@ -135,6 +135,11 @@ else
     sed -i -e "s|initParams=.*|&,sga_target=${INIT_SGA_SIZE}M,pga_aggregate_target=${INIT_PGA_SIZE}M|g" $ORACLE_BASE/dbca.rsp
 fi;
 
+# Adding additional Database Init Parameters
+if [[ ! -z "${INIT_PARAMS}" ]]; then
+  sed -i -e "s|initParams=.*|&,${INIT_PARAMS}|g" $ORACLE_BASE/dbca.rsp
+fi
+
 # Create network related config files (sqlnet.ora, listener.ora)
 setupNetworkConfig;
 


### PR DESCRIPTION
Close #2008 

Added env var `INIT_PARAMS`. It takes a string of the following format:
**"\<key1\>=\<value1\>,\<key2\>=\<value2\>..."**
where `key` is the init parameter and `value` is the value for that parameter.

When this env var is passed to `docker run` command, it sets the specified init parameters of the database.

Signed-off-by: abhisbyk <abhishek.by.kumar@oracle.com>