### PR TITLE
Proposal: a new extension for pre-creating a database

### DIFF
--- a/OracleDatabase/SingleInstance/extensions/pre-create-db/Dockerfile
+++ b/OracleDatabase/SingleInstance/extensions/pre-create-db/Dockerfile
@@ -1,0 +1,38 @@
+# LICENSE UPL 1.0
+#
+# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+#
+# REQUIREMETNS FOR THIS IMAGE
+# ----------------------------------
+# Any release of prebuilt oracle/database base docker image
+#
+# HOW TO BUILD THIS IMAGE
+# -----------------------
+#
+# Run:
+#      $ docker build -t <extended_image_name> . \
+#        --build-arg BASE_IMAGE=<base image> \
+#        --build-arg PRE_CREATE_ORACLE_SID=<your CDB name> \
+#        --build-arg PRE_CREATE_ORACLE_PDB=<your PDB name> \
+#        --build-arg PRE_CREATE_ORACLE_PWD=<your password>
+#
+
+ARG BASE_IMAGE=12.2.0.1-ee
+FROM ${BASE_IMAGE}
+
+# Extn name
+ARG EXTENSION_NAME=pre-create-db
+
+ARG PRE_CREATE_ORACLE_SID
+RUN if [[ -z "$PRE_CREATE_ORACLE_SID" ]] ; then echo No PRE_CREATE_ORACLE_SID found, please provide it in --build-arg; exit 1 ; fi
+ARG PRE_CREATE_ORACLE_PDB
+RUN if [[ -z "$PRE_CREATE_ORACLE_PDB" ]] ; then echo No PRE_CREATE_ORACLE_PDB found, please provide it in --build-arg; exit 1 ; fi
+ARG PRE_CREATE_ORACLE_PWD
+RUN if [[ -z "$PRE_CREATE_ORACLE_PWD" ]] ; then echo No PRE_CREATE_ORACLE_PWD found, please provide it in --build-arg; exit 1 ; fi
+
+RUN echo "Creating a new SID/CDB: $PRE_CREATE_ORACLE_SID"
+RUN echo "Creating a new PDB: $PRE_CREATE_ORACLE_PDB"
+RUN echo "PASSWORD FOR SYS AND SYSTEM: $PRE_CREATE_ORACLE_PWD"
+
+# Create database
+RUN $ORACLE_BASE/$CREATE_DB_FILE $PRE_CREATE_ORACLE_SID $PRE_CREATE_ORACLE_PDB $PRE_CREATE_ORACLE_PWD

--- a/OracleDatabase/SingleInstance/extensions/pre-create-db/README.md
+++ b/OracleDatabase/SingleInstance/extensions/pre-create-db/README.md
@@ -1,0 +1,36 @@
+#  Pre-Create Database
+
+This extension adds a layer on top of a base Oracle image with a pre-created
+database in a multitenant configuration with one pluggable database and 
+a pre-set password. This can save 10-15 minutes of database creation time in
+some simple workflows, like making first steps,
+conducting experiments, or running tests.
+
+*The database files are created on the image filesystem itself, 
+which means you can not use a separate volume for oradata anymore*
+
+Once you have created the base image, go into the **extension/pre-create-db** folder and build a new extended image as follows:
+
+    [oracle@localhost dockerfiles]$ docker build -t <new image name> . \
+        --build-arg BASE_IMAGE=<base image> \
+        --build-arg PRE_CREATE_ORACLE_SID=<your CDB name> \
+        --build-arg PRE_CREATE_ORACLE_PDB=<your PDB name> \
+        --build-arg PRE_CREATE_ORACLE_PWD=<your password>
+
+Example
+
+    docker build -t oracle/database:ext . \
+        --build-arg BASE_IMAGE=oracle/database:12.2.0.1-ee \
+        --build-arg PRE_CREATE_ORACLE_SID=MYCDB \
+        --build-arg PRE_CREATE_ORACLE_PDB=MYPDB \
+        --build-arg PRE_CREATE_ORACLE_PWD=Welcome1
+
+The resulting image will contain a MYCDB database in a
+multitenant configuration with one pluggable database MYPDB.
+
+The new image can then be started like this:
+
+    docker run --name mydb \
+        -p 1521:1521 -p 5500:5500 \
+        -e ORACLE_SID=MYCDB \
+        oracle/database:ext


### PR DESCRIPTION
This extension adds a layer on top of a base Oracle image with a pre-created
database in a multitenant configuration with one pluggable database and 
a pre-set password. This can save 10-15 minutes of database creation time in
some simple workflows, like making first steps,
conducting experiments, or running tests.