### PR TITLE
fix: remove the module files as they are created by dnf

### DIFF
--- a/OracleLinuxDevelopers/oraclelinux8/golang/latest/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/golang/latest/Dockerfile
@@ -5,9 +5,6 @@
 # so that any automation that relied on microdnf continues to work
 FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
-# Enable the right module stream for microdnf
-COPY go-toolset.module /etc/dnf/modules.d/go-toolset.module
-
 RUN dnf -y module enable go-toolset:ol8 && \
     dnf -y install go-toolset && \
     rm -rf /var/cache/dnf

--- a/OracleLinuxDevelopers/oraclelinux8/golang/latest/go-toolset.module
+++ b/OracleLinuxDevelopers/oraclelinux8/golang/latest/go-toolset.module
@@ -1,5 +1,0 @@
-[go-toolset]
-name=go-toolset
-stream=ol8
-profiles=common
-state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/nodejs/10/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/nodejs/10/Dockerfile
@@ -5,9 +5,6 @@
 # so that any automation that relied on microdnf continues to work
 FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
-# Enable the right module stream for microdnf
-COPY nodejs.module /etc/dnf/modules.d/nodejs.module
-
 RUN dnf -y module enable nodejs:10 && \
     dnf -y install nodejs npm && \
     rm -rf /var/cache/dnf

--- a/OracleLinuxDevelopers/oraclelinux8/nodejs/10/nodejs.module
+++ b/OracleLinuxDevelopers/oraclelinux8/nodejs/10/nodejs.module
@@ -1,5 +1,0 @@
-[nodejs]
-name=nodejs
-stream=10
-profiles=common
-state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/nodejs/12/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/nodejs/12/Dockerfile
@@ -5,9 +5,6 @@
 # so that any automation that relied on microdnf continues to work
 FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
-# Enable the right module stream for microdnf
-COPY nodejs.module /etc/dnf/modules.d/nodejs.module
-
 RUN dnf -y module enable nodejs:12 && \
     dnf -y install nodejs npm && \
     rm -rf /var/cache/dnf

--- a/OracleLinuxDevelopers/oraclelinux8/nodejs/12/nodejs.module
+++ b/OracleLinuxDevelopers/oraclelinux8/nodejs/12/nodejs.module
@@ -1,5 +1,0 @@
-[nodejs]
-name=nodejs
-stream=12
-profiles=common
-state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/nodejs/14-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/nodejs/14-oracledb/Dockerfile
@@ -5,9 +5,6 @@
 # so that any automation that relied on microdnf continues to work
 FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
-# Enable the right module stream for microdnf
-COPY nodejs.module /etc/dnf/modules.d/nodejs.module
-
 RUN dnf -y module enable nodejs:14 && \
     dnf -y install oracle-instantclient-release-el8 oraclelinux-developer-release-el8 && \
     dnf -y install oracle-instantclient-basic node-oracledb-node14 nodejs npm && \

--- a/OracleLinuxDevelopers/oraclelinux8/nodejs/14-oracledb/nodejs.module
+++ b/OracleLinuxDevelopers/oraclelinux8/nodejs/14-oracledb/nodejs.module
@@ -1,5 +1,0 @@
-[nodejs]
-name=nodejs
-stream=14
-profiles=common
-state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/nodejs/14/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/nodejs/14/Dockerfile
@@ -5,9 +5,6 @@
 # so that any automation that relied on microdnf continues to work
 FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
-# Enable the right module stream for microdnf
-COPY nodejs.module /etc/dnf/modules.d/nodejs.module
-
 RUN dnf -y module enable nodejs:14 && \
     dnf -y install nodejs npm && \
     rm -rf /var/cache/dnf

