### PR TITLE
Using DBCA option -autoGeneratePasswords while creating the database

### DIFF
--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -138,14 +138,13 @@ In case these parameters are passed to the `docker run` command while reusing ex
 
 #### Changing the admin accounts passwords
 
-On the first startup of the container a random password will be generated for the database if not provided. You can find this password in the output line:
-
-    ORACLE PASSWORD FOR SYS, SYSTEM AND PDBADMIN:
+On the first startup of the container, a random password will be generated for the database if not provided. The user has to mandatorily change the password after the database is created and the corresponding container is healthy.
 
 The password for those accounts can be changed via the `docker exec` command. **Note**, the container has to be running:
 
     docker exec <container name> ./setPassword.sh <your password>
 
+This new password will be used afterwards.
 #### Enabling archive log mode while creating the database
 
 Archive mode can be enabled during the first time when database is created by setting ENABLE_ARCHIVELOG to `true` and passing it to `docker run` command. Archive logs are stored at the directory location: `/opt/oracle/oradata/$ORACLE_SID/archive_logs` inside the container.

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
@@ -77,11 +77,18 @@ if [[ -n "${WALLET_DIR}" ]] && [[ -f $WALLET_DIR/ewallet.p12 ]]; then
   export DBCA_CRED_OPTIONS="-useWalletForDBCredentials true  -dbCredentialsWalletLocation ${WALLET_DIR}"
 else
   if [[ "${CLONE_DB}" == "true" ]] || [[ "${STANDBY_DB}" == "true" ]]; then
+    # Validation: Checking if ORACLE_PWD is provided or not
+    if [[ -z "$ORACLE_PWD" ]]; then
+      echo "ERROR: Please provide sys password of the primary database as ORACLE_PWD env variable. Exiting..."
+      exit 1
+    fi
+
     # Creating temporary response file containing sysPassword for clone/standby cases
     echo "sysPassword=${ORACLE_PWD}" > $ORACLE_BASE/dbca.rsp
     chmod 400 $ORACLE_BASE/dbca.rsp
     export DBCA_CRED_OPTIONS=" -responseFile $ORACLE_BASE/dbca.rsp"
   else
+    # Use DBCA auto password generation for generating a random strong password for admin accounts
     export DBCA_CRED_OPTIONS="-autoGeneratePasswords"
   fi
 

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
@@ -88,8 +88,10 @@ else
     chmod 400 $ORACLE_BASE/dbca.rsp
     export DBCA_CRED_OPTIONS=" -responseFile $ORACLE_BASE/dbca.rsp"
   else
-    # Use DBCA auto password generation for generating a random strong password for admin accounts
-    export DBCA_CRED_OPTIONS="-autoGeneratePasswords"
+    # If ORACLE_PWD is not provided, use DBCA auto password generation for generating a random, strong password
+    if [[ -z "${ORACLE_PWD}" ]]; then
+      export DBCA_CRED_OPTIONS="-autoGeneratePasswords"
+    fi
   fi
 
 fi
@@ -144,6 +146,12 @@ chmod 400 $ORACLE_BASE/dbca.rsp
 sed -i -e "s|###ORACLE_SID###|$ORACLE_SID|g" $ORACLE_BASE/dbca.rsp
 sed -i -e "s|###ORACLE_PDB###|$ORACLE_PDB|g" $ORACLE_BASE/dbca.rsp
 sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" $ORACLE_BASE/dbca.rsp
+if [[ -n "${WALLET_DIR}" ]] && [[ -f $WALLET_DIR/ewallet.p12 ]] || [[ -z "$ORACLE_PWD" ]]; then
+   # Deleting password options from dbca response file as wallet will be used for credentials or ORACLE_PWD is not provided (i.e. password auto-generation intended)
+   sed -i -e "/###ORACLE_PWD###/d" $ORACLE_BASE/dbca.rsp
+else
+   sed -i -e "s|###ORACLE_PWD###|$ORACLE_PWD|g" $ORACLE_BASE/dbca.rsp
+fi
 
 # If both INIT_SGA_SIZE & INIT_PGA_SIZE aren't provided by user
 if [[ "${INIT_SGA_SIZE}" == "" && "${INIT_PGA_SIZE}" == "" ]]; then

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createObserver.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createObserver.sh
@@ -31,8 +31,10 @@ fi
 # Creating the directory for Observer configuration and log file
 mkdir -p ${DG_OBSERVER_DIR}
 
-# Starting observer in background
-nohup echo "${ORACLE_PWD}" | dgmgrl -echo sys@${PRIMARY_DB_CONN_STR} "START OBSERVER ${DG_OBSERVER_NAME} FILE IS ${DG_OBSERVER_DIR}/fsfo.dat LOGFILE IS ${DG_OBSERVER_DIR}/observer.log" > ${DG_OBSERVER_DIR}/nohup.out &
+# Starting observer in background, passing password using here-doc
+nohup dgmgrl -echo sys@${PRIMARY_DB_CONN_STR} "START OBSERVER ${DG_OBSERVER_NAME} FILE IS ${DG_OBSERVER_DIR}/fsfo.dat LOGFILE IS ${DG_OBSERVER_DIR}/observer.log" > ${DG_OBSERVER_DIR}/nohup.out << EOF &
+${ORACLE_PWD}
+EOF
 # Sleep for dgmgrl to start observer in background otherwise container will exit
 sleep 4
 

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createObserver.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createObserver.sh
@@ -32,6 +32,7 @@ fi
 mkdir -p ${DG_OBSERVER_DIR}
 
 # Starting observer in background
