### PR TITLE
feat(developper):  add golang 1.16 container

### DIFF
--- a/OracleLinuxDevelopers/oraclelinux7/golang/1.13/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/golang/1.13/Dockerfile
@@ -3,7 +3,7 @@
 FROM oraclelinux:7-slim
 
 RUN yum -y install oracle-golang-release-el7 && \
-    yum-config-manager --disable ol7_developer_golang116 && \
+    yum-config-manager --disable ol7_developer_golang\* && \
     yum-config-manager --enable ol7_developer_golang113 && \
     yum -y install golang && \
     rm -rf /var/cache/yum/*

--- a/OracleLinuxDevelopers/oraclelinux7/golang/1.15/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/golang/1.15/Dockerfile
@@ -3,7 +3,7 @@
 FROM oraclelinux:7-slim
 
 RUN yum -y install oracle-golang-release-el7 && \
-    yum-config-manager --disable ol7_developer_golang116 && \
+    yum-config-manager --disable ol7_developer_golang\* && \
     yum-config-manager --enable ol7_developer_golang115 && \
     yum -y install golang && \
     rm -rf /var/cache/yum/*

--- a/OracleLinuxDevelopers/oraclelinux7/golang/1.16/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/golang/1.16/Dockerfile
@@ -4,7 +4,7 @@ FROM oraclelinux:7-slim
 
 RUN yum -y install oracle-golang-release-el7 && \
     yum-config-manager --disable ol7_developer_golang\* && \
-    yum-config-manager --enable ol7_developer_golang114 && \
+    yum-config-manager --enable ol7_developer_golang116 && \
     yum -y install golang && \
     rm -rf /var/cache/yum/*
 


### PR DESCRIPTION
Add a a golang 1.16 specific container. For now it will generate the
same container as the one in the `golang` directory, but it "locks" the
version on 1.16.
It will also be built by the `build-and-push-dev-images` action.
Also update containers from previous golang version to disable any
pre-set golang channel. This will avoid issue if/when 1.16 is no more
the default version.

Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>