--- a/OracleLinuxDevelopers/oraclelinux8/nodejs/14/nodejs.module
+++ b/OracleLinuxDevelopers/oraclelinux8/nodejs/14/nodejs.module
@@ -1,5 +1,0 @@
-[nodejs]
-name=nodejs
-stream=14
-profiles=common
-state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.2-apache/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.2-apache/Dockerfile
@@ -5,9 +5,6 @@
 # so that any automation that relied on microdnf continues to work
 FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
-# Enable the right module streams for microdnf
-COPY *.module /etc/dnf/modules.d/
-
 RUN dnf -y module enable php:7.2 httpd:2.4 && \
     dnf -y install httpd httpd-filesystem httpd-tools \
            mod_http2 mod_ssl openssl \

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.2-apache/httpd.module
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.2-apache/httpd.module
@@ -1,5 +1,0 @@
-[httpd]
-name=httpd
-stream=2.4
-profiles=common
-state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.2-apache/php.module
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.2-apache/php.module
@@ -1,5 +1,0 @@
-[php]
-name=php
-stream=7.2
-profiles=common
-state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.2-cli/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.2-cli/Dockerfile
@@ -5,9 +5,6 @@
 # so that any automation that relied on microdnf continues to work
 FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
-# Enable the right module stream for microdnf
-COPY php.module /etc/dnf/modules.d/php.module
-
 RUN dnf -y module enable php:7.2 && \
     dnf -y install php-cli \
                    php-common \

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.2-cli/php.module
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.2-cli/php.module
@@ -1,5 +1,0 @@
-[php]
-name=php
-stream=7.2
-profiles=common
-state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.2-fpm/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.2-fpm/Dockerfile
@@ -5,9 +5,6 @@
 # so that any automation that relied on microdnf continues to work
 FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
-# Enable the right module stream for microdnf
-COPY php.module /etc/dnf/modules.d/php.module
-
 RUN dnf -y module enable php:7.2 && \
     dnf -y install php-cli \
                    php-common \

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.2-fpm/php.module
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.2-fpm/php.module
@@ -1,5 +1,0 @@
-[php]
-name=php
-stream=7.2
-profiles=common
-state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.3-apache/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.3-apache/Dockerfile
@@ -2,9 +2,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
-# Enable the right module streams for microdnf
-COPY *.module /etc/dnf/modules.d/
-
 RUN dnf -y module enable php:7.3 httpd:2.4 && \
     dnf -y install httpd httpd-filesystem httpd-tools \
                    mod_http2 mod_ssl openssl \

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.3-apache/httpd.module
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.3-apache/httpd.module
@@ -1,5 +1,0 @@
-[httpd]
-name=httpd
-stream=2.4
-profiles=common
-state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.3-apache/php.module
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.3-apache/php.module
@@ -1,5 +1,0 @@
-[php]
-name=php
-stream=7.3
-profiles=common
-state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.3-cli/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.3-cli/Dockerfile
@@ -5,9 +5,6 @@
 # so that any automation that relied on microdnf continues to work
 FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
-# Enable the right module stream for microdnf
-COPY php.module /etc/dnf/modules.d/php.module
-
 RUN dnf -y module enable php:7.3 && \
     dnf -y install php-cli \
                    php-common \

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.3-cli/php.module
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.3-cli/php.module
@@ -1,5 +1,0 @@
-[php]
-name=php
-stream=7.3
-profiles=common
-state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.3-fpm/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.3-fpm/Dockerfile
@@ -5,9 +5,6 @@
 # so that any automation that relied on microdnf continues to work
 FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
-# Enable the right module stream for microdnf
-COPY php.module /etc/dnf/modules.d/php.module
-
 RUN dnf -y module enable php:7.3 && \
     dnf -y install php-cli \
                    php-common \

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.3-fpm/php.module
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.3-fpm/php.module
@@ -1,5 +1,0 @@
-[php]
-name=php
-stream=7.3
-profiles=common
-state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.4-apache/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.4-apache/Dockerfile
@@ -5,9 +5,6 @@
 # so that any automation that relied on microdnf continues to work
 FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
