### PR TITLE
feat(dev-images): create a base image for compatibility purposes

### DIFF
--- a/.github/workflows/build-and-push-dev-images.yml
+++ b/.github/workflows/build-and-push-dev-images.yml
@@ -27,13 +27,13 @@ on:
         required: false
       lang:
         description: List of languages to build
-        default: 'golang, nodejs, php, python, ruby'
+        default: 'compat, golang, nodejs, php, python, ruby'
         required: false
 
 # Default values for the builds triggered by the push event
 env:
   ol: 'oraclelinux7, oraclelinux8'
-  lang: 'golang, nodejs, php, python, ruby'
+  lang: 'compat, golang, nodejs, php, python, ruby'
 
 jobs:
   prepare:

--- a/OracleLinuxDevelopers/oraclelinux8/compat/8-slim/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/compat/8-slim/Dockerfile
@@ -1,0 +1,8 @@
+# Copyright (c) 2020 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+FROM ghcr.io/oracle/oraclelinux:8
+
+# This adds microdnf to the normal image so that any automation that relies on
+# it being installed continues to work
+RUN dnf install -y microdnf && \
+    rm -rf /var/cache/dnf


### PR DESCRIPTION
This image adds microdnf to the oraclelinux:8 image so that any
downstream automation continues to work after the replacement of
the current oraclelinux:8-slim base image.

This the first step and is required to update #2020 to reference 
the right base image.

Signed-off-by: Avi Miller <avi.miller@oracle.com>