### PR TITLE
Adding support for oracle wallet in the pod environment for 19c

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
@@ -62,7 +62,9 @@ ENV ORACLE_BASE=/opt/oracle \
     CLONE_DB=false \
     # Env var below should be in <HOST>:<PORT>/<SERVICE_NAME> format
     PRIMARY_DB_CONN_STR="" \
-    CHECKPOINT_FILE_EXTN=".created"
+    CHECKPOINT_FILE_EXTN=".created" \
+    # Directory for keeping Oracle Wallet
+    WALLET_DIR=""
 
 # Use second ENV so that variable get substituted
 ENV PATH=$ORACLE_HOME/bin:$ORACLE_HOME/OPatch/:/usr/sbin:$PATH \


### PR DESCRIPTION
Close #2073 

Added support for Oracle Wallet for SingleInstance 19c. If the wallet is present (represented by `WALLET_DIR` env var), the wallet is used for database creation, not `ORACLE_PWD`.
Thus, in the kube environment, we can create oracle wallet using some init container and there will not be any need of passing the password in the form of `ORACLE_PWD` env var.
This way, database password will not persist as an env variable in the pod environment.

Signed-off-by: abhisbyk <abhishek.by.kumar@oracle.com>