### PR TITLE
Sharding extension for SIDB container image

### DIFF
--- a/OracleDatabase/SingleInstance/extensions/sharding/Dockerfile
+++ b/OracleDatabase/SingleInstance/extensions/sharding/Dockerfile
@@ -1,0 +1,74 @@
+# LICENSE UPL 1.0
+#
+# Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+#
+# ORACLE DOCKERFILES PROJECT
+# --------------------------
+# This is the Dockerfile for Oracle Database with Fast Fail Over support
+#
+# REQUIREMETNS FOR THIS IMAGE
+# ----------------------------------
+# Any release of prebuilt oracle/database base docker image
+#
+# HOW TO BUILD THIS IMAGE
+# -----------------------
+#
+# Run:
+#      $ docker build -t <extended_image_name> . --build-arg BASE_IMAGE=18.3.0-ee
+#
+
+ARG BASE_IMAGE_VERSION=19.3.0
+ARG BASE_IMAGE=oracle/database:${BASE_IMAGE_VERSION}-ee
+ARG BASE_REPO=https://github.com/oracle/db-sharding
+
+# Creating stage for downloading necessary script files
+FROM ${BASE_IMAGE} as downloader
+ARG BASE_REPO
+ENV BASE_REPO=$BASE_REPO
+WORKDIR /tmp
+
+RUN curl -L -o master.tar.gz ${BASE_REPO}/archive/master.tar.gz && \
+    tar -xvf master.tar.gz
+
+# Creating another stage for sharding extension creation
+FROM ${BASE_IMAGE}
+# Extn name
+ARG EXTENSION_NAME=sharding
+ARG BASE_IMAGE_VERSION
+
+# Environment variables required for this build (do NOT change)
+# -------------------------------------------------------------
+ENV CMD_EXEC="cmdExec" \
+   DEMO_APP="demoapp.sql" \
+   MAIN_PY="main.py" \
+   COMMON_PY="oracommon.py" \
+   ENV_PY="oraenv.py" \
+   FACTORY_PY="orafactory.py" \
+   GSM_PY="oragsm.py" \
+   LOGGER_PY="oralogger.py" \
+   MACHINE_PY="oramachine.py" \
+   PCATALOG_PY="orapcatalog.py" \
+   SHARD_PY="orapshard.py" \
+   SCATALOG_PY="orascatalog.py" \
+   SSHARD_PY="orasshard.py" \
+   RUN_SHARD_FILE="runOraShardSetup.sh" \
+   RUN_FILE="runOracle.sh" \
+   SHARD_SETUP="false"
+
+# backup original runOracle
+RUN if test -e "$ORACLE_BASE/$RUN_FILE.orig"; then EXTN='extended'; else EXTN='orig'; fi ; \
+    mv "$ORACLE_BASE/$RUN_FILE" "$ORACLE_BASE/$RUN_FILE.$EXTN"
+
+# Copy updated scripts for sharding support
+COPY  --chown=oracle:dba --from=downloader /tmp/db-sharding-master/docker-based-sharding-deployment/dockerfiles/${BASE_IMAGE_VERSION}/scripts/* $ORACLE_BASE/scripts/sharding/
+RUN mv "$ORACLE_BASE/scripts/sharding/$RUN_FILE" "$ORACLE_BASE/$RUN_FILE.$EXTENSION_NAME"
+
+# Set perms and append a call to main runOracle
+RUN if test -e "$ORACLE_BASE/$RUN_FILE.extended"; then \
+        mv "$ORACLE_BASE/$RUN_FILE.extended" "$ORACLE_BASE/$RUN_FILE" ; \
+    else echo ". $ORACLE_BASE/$RUN_FILE.orig" > "$ORACLE_BASE/$RUN_FILE" ; fi ; \
+    if ! grep "$RUN_FILE.$EXTENSION_NAME" "$ORACLE_BASE/$RUN_FILE"; then \
+       sed  -i "\$a . $ORACLE_BASE/$RUN_FILE.$EXTENSION_NAME" "$ORACLE_BASE/$RUN_FILE"; \
+    fi && \
+    sed -i '/wait \$childPID/d' "$ORACLE_BASE"/runOracle.sh.orig && \
+    chmod ug+x $ORACLE_BASE/$RUN_FILE $ORACLE_BASE/$RUN_FILE.$EXTENSION_NAME $ORACLE_BASE/scripts/sharding/*.sh $ORACLE_BASE/scripts/sharding/*.py && sync

--- a/OracleDatabase/SingleInstance/extensions/sharding/Dockerfile
+++ b/OracleDatabase/SingleInstance/extensions/sharding/Dockerfile
@@ -14,7 +14,7 @@
 # -----------------------
 #
 # Run:
-#      $ docker build -t <extended_image_name> . --build-arg BASE_IMAGE=18.3.0-ee
+#      $ docker build -t <extended_image_name> . --build-arg BASE_IMAGE=oracle/database:19.3.0-ee
 #
 
 ARG BASE_IMAGE_VERSION=19.3.0

--- a/OracleDatabase/SingleInstance/extensions/sharding/Dockerfile
+++ b/OracleDatabase/SingleInstance/extensions/sharding/Dockerfile
@@ -22,12 +22,13 @@ ARG BASE_IMAGE=oracle/database:${BASE_IMAGE_VERSION}-ee
 ARG BASE_REPO=https://github.com/oracle/db-sharding
 
 # Creating stage for downloading necessary script files
-FROM ${BASE_IMAGE} as downloader
+FROM oraclelinux:7-slim as downloader
 ARG BASE_REPO
 ENV BASE_REPO=$BASE_REPO
 WORKDIR /tmp
 
-RUN curl -L -o master.tar.gz ${BASE_REPO}/archive/master.tar.gz && \
+RUN yum -y install gzip tar && \
+    curl -L -o master.tar.gz ${BASE_REPO}/archive/master.tar.gz && \
     tar -xvf master.tar.gz
 
 # Creating another stage for sharding extension creation

--- a/OracleDatabase/SingleInstance/extensions/sharding/README.md
+++ b/OracleDatabase/SingleInstance/extensions/sharding/README.md
@@ -1,7 +1,7 @@
 # Sharding Extension
 Sharding extension is required to build the catalog and shard containers. When
 the SIDB container image is extended with **sharding** extension, it downloads the 
-required scripts from [db-sharding/docker-based-sharding-deployment/dockerfiles/19.3.0/scripts](https://github.com/oracle/db-sharding/tree/master/docker-based-sharding-deployment/dockerfiles/19.3.0/scripts)
-and package them with the SIDB container image to form extended image.
+required scripts from [db-sharding/docker-based-sharding-deployment](https://github.com/oracle/db-sharding/tree/master/docker-based-sharding-deployment)
+repository, and package them with the SIDB container image to form extended image.
 
 More information on catalog and shard containers can be found at `db-sharding/docker-based-sharding-deployment` [README](https://github.com/oracle/db-sharding/blob/master/docker-based-sharding-deployment/README.md).

--- a/OracleDatabase/SingleInstance/extensions/sharding/README.md
+++ b/OracleDatabase/SingleInstance/extensions/sharding/README.md
@@ -1,0 +1,7 @@
+# Sharding Extension
+Sharding extension is required to build the catalog and shard containers. When
+the SIDB container image is extended with **sharding** extension, it downloads the 
+required scripts from [db-sharding/docker-based-sharding-deployment/dockerfiles/19.3.0/scripts](https://github.com/oracle/db-sharding/tree/master/docker-based-sharding-deployment/dockerfiles/19.3.0/scripts)
+and package them with the SIDB container image to form extended image.
+
+More information on catalog and shard containers can be found at `db-sharding/docker-based-sharding-deployment` [README](https://github.com/oracle/db-sharding/blob/master/docker-based-sharding-deployment/README.md).

--- a/OracleDatabase/SingleInstance/extensions/sharding/README.md
+++ b/OracleDatabase/SingleInstance/extensions/sharding/README.md
@@ -1,7 +1,7 @@
 # Sharding Extension
 Sharding extension is required to build the catalog and shard containers. When
-the SIDB container image is extended with **sharding** extension, it downloads the 
+the SingleInstance container image is extended with **sharding** extension, it downloads the 
 required scripts from [db-sharding/docker-based-sharding-deployment](https://github.com/oracle/db-sharding/tree/master/docker-based-sharding-deployment)
-repository, and package them with the SIDB container image to form extended image.
+repository, and package them with the SingleInstance container image to form extended image.
 
 More information on catalog and shard containers can be found at `db-sharding/docker-based-sharding-deployment` [README](https://github.com/oracle/db-sharding/blob/master/docker-based-sharding-deployment/README.md).

--- a/OracleDatabase/SingleInstance/extensions/sharding/README.md
+++ b/OracleDatabase/SingleInstance/extensions/sharding/README.md
@@ -1,7 +1,7 @@
-# Sharding Extension
-Sharding extension is required to build the catalog and shard containers. When
-the SingleInstance container image is extended with **sharding** extension, it downloads the 
+# The Sharding Extension
+The sharding extension is required to build the catalog and shard containers. When
+the SingleInstance container image is extended with the **sharding** extension, it downloads the 
 required scripts from [db-sharding/docker-based-sharding-deployment](https://github.com/oracle/db-sharding/tree/master/docker-based-sharding-deployment)
-repository, and package them with the SingleInstance container image to form extended image.
+repository, and packages them with the SingleInstance container image to form an extended image.
 
 More information on catalog and shard containers can be found at `db-sharding/docker-based-sharding-deployment` [README](https://github.com/oracle/db-sharding/blob/master/docker-based-sharding-deployment/README.md).


### PR DESCRIPTION
Used **multi-stage builds**: 

- In first stage downloaded the entire repository from [oracle/db-sharding](https://github.com/oracle/db-sharding) using `Curl` utility. 
- In the second stage copy the necessary scripts from the previous stage, to the `$ORACLE_HOME/scripts/sharding` directory of the image to build sharding extension.

Signed-off-by: abhisbyk <abhishek.by.kumar@oracle.com>