-nohup dgmgrl -echo sys/${ORACLE_PWD}@${PRIMARY_DB_CONN_STR} "START OBSERVER ${DG_OBSERVER_NAME} FILE IS ${DG_OBSERVER_DIR}/fsfo.dat LOGFILE IS ${DG_OBSERVER_DIR}/observer.log" > ${DG_OBSERVER_DIR}/nohup.out &
+nohup echo "${ORACLE_PWD}" | dgmgrl -echo sys@${PRIMARY_DB_CONN_STR} "START OBSERVER ${DG_OBSERVER_NAME} FILE IS ${DG_OBSERVER_DIR}/fsfo.dat LOGFILE IS ${DG_OBSERVER_DIR}/observer.log" > ${DG_OBSERVER_DIR}/nohup.out &
 # Sleep for dgmgrl to start observer in background otherwise container will exit
 sleep 4
+

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/dbca.rsp.tmpl
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/dbca.rsp.tmpl
@@ -72,16 +72,6 @@ numberOfPDBs=1
 pdbName=###ORACLE_PDB###
 
 #-----------------------------------------------------------------------------
-# Name          : pdbAdminPassword
-# Datatype      : String
-# Description   : PDB Administrator user password
-# Valid values  : Check Oracle12c Administrator's Guide
-# Default value : None
-# Mandatory     : No
-#-----------------------------------------------------------------------------
-pdbAdminPassword=###ORACLE_PWD###
-
-#-----------------------------------------------------------------------------
 # Name          : templateName
 # Datatype      : String
 # Description   : Name of the template
@@ -90,26 +80,6 @@ pdbAdminPassword=###ORACLE_PWD###
 # Mandatory     : Yes
 #-----------------------------------------------------------------------------
 templateName=General_Purpose.dbc
-
-#-----------------------------------------------------------------------------
-# Name          : sysPassword
-# Datatype      : String
-# Description   : Password for SYS user
-# Valid values  : Check Oracle12c Administrator's Guide
-# Default value : None
-# Mandatory     : Yes
-#-----------------------------------------------------------------------------
-sysPassword=###ORACLE_PWD###
-
-#-----------------------------------------------------------------------------
-# Name          : systemPassword
-# Datatype      : String
-# Description   : Password for SYSTEM user
-# Valid values  : Check Oracle12c Administrator's Guide
-# Default value : None
-# Mandatory     : Yes
-#-----------------------------------------------------------------------------
-systemPassword=###ORACLE_PWD###
 
 #-----------------------------------------------------------------------------
 # Name          : emConfiguration
@@ -131,17 +101,6 @@ emConfiguration=DBEXPRESS
 #                 or auto generates a free port between 5500 and 5599
 #-----------------------------------------------------------------------------
 emExpressPort=5500
-
-#-----------------------------------------------------------------------------
-# Name          : dbsnmpPassword
-# Datatype      : String
-# Description   : Password for DBSNMP user
-# Valid values  : Check Oracle12c Administrator's Guide
-# Default value : None
-# Mandatory     : Yes, if emConfiguration is specified or
-#                 the value of runCVUChecks is TRUE
-#-----------------------------------------------------------------------------
-dbsnmpPassword=###ORACLE_PWD###
 
 #-----------------------------------------------------------------------------
 # Name          : characterSet

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/dbca.rsp.tmpl
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/dbca.rsp.tmpl
@@ -72,6 +72,16 @@ numberOfPDBs=1
 pdbName=###ORACLE_PDB###
 
 #-----------------------------------------------------------------------------
+ # Name          : pdbAdminPassword
+ # Datatype      : String
+ # Description   : PDB Administrator user password
+ # Valid values  : Check Oracle12c Administrator's Guide
+ # Default value : None
+ # Mandatory     : No
+ #-----------------------------------------------------------------------------
+ pdbAdminPassword=###ORACLE_PWD###
+
+#-----------------------------------------------------------------------------
 # Name          : templateName
 # Datatype      : String
 # Description   : Name of the template
@@ -80,6 +90,26 @@ pdbName=###ORACLE_PDB###
 # Mandatory     : Yes
 #-----------------------------------------------------------------------------
 templateName=General_Purpose.dbc