-# Enable the right module streams for microdnf
-COPY *.module /etc/dnf/modules.d/
-
 RUN dnf -y module enable php:7.4 httpd:2.4 && \
     dnf -y install httpd httpd-filesystem httpd-tools \
            mod_http2 mod_ssl openssl \

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.4-apache/httpd.module
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.4-apache/httpd.module
@@ -1,5 +1,0 @@
-[httpd]
-name=httpd
-stream=2.4
-profiles=common
-state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.4-apache/php.module
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.4-apache/php.module
@@ -1,5 +1,0 @@
-[php]
-name=php
-stream=7.4
-profiles=common
-state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.4-cli/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.4-cli/Dockerfile
@@ -5,9 +5,6 @@
 # so that any automation that relied on microdnf continues to work
 FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
-# Enable the right module stream for microdnf
-COPY php.module /etc/dnf/modules.d/php.module
-
 RUN dnf -y module enable php:7.4 && \
     dnf -y install php-cli \
                    php-common \

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.4-cli/php.module
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.4-cli/php.module
@@ -1,5 +1,0 @@
-[php]
-name=php
-stream=7.4
-profiles=common
-state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.4-fpm/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.4-fpm/Dockerfile
@@ -5,8 +5,6 @@
 # so that any automation that relied on microdnf continues to work
 FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
-COPY php.module /etc/dnf/modules.d/php.module
-
 RUN dnf -y module enable php:7.4 && \
     dnf -y install php-cli \
                    php-common \

--- a/OracleLinuxDevelopers/oraclelinux8/php/7.4-fpm/php.module
+++ b/OracleLinuxDevelopers/oraclelinux8/php/7.4-fpm/php.module
@@ -1,5 +1,0 @@
-[php]
-name=php
-stream=7.4
-profiles=common
-state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/python/3.6-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/python/3.6-oracledb/Dockerfile
@@ -5,9 +5,6 @@
 # so that any automation that relied on microdnf continues to work
 FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
-# Enable the right module stream for microdnf
-COPY python36.module /etc/dnf/modules.d/python36.module
-
 RUN dnf -y install oracle-instantclient-release-el8 oraclelinux-developer-release-el8 && \
     dnf -y module enable python36 && \
     dnf -y install oracle-instantclient-basic \

--- a/OracleLinuxDevelopers/oraclelinux8/python/3.6-oracledb/python36.module
+++ b/OracleLinuxDevelopers/oraclelinux8/python/3.6-oracledb/python36.module
@@ -1,5 +1,0 @@
-[python36]
-name=python36
-stream=3.6
-profiles=common
-state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/python/3.6/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/python/3.6/Dockerfile
@@ -5,9 +5,6 @@
 # so that any automation that relied on microdnf continues to work
 FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
-# Enable the right module stream for microdnf
-COPY python36.module /etc/dnf/modules.d/python36.module
-
 RUN dnf -y module enable python36 && \
     dnf -y install python36 python3-pip python3-setuptools && \
     rm -rf /var/cache/dnf

--- a/OracleLinuxDevelopers/oraclelinux8/python/3.6/python36.module
+++ b/OracleLinuxDevelopers/oraclelinux8/python/3.6/python36.module
@@ -1,5 +1,0 @@
-[python36]
-name=python36
-stream=3.6
-profiles=common
-state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/python/3.8/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/python/3.8/Dockerfile
@@ -5,9 +5,6 @@
 # so that any automation that relied on microdnf continues to work
 FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
-# Enable the right module stream for microdnf
-COPY python38.module /etc/dnf/modules.d/python38.module
-
 RUN dnf -y module enable python38 && \
     dnf -y install python36 python3-pip python3-setuptools && \
     rm -rf /var/cache/dnf

--- a/OracleLinuxDevelopers/oraclelinux8/python/3.8/python38.module
+++ b/OracleLinuxDevelopers/oraclelinux8/python/3.8/python38.module
@@ -1,5 +1,0 @@
-[python38]
-name=python38
-stream=3.8
-profiles=common
-state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/python/3.9/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/python/3.9/Dockerfile
@@ -5,9 +5,6 @@
 # so that any automation that relied on microdnf continues to work
 FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
-# Enable the right module stream for microdnf
-COPY python39.module /etc/dnf/modules.d/python39.module
-
 RUN dnf -y module enable python39 && \
     dnf -y install python36 python3-pip python3-setuptools && \
     rm -rf /var/cache/dnf

--- a/OracleLinuxDevelopers/oraclelinux8/python/3.9/python39.module
+++ b/OracleLinuxDevelopers/oraclelinux8/python/3.9/python39.module
@@ -1,5 +1,0 @@
-[python39]
-name=python39
-stream=3.9
-profiles=common
-state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/ruby/2.6/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/ruby/2.6/Dockerfile
@@ -5,9 +5,6 @@
 # so that any automation that relied on microdnf continues to work
 FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
-# Enable the right module stream for microdnf
-COPY ruby.module  /etc/dnf/modules.d/ruby.module
-
 RUN dnf -y module enable ruby:2.6 && \
     dnf -y install ruby ruby-libs ruby-devel ruby-irb \
                    rubygems rubygem-rake rubygem-bundler \

--- a/OracleLinuxDevelopers/oraclelinux8/ruby/2.6/ruby.module
+++ b/OracleLinuxDevelopers/oraclelinux8/ruby/2.6/ruby.module
@@ -1,5 +1,0 @@
-[ruby]
-name=ruby
-stream=2.6
-profiles=common
-state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/ruby/2.7-nodejs/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/ruby/2.7-nodejs/Dockerfile
@@ -5,10 +5,6 @@
 # so that any automation that relied on microdnf continues to work
 FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
-# Enable the right module streams for microdnf
-COPY ruby.module  /etc/dnf/modules.d/ruby.module
-COPY nodejs.module /etc/dnf/modules.d/nodejs.module
-
 RUN dnf -y module enable ruby:2.7 nodejs:14 && \
     dnf -y install ruby ruby-libs ruby-devel ruby-irb \
                    nodejs npm \

--- a/OracleLinuxDevelopers/oraclelinux8/ruby/2.7-nodejs/nodejs.module
+++ b/OracleLinuxDevelopers/oraclelinux8/ruby/2.7-nodejs/nodejs.module
@@ -1,5 +1,0 @@
-[nodejs]
-name=nodejs
-stream=14
-profiles=common
-state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/ruby/2.7-nodejs/ruby.module
+++ b/OracleLinuxDevelopers/oraclelinux8/ruby/2.7-nodejs/ruby.module
@@ -1,5 +1,0 @@
-[ruby]
-name=ruby
-stream=2.7
-profiles=common
-state=enabled

--- a/OracleLinuxDevelopers/oraclelinux8/ruby/2.7/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/ruby/2.7/Dockerfile
@@ -5,9 +5,6 @@
 # so that any automation that relied on microdnf continues to work
 FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
-# Enable the right module stream for microdnf
-COPY ruby.module  /etc/dnf/modules.d/ruby.module
-
 RUN dnf -y module enable ruby:2.7 && \
     dnf -y install ruby ruby-libs ruby-devel ruby-irb \
                    rubygems rubygem-rake rubygem-bundler \

--- a/OracleLinuxDevelopers/oraclelinux8/ruby/2.7/ruby.module
+++ b/OracleLinuxDevelopers/oraclelinux8/ruby/2.7/ruby.module
@@ -1,5 +1,0 @@
-[ruby]
-name=ruby
-stream=2.7
-profiles=common
-state=enabled


### PR DESCRIPTION
@AmedeeBulle (gently) pointed out that we no longer need the `.module` files as `dnf module enable` creates them.

Signed-off-by: Avi Miller <avi.miller@oracle.com>