### PR TITLE
Enabling Database API as a ORDS Default Feature

### DIFF
--- a/OracleRestDataServices/dockerfiles/ords_params.properties.tmpl
+++ b/OracleRestDataServices/dockerfiles/ords_params.properties.tmpl
@@ -1,4 +1,5 @@
 rest.services.ords.add=true
+database.api.enabled=true
 db.hostname=###ORACLE_HOST###
 db.port=###ORACLE_PORT###
 db.servicename=###ORACLE_SERVICE###


### PR DESCRIPTION
Enabling Database API as a ORDS Default Feature .
As we don't get a console during docker runtime to choose between available features:
`Enter a number to select a feature to enable: 
   [1] SQL Developer Web  (Enables all features)
   [2] REST Enabled SQL
   [3] Database API 
   [4] REST Enabled SQL and Database API 
   [5] None`
  Running the docker image built directly by cloning the present OracleRestDataService Repo would fail in the above step , and ORDS would fail to install successfully.
  So Enabling one feature by default would install the ORDS Successfully and one can anytime enable other features manually using ords.war