+
+#-----------------------------------------------------------------------------
+ # Name          : sysPassword
+ # Datatype      : String
+ # Description   : Password for SYS user
+ # Valid values  : Check Oracle12c Administrator's Guide
+ # Default value : None
+ # Mandatory     : Yes
+ #-----------------------------------------------------------------------------
+ sysPassword=###ORACLE_PWD###
+
+ #-----------------------------------------------------------------------------
+ # Name          : systemPassword
+ # Datatype      : String
+ # Description   : Password for SYSTEM user
+ # Valid values  : Check Oracle12c Administrator's Guide
+ # Default value : None
+ # Mandatory     : Yes
+ #-----------------------------------------------------------------------------
+ systemPassword=###ORACLE_PWD###
 
 #-----------------------------------------------------------------------------
 # Name          : emConfiguration
@@ -101,6 +131,17 @@ emConfiguration=DBEXPRESS
 #                 or auto generates a free port between 5500 and 5599
 #-----------------------------------------------------------------------------
 emExpressPort=5500
+
+#-----------------------------------------------------------------------------
+ # Name          : dbsnmpPassword
+ # Datatype      : String
+ # Description   : Password for DBSNMP user
+ # Valid values  : Check Oracle12c Administrator's Guide
+ # Default value : None
+ # Mandatory     : Yes, if emConfiguration is specified or
+ #                 the value of runCVUChecks is TRUE
+ #-----------------------------------------------------------------------------
+ dbsnmpPassword=###ORACLE_PWD###
 
 #-----------------------------------------------------------------------------
 # Name          : characterSet

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/dbca.rsp.tmpl
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/dbca.rsp.tmpl
@@ -72,14 +72,14 @@ numberOfPDBs=1
 pdbName=###ORACLE_PDB###
 
 #-----------------------------------------------------------------------------
- # Name          : pdbAdminPassword
- # Datatype      : String
- # Description   : PDB Administrator user password
- # Valid values  : Check Oracle12c Administrator's Guide
- # Default value : None
- # Mandatory     : No
- #-----------------------------------------------------------------------------
- pdbAdminPassword=###ORACLE_PWD###
+# Name          : pdbAdminPassword
+# Datatype      : String
+# Description   : PDB Administrator user password
+# Valid values  : Check Oracle12c Administrator's Guide
+# Default value : None
+# Mandatory     : No
+#-----------------------------------------------------------------------------
+pdbAdminPassword=###ORACLE_PWD###
 
 #-----------------------------------------------------------------------------
 # Name          : templateName
@@ -92,24 +92,24 @@ pdbName=###ORACLE_PDB###
 templateName=General_Purpose.dbc
 
 #-----------------------------------------------------------------------------
- # Name          : sysPassword
- # Datatype      : String
- # Description   : Password for SYS user
- # Valid values  : Check Oracle12c Administrator's Guide
- # Default value : None
- # Mandatory     : Yes
- #-----------------------------------------------------------------------------
- sysPassword=###ORACLE_PWD###
+# Name          : sysPassword
+# Datatype      : String
+# Description   : Password for SYS user
+# Valid values  : Check Oracle12c Administrator's Guide
+# Default value : None
+# Mandatory     : Yes
+#-----------------------------------------------------------------------------
+sysPassword=###ORACLE_PWD###
 
- #-----------------------------------------------------------------------------
- # Name          : systemPassword
- # Datatype      : String
- # Description   : Password for SYSTEM user
- # Valid values  : Check Oracle12c Administrator's Guide
- # Default value : None
- # Mandatory     : Yes
- #-----------------------------------------------------------------------------
- systemPassword=###ORACLE_PWD###
+#-----------------------------------------------------------------------------
+# Name          : systemPassword
+# Datatype      : String
+# Description   : Password for SYSTEM user
+# Valid values  : Check Oracle12c Administrator's Guide
+# Default value : None
+# Mandatory     : Yes
+#-----------------------------------------------------------------------------
+systemPassword=###ORACLE_PWD###
 
 #-----------------------------------------------------------------------------
 # Name          : emConfiguration
@@ -133,15 +133,15 @@ emConfiguration=DBEXPRESS
 emExpressPort=5500
 
 #-----------------------------------------------------------------------------
- # Name          : dbsnmpPassword
- # Datatype      : String
- # Description   : Password for DBSNMP user
- # Valid values  : Check Oracle12c Administrator's Guide
- # Default value : None
- # Mandatory     : Yes, if emConfiguration is specified or
- #                 the value of runCVUChecks is TRUE
- #-----------------------------------------------------------------------------
- dbsnmpPassword=###ORACLE_PWD###
+# Name          : dbsnmpPassword
+# Datatype      : String
+# Description   : Password for DBSNMP user
+# Valid values  : Check Oracle12c Administrator's Guide
+# Default value : None
+# Mandatory     : Yes, if emConfiguration is specified or
+#                 the value of runCVUChecks is TRUE
+#-----------------------------------------------------------------------------
+dbsnmpPassword=###ORACLE_PWD###
 
 #-----------------------------------------------------------------------------
 # Name          : characterSet


### PR DESCRIPTION
For 21c, DBCA option `-autoGeneratePasswords` used for generating passwords automatically while creating the database. The user has to change this password **mandatorily** using `setpassword.sh` script after the database is created and the corresponding container is healthy. This new password will be used afterwards by the user to connect with the database.