### PR TITLE
Static check issues resolution for 21c scripts

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/checkDBStatus.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/checkDBStatus.sh
@@ -59,8 +59,11 @@ EOF
 
 # Function to check that observer is running or not
 checkObserver() {
-   dg_observer_status="$(dgmgrl sys/"${ORACLE_PWD:?"ORACLE_PWD is not set. Exiting..."}"@"$PRIMARY_DB_CONN_STR" "show observer")"
-   if ! echo "$dg_observer_status" | grep -q 'Observer ".*"' -ne 0 ; then
+   dg_observer_status=$(dgmgrl sys@"$PRIMARY_DB_CONN_STR" "show observer" << EOF
+${ORACLE_PWD}
+EOF
+)
+   if ! echo "$dg_observer_status" | grep -q 'Observer ".*"' ; then
       exit 4
    fi 
 

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/checkDBStatus.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/checkDBStatus.sh
@@ -17,13 +17,13 @@
 # Function to check database role: either Primary or Secondary
 checkDatabaseRole() {
    # Obtain DB_ROLE using SQLPlus
-   DB_ROLE=`sqlplus -s / << EOF
+   DB_ROLE=$(sqlplus -s / << EOF
 set heading off;
 set pagesize 0;
-SELECT database_role FROM v\\$database ;
+SELECT database_role FROM v\$database ;
 exit;
 EOF
-`
+)
    # Store return code from SQL*Plus
    ret=$?
 
@@ -38,17 +38,17 @@ EOF
 # Or in case of Secondary Database PDBs should be opened only in "READ ONLY" mode 
 checkPDBOpen() {
    # Obtain OPEN_MODE for PDB using SQLPlus
-   PDB_OPEN_MODE=`sqlplus -s / << EOF
+   PDB_OPEN_MODE=$(sqlplus -s / << EOF
 set heading off;
 set pagesize 0;
-SELECT DISTINCT open_mode FROM v\\$pdbs;
+SELECT DISTINCT open_mode FROM v\$pdbs;
 exit;
 EOF
-`
+)
    # Store return code from SQL*Plus
    ret=$?
 
-   if [ $ret -eq 0 ] && [ "$DB_ROLE" = "PRIMARY" ] && ! `echo $PDB_OPEN_MODE | grep -q "READ WRITE"`; then
+   if [ $ret -eq 0 ] && [ "$DB_ROLE" = "PRIMARY" ] && ! echo "$PDB_OPEN_MODE" | grep -q "READ WRITE"; then
       exit 2
    elif [ $ret -eq 0 ] && [ "$DB_ROLE" = "PHYSICAL STANDBY" ] && [ "$PDB_OPEN_MODE" != "READ ONLY" ]; then
       exit 2
@@ -59,9 +59,8 @@ EOF
 
 # Function to check that observer is running or not
 checkObserver() {
-   dg_observer_status="`dgmgrl sys/$ORACLE_PWD@$PRIMARY_DB_CONN_STR "show observer"`"
-   echo ${dg_observer_status} | grep -q 'Observer ".*"'
-   if [ $? -ne 0 ]; then
+   dg_observer_status="$(dgmgrl sys/"${ORACLE_PWD:?"ORACLE_PWD is not set. Exiting..."}"@"$PRIMARY_DB_CONN_STR" "show observer")"
+   if ! echo "$dg_observer_status" | grep -q 'Observer ".*"' -ne 0 ; then
       exit 4
    fi 
 
@@ -74,7 +73,7 @@ checkObserver() {
 if [ "$DG_OBSERVER_ONLY" = "true" ]; then
    checkObserver
 else
-   ORACLE_SID="`grep $ORACLE_HOME /etc/oratab | cut -d: -f1`"
+   ORACLE_SID="$(grep "$ORACLE_HOME" /etc/oratab | cut -d: -f1)"
    DB_ROLE=""
    ORAENV_ASK=NO
    source oraenv

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/checkSpace.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/checkSpace.sh
@@ -11,10 +11,10 @@
 # 
 
 REQUIRED_SPACE_GB=21
-AVAILABLE_SPACE_GB=`df -PB 1G / | tail -n 1 | awk '{ print $4 }'`
+AVAILABLE_SPACE_GB=$(df -PB 1G / | tail -n 1 | awk '{ print $4 }')
 
-if [ $AVAILABLE_SPACE_GB -lt $REQUIRED_SPACE_GB ]; then
-  script_name=`basename "$0"`
+if [ "$AVAILABLE_SPACE_GB" -lt $REQUIRED_SPACE_GB ]; then
+  script_name=$(basename "$0")
   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
   echo "$script_name: ERROR - There is not enough space available in the container."
   echo "$script_name: The container needs at least $REQUIRED_SPACE_GB GB, but only $AVAILABLE_SPACE_GB GB are available."

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
@@ -106,12 +106,12 @@ if [[ "${CLONE_DB}" == "true" ]] || [[ "${STANDBY_DB}" == "true" ]]; then
   # Creating the database using the dbca command
   if [ "${STANDBY_DB}" = "true" ]; then
     # Creating standby database
-    dbca -silent -createDuplicateDB -gdbName "$PRIMARY_DB_NAME" -primaryDBConnectionString "$PRIMARY_DB_CONN_STR" "$DBCA_CRED_OPTIONS" -sid "$ORACLE_SID" -createAsStandby -dbUniquename "$ORACLE_SID" ORACLE_HOSTNAME="$ORACLE_HOSTNAME" ||
+    dbca -silent -createDuplicateDB -gdbName "$PRIMARY_DB_NAME" -primaryDBConnectionString "$PRIMARY_DB_CONN_STR" ${DBCA_CRED_OPTIONS} -sid "$ORACLE_SID" -createAsStandby -dbUniquename "$ORACLE_SID" ORACLE_HOSTNAME="$ORACLE_HOSTNAME" ||
       cat /opt/oracle/cfgtoollogs/dbca/"$ORACLE_SID"/"$ORACLE_SID".log ||
       cat /opt/oracle/cfgtoollogs/dbca/"$ORACLE_SID".log
   else
     # Creating clone database after duplicating a primary database; CLONE_DB is set to true here
-    dbca -silent -createDuplicateDB -gdbName "$ORACLE_SID" -primaryDBConnectionString "$PRIMARY_DB_CONN_STR" "$DBCA_CRED_OPTIONS" -sid "$ORACLE_SID" -databaseConfigType SINGLE -useOMF true -dbUniquename "$ORACLE_SID" ORACLE_HOSTNAME="$ORACLE_HOSTNAME" ||
+    dbca -silent -createDuplicateDB -gdbName "$ORACLE_SID" -primaryDBConnectionString "$PRIMARY_DB_CONN_STR" ${DBCA_CRED_OPTIONS} -sid "$ORACLE_SID" -databaseConfigType SINGLE -useOMF true -dbUniquename "$ORACLE_SID" ORACLE_HOSTNAME="$ORACLE_HOSTNAME" ||
       cat /opt/oracle/cfgtoollogs/dbca/"$ORACLE_SID"/"$ORACLE_SID".log ||
       cat /opt/oracle/cfgtoollogs/dbca/"$ORACLE_SID".log
   fi

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
@@ -17,10 +17,10 @@ set -e
 
 ############## Setting up network related config files (sqlnet.ora, listener.ora) ##############
 function setupNetworkConfig {
-  mkdir -p $ORACLE_BASE_HOME/network/admin
+  mkdir -p "$ORACLE_BASE_HOME"/network/admin
 
   # sqlnet.ora
-  echo "NAMES.DIRECTORY_PATH= (TNSNAMES, EZCONNECT, HOSTNAME)" > $ORACLE_BASE_HOME/network/admin/sqlnet.ora
+  echo "NAMES.DIRECTORY_PATH= (TNSNAMES, EZCONNECT, HOSTNAME)" > "$ORACLE_BASE_HOME"/network/admin/sqlnet.ora
 
   # listener.ora
   echo "LISTENER = 
@@ -33,15 +33,15 @@ function setupNetworkConfig {
 
 DEDICATED_THROUGH_BROKER_LISTENER=ON
 DIAG_ADR_ENABLED = off
-" > $ORACLE_BASE_HOME/network/admin/listener.ora
+" > "$ORACLE_BASE_HOME"/network/admin/listener.ora
 
 }
 
 function setupTnsnames {
-  mkdir -p $ORACLE_BASE_HOME/network/admin
+  mkdir -p "$ORACLE_BASE_HOME"/network/admin
 
   # tnsnames.ora
-  echo "$ORACLE_SID=localhost:1521/$ORACLE_SID" > $ORACLE_BASE_HOME/network/admin/tnsnames.ora
+  echo "$ORACLE_SID=localhost:1521/$ORACLE_SID" > "$ORACLE_BASE_HOME"/network/admin/tnsnames.ora
   echo "$ORACLE_PDB= 
 (DESCRIPTION = 
   (ADDRESS = (PROTOCOL = TCP)(HOST = 0.0.0.0)(PORT = 1521))
@@ -49,7 +49,7 @@ function setupTnsnames {
     (SERVER = DEDICATED)
     (SERVICE_NAME = $ORACLE_PDB)
   )
-)" >> $ORACLE_BASE_HOME/network/admin/tnsnames.ora
+)" >> "$ORACLE_BASE_HOME"/network/admin/tnsnames.ora
 
 }
 
@@ -72,7 +72,7 @@ if [[ "${INIT_SGA_SIZE}" != "" && "${INIT_PGA_SIZE}" == "" ]] || [[ "${INIT_SGA_
 fi;
 
 # Auto generate ORACLE PWD if not passed on
-export ORACLE_PWD=${3:-"`openssl rand -base64 8`1"}
+export ORACLE_PWD=${3:-"$(openssl rand -base64 8)1"}
 
 # If wallet is present for database credentials then prepare dbca options to use
 if [[ -n "${WALLET_DIR}" ]] && [[ -f $WALLET_DIR/ewallet.p12 ]]; then
@@ -81,7 +81,7 @@ if [[ -n "${WALLET_DIR}" ]] && [[ -f $WALLET_DIR/ewallet.p12 ]]; then
 else
   if [[ "${CLONE_DB}" == "true" ]] || [[ "${STANDBY_DB}" == "true" ]]; then
     # Creating temporary response file containing sysPassword for clone/standby cases
-    echo "sysPassword=${ORACLE_PWD}" > $ORACLE_BASE/dbca.rsp
+    echo "sysPassword=${ORACLE_PWD}" > "$ORACLE_BASE"/dbca.rsp
     export DBCA_CRED_OPTIONS=" -responseFile $ORACLE_BASE/dbca.rsp"
   fi
 
@@ -106,14 +106,14 @@ if [[ "${CLONE_DB}" == "true" ]] || [[ "${STANDBY_DB}" == "true" ]]; then
   # Creating the database using the dbca command
   if [ "${STANDBY_DB}" = "true" ]; then
     # Creating standby database
-    dbca -silent -createDuplicateDB -gdbName ${PRIMARY_DB_NAME} -primaryDBConnectionString ${PRIMARY_DB_CONN_STR} ${DBCA_CRED_OPTIONS} -sid ${ORACLE_SID} -createAsStandby -dbUniquename ${ORACLE_SID} ORACLE_HOSTNAME=${ORACLE_HOSTNAME} ||
-      cat /opt/oracle/cfgtoollogs/dbca/$ORACLE_SID/$ORACLE_SID.log ||
-      cat /opt/oracle/cfgtoollogs/dbca/$ORACLE_SID.log
+    dbca -silent -createDuplicateDB -gdbName "$PRIMARY_DB_NAME" -primaryDBConnectionString "$PRIMARY_DB_CONN_STR" "$DBCA_CRED_OPTIONS" -sid "$ORACLE_SID" -createAsStandby -dbUniquename "$ORACLE_SID" ORACLE_HOSTNAME="$ORACLE_HOSTNAME" ||
+      cat /opt/oracle/cfgtoollogs/dbca/"$ORACLE_SID"/"$ORACLE_SID".log ||
+      cat /opt/oracle/cfgtoollogs/dbca/"$ORACLE_SID".log
   else
     # Creating clone database after duplicating a primary database; CLONE_DB is set to true here
-    dbca -silent -createDuplicateDB -gdbName ${ORACLE_SID} -primaryDBConnectionString ${PRIMARY_DB_CONN_STR} ${DBCA_CRED_OPTIONS} -sid ${ORACLE_SID} -databaseConfigType SINGLE -useOMF true -dbUniquename ${ORACLE_SID} ORACLE_HOSTNAME=${ORACLE_HOSTNAME} ||
-      cat /opt/oracle/cfgtoollogs/dbca/$ORACLE_SID/$ORACLE_SID.log ||
-      cat /opt/oracle/cfgtoollogs/dbca/$ORACLE_SID.log
+    dbca -silent -createDuplicateDB -gdbName "$ORACLE_SID" -primaryDBConnectionString "$PRIMARY_DB_CONN_STR" "$DBCA_CRED_OPTIONS" -sid "$ORACLE_SID" -databaseConfigType SINGLE -useOMF true -dbUniquename "$ORACLE_SID" ORACLE_HOSTNAME="$ORACLE_HOSTNAME" ||
+      cat /opt/oracle/cfgtoollogs/dbca/"$ORACLE_SID"/"$ORACLE_SID".log ||
+      cat /opt/oracle/cfgtoollogs/dbca/"$ORACLE_SID".log
   fi
 
   # Setup tnsnames.ora after execution of DBCA command to prevent getting overwritten
@@ -129,24 +129,24 @@ if [[ "${CLONE_DB}" == "true" ]] || [[ "${STANDBY_DB}" == "true" ]]; then
   lsnrctl start;
 
   # Remove temporary response file
-  if [ -f $ORACLE_BASE/dbca.rsp ]; then
-    rm $ORACLE_BASE/dbca.rsp
+  if [ -f "$ORACLE_BASE"/dbca.rsp ]; then
+    rm "$ORACLE_BASE"/dbca.rsp
   fi
 
   exit 0
 fi
 
 # Replace place holders in response file
-cp $ORACLE_BASE/$CONFIG_RSP $ORACLE_BASE/dbca.rsp
-sed -i -e "s|###ORACLE_SID###|$ORACLE_SID|g" $ORACLE_BASE/dbca.rsp
-sed -i -e "s|###ORACLE_PDB###|$ORACLE_PDB|g" $ORACLE_BASE/dbca.rsp
+cp "$ORACLE_BASE"/"$CONFIG_RSP" "$ORACLE_BASE"/dbca.rsp
+sed -i -e "s|###ORACLE_SID###|$ORACLE_SID|g" "$ORACLE_BASE"/dbca.rsp
+sed -i -e "s|###ORACLE_PDB###|$ORACLE_PDB|g" "$ORACLE_BASE"/dbca.rsp
 if [[ -n "${WALLET_DIR}" ]] && [[ -f $WALLET_DIR/ewallet.p12 ]]; then
   # Deleting password options from dbca response file as wallet will be used for credentials
-  sed -i -e "/###ORACLE_PWD###/d" $ORACLE_BASE/dbca.rsp
+  sed -i -e "/###ORACLE_PWD###/d" "$ORACLE_BASE"/dbca.rsp
 else
-  sed -i -e "s|###ORACLE_PWD###|$ORACLE_PWD|g" $ORACLE_BASE/dbca.rsp
+  sed -i -e "s|###ORACLE_PWD###|$ORACLE_PWD|g" "$ORACLE_BASE"/dbca.rsp
 fi
-sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" $ORACLE_BASE/dbca.rsp
+sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" "$ORACLE_BASE"/dbca.rsp
 
 # If both INIT_SGA_SIZE & INIT_PGA_SIZE aren't provided by user
 if [[ "${INIT_SGA_SIZE}" == "" && "${INIT_PGA_SIZE}" == "" ]]; then
@@ -155,12 +155,12 @@ if [[ "${INIT_SGA_SIZE}" == "" && "${INIT_PGA_SIZE}" == "" ]]; then
     # The minimum of 2G is for small environments to guarantee that Oracle has enough memory to function
     # However, bigger environment can and should use more of the available memory
     # This is due to Github Issue #307
-    if [ `nproc` -gt 8 ]; then
-        sed -i -e "s|totalMemory=2048||g" $ORACLE_BASE/dbca.rsp
+    if [ "$(nproc)" -gt 8 ]; then
+        sed -i -e "s|totalMemory=2048||g" "$ORACLE_BASE"/dbca.rsp
     fi;
 else
-    sed -i -e "s|totalMemory=2048||g" $ORACLE_BASE/dbca.rsp
-    sed -i -e "s|initParams=.*|&,sga_target=${INIT_SGA_SIZE}M,pga_aggregate_target=${INIT_PGA_SIZE}M|g" $ORACLE_BASE/dbca.rsp
+    sed -i -e "s|totalMemory=2048||g" "$ORACLE_BASE"/dbca.rsp
+    sed -i -e "s|initParams=.*|&,sga_target=${INIT_SGA_SIZE}M,pga_aggregate_target=${INIT_PGA_SIZE}M|g" "$ORACLE_BASE"/dbca.rsp
 fi;
 
 # Create network related config files (sqlnet.ora, tnsnames.ora, listener.ora)
@@ -171,9 +171,9 @@ export ARCHIVELOG_DIR=$ORACLE_BASE/oradata/$ORACLE_SID/$ARCHIVELOG_DIR_NAME
 
 # Start LISTENER and run DBCA
 lsnrctl start &&
-dbca -silent -createDatabase -enableArchive $ENABLE_ARCHIVELOG -archiveLogDest $ARCHIVELOG_DIR ${DBCA_CRED_OPTIONS} -responseFile $ORACLE_BASE/dbca.rsp ||
- cat /opt/oracle/cfgtoollogs/dbca/$ORACLE_SID/$ORACLE_SID.log ||
- cat /opt/oracle/cfgtoollogs/dbca/$ORACLE_SID.log
+dbca -silent -createDatabase -enableArchive "$ENABLE_ARCHIVELOG" -archiveLogDest "$ARCHIVELOG_DIR" "$DBCA_CRED_OPTIONS" -responseFile "$ORACLE_BASE"/dbca.rsp ||
+ cat /opt/oracle/cfgtoollogs/dbca/"$ORACLE_SID"/"$ORACLE_SID".log ||
+ cat /opt/oracle/cfgtoollogs/dbca/"$ORACLE_SID".log
 
 # Setup tnsnames.ora after execution of DBCA command to prevent getting overwritten
 setupTnsnames;
@@ -197,4 +197,4 @@ exit;
 EOF
 
 # Remove temporary response file
-rm $ORACLE_BASE/dbca.rsp
+rm "$ORACLE_BASE"/dbca.rsp

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createObserver.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createObserver.sh
@@ -17,21 +17,21 @@
 set -e
 
 # Validation: Check if PRIMARY_DB_CONN_STR is provided or not
-if [ -z "${PRIMARY_DB_CONN_STR}" ]; then
+if [ -z "$PRIMARY_DB_CONN_STR" ]; then
     echo "ERROR: Please provide PRIMARY_DB_CONN_STR to connect with primary database. Exiting..."
     exit 1
 fi
 
 # Validation: Check if ORACLE_PWD (which is password for sys user of the primary database) is provided or not
-if [ -z "${ORACLE_PWD}" ]; then
+if [ -z "$ORACLE_PWD" ]; then
     echo "ERROR: Please provide sys user password of primary database as ORACLE_PWD. Exiting..."
     exit 1
 fi
 
 # Creating the directory for Observer configuration and log file
-mkdir -p ${DG_OBSERVER_DIR}
+mkdir -p "$DG_OBSERVER_DIR"
 
 # Starting observer in background
-nohup dgmgrl -echo sys/${ORACLE_PWD}@${PRIMARY_DB_CONN_STR} "START OBSERVER ${DG_OBSERVER_NAME} FILE IS ${DG_OBSERVER_DIR}/fsfo.dat LOGFILE IS ${DG_OBSERVER_DIR}/observer.log" > ${DG_OBSERVER_DIR}/nohup.out &
+nohup dgmgrl -echo sys/"$ORACLE_PWD"@"$PRIMARY_DB_CONN_STR" "START OBSERVER $DG_OBSERVER_NAME FILE IS $DG_OBSERVER_DIR/fsfo.dat LOGFILE IS $DG_OBSERVER_DIR/observer.log" > "$DG_OBSERVER_DIR"/nohup.out &
 # Sleep for dgmgrl to start observer in background otherwise container will exit
 sleep 4

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/installDBBinaries.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/installDBBinaries.sh
@@ -54,7 +54,7 @@ mv "$INSTALL_DIR"/"$INSTALL_FILE_1" "$ORACLE_HOME"/ && \
 unzip "$INSTALL_FILE_1" && \
 rm "$INSTALL_FILE_1"    && \
 "$ORACLE_HOME"/runInstaller -silent -force -waitforcompletion -responsefile "$INSTALL_DIR"/"$INSTALL_RSP" -ignorePrereqFailure && \
-cd "$HOME" || exit
+cd "$HOME"
 
 if $SLIMMING; then
     # Remove not needed components

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/installDBBinaries.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/installDBBinaries.sh
@@ -21,7 +21,7 @@ if [ "$EDITION" == "" ]; then
 fi;
 
 # Check whether correct edition has been passed on
-if [ "$EDITION" != "EE" -a "$EDITION" != "SE2" ]; then
+if [ "$EDITION" != "EE" ] && [ "$EDITION" != "SE2" ]; then
    echo "ERROR: Wrong edition has been passed on!"
    echo "Edition $EDITION is no a valid edition!"
    exit 1;
@@ -44,44 +44,44 @@ fi;
 
 # Replace place holders
 # ---------------------
-sed -i -e "s|###ORACLE_EDITION###|$EDITION|g" $INSTALL_DIR/$INSTALL_RSP && \
-sed -i -e "s|###ORACLE_BASE###|$ORACLE_BASE|g" $INSTALL_DIR/$INSTALL_RSP && \
-sed -i -e "s|###ORACLE_HOME###|$ORACLE_HOME|g" $INSTALL_DIR/$INSTALL_RSP
+sed -i -e "s|###ORACLE_EDITION###|$EDITION|g" "$INSTALL_DIR"/"$INSTALL_RSP" && \
+sed -i -e "s|###ORACLE_BASE###|$ORACLE_BASE|g" "$INSTALL_DIR"/"$INSTALL_RSP" && \
+sed -i -e "s|###ORACLE_HOME###|$ORACLE_HOME|g" "$INSTALL_DIR"/"$INSTALL_RSP"
 
 # Install Oracle binaries
-cd $ORACLE_HOME       && \
-mv $INSTALL_DIR/$INSTALL_FILE_1 $ORACLE_HOME/ && \
-unzip $INSTALL_FILE_1 && \
-rm $INSTALL_FILE_1    && \
-$ORACLE_HOME/runInstaller -silent -force -waitforcompletion -responsefile $INSTALL_DIR/$INSTALL_RSP -ignorePrereqFailure && \
-cd $HOME
+cd "$ORACLE_HOME"       && \
+mv "$INSTALL_DIR"/"$INSTALL_FILE_1" "$ORACLE_HOME"/ && \
+unzip "$INSTALL_FILE_1" && \
+rm "$INSTALL_FILE_1"    && \
+"$ORACLE_HOME"/runInstaller -silent -force -waitforcompletion -responsefile "$INSTALL_DIR"/"$INSTALL_RSP" -ignorePrereqFailure && \
+cd "$HOME" || exit
 
 if $SLIMMING; then
     # Remove not needed components
     # APEX
-    rm -rf $ORACLE_HOME/apex && \
+    rm -rf "$ORACLE_HOME"/apex && \
     # ORDS
-    rm -rf $ORACLE_HOME/ords && \
+    rm -rf "$ORACLE_HOME"/ords && \
     # SQL Developer
-    rm -rf $ORACLE_HOME/sqldeveloper && \
+    rm -rf "$ORACLE_HOME"/sqldeveloper && \
     # UCP connection pool
-    rm -rf $ORACLE_HOME/ucp && \
+    rm -rf "$ORACLE_HOME"/ucp && \
     # All installer files
-    rm -rf $ORACLE_HOME/lib/*.zip && \
+    rm -rf "$ORACLE_HOME"/lib/*.zip && \
     # OUI backup
-    rm -rf $ORACLE_HOME/inventory/backup/* && \
+    rm -rf "$ORACLE_HOME"/inventory/backup/* && \
     # Network tools help
-    rm -rf $ORACLE_HOME/network/tools/help && \
+    rm -rf "$ORACLE_HOME"/network/tools/help && \
     # Database upgrade assistant
-    rm -rf $ORACLE_HOME/assistants/dbua && \
+    rm -rf "$ORACLE_HOME"/assistants/dbua && \
     # Database migration assistant
-    rm -rf $ORACLE_HOME/dmu && \
+    rm -rf "$ORACLE_HOME"/dmu && \
     # Remove pilot workflow installer
-    rm -rf $ORACLE_HOME/install/pilot && \
+    rm -rf "$ORACLE_HOME"/install/pilot && \
     # Support tools
-    rm -rf $ORACLE_HOME/suptools && \
+    rm -rf "$ORACLE_HOME"/suptools && \
     # Temp location
     rm -rf /tmp/* && \
     # Database files directory
-    rm -rf $INSTALL_DIR/database
+    rm -rf "$INSTALL_DIR"/database
 fi

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/relinkOracleBinary.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/relinkOracleBinary.sh
@@ -10,14 +10,14 @@
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
 
-major_version=$(${ORACLE_HOME}/bin/oraversion -majorVersion)
-LIB_EDITION="/usr/bin/ar t ${ORACLE_HOME}/lib/libedtn"
-if [ ${major_version} -gt 19 ]; then
-    LIB_EDITION=$(${LIB_EDITION}.a)
+major_version=$("$ORACLE_HOME"/bin/oraversion -majorVersion)
+LIB_EDITION="/usr/bin/ar t $ORACLE_HOME/lib/libedtn"
+if [ "$major_version" -gt 19 ]; then
+    LIB_EDITION=$("$LIB_EDITION".a)
 else
-    LIB_EDITION=$(${LIB_EDITION}${major_version}.a)
+    LIB_EDITION=$("$LIB_EDITION""$major_version".a)
 fi
-LIB_EDITION=$(echo ${LIB_EDITION} | cut -d. -f1)
+LIB_EDITION=$(echo "$LIB_EDITION" | cut -d. -f1)
 LIB_EDITION=${LIB_EDITION: -3}
 
 if [ "${LIB_EDITION}" == "ent" ]; then
@@ -29,12 +29,12 @@ if [ "${LIB_EDITION}" == "std" ]; then
 fi
 
 # If datafiles already exists
-if [ -f $ORACLE_BASE/oradata/.${ORACLE_SID}${CHECKPOINT_FILE_EXTN} ]; then
-    datafiles_edition=$(ls $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/.docker_* | rev | cut -d_ -f1 | rev)
-    if [ -n "${ORACLE_EDITION}" ] && [ "${ORACLE_EDITION,,}" != $datafiles_edition ]; then
+if [ -f "$ORACLE_BASE"/oradata/."${ORACLE_SID}""${CHECKPOINT_FILE_EXTN}" ]; then
+    datafiles_edition=$(find "$ORACLE_BASE"/oradata/dbconfig/"$ORACLE_SID"/ -maxdepth 1 -name '.docker_*' | rev | cut -d_ -f1 | rev)
+    if [ -n "${ORACLE_EDITION}" ] && [ "${ORACLE_EDITION,,}" != "$datafiles_edition" ]; then
         echo "The datafiles being used were created with $datafiles_edition edition software home. Please pass -e ORACLE_EDITION=$datafiles_edition to the docker run cmd.";
         exit 1;
-    elif [ -z "${ORACLE_EDITION}" ] && [ "${CURRENT_EDITION,,}" != $datafiles_edition ]; then
+    elif [ -z "${ORACLE_EDITION}" ] && [ "${CURRENT_EDITION,,}" != "$datafiles_edition" ]; then
         echo "The current software home is of ${CURRENT_EDITION,,} edition whereas the datafiles being used were created with $datafiles_edition edition software home. Please pass -e ORACLE_EDITION=$datafiles_edition to the docker run cmd.";
         exit 1;
     fi
@@ -50,5 +50,5 @@ if [ -n "${ORACLE_EDITION}" ]; then
     fi
 fi
 
-echo "ORACLE EDITION: ${CURRENT_EDITION}"
-touch $ORACLE_HOME/install/.docker_${CURRENT_EDITION,,}
+echo "ORACLE EDITION: $CURRENT_EDITION}"
+touch "$ORACLE_HOME"/install/.docker_"${CURRENT_EDITION,,}"

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/relinkOracleBinary.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/relinkOracleBinary.sh
@@ -13,7 +13,7 @@
 major_version=$("$ORACLE_HOME"/bin/oraversion -majorVersion)
 LIB_EDITION="/usr/bin/ar t $ORACLE_HOME/lib/libedtn"
 if [ "$major_version" -gt 19 ]; then
-    LIB_EDITION=$("$LIB_EDITION".a)
+    LIB_EDITION=$(${LIB_EDITION}.a)
 else
     LIB_EDITION=$("$LIB_EDITION""$major_version".a)
 fi
@@ -50,5 +50,5 @@ if [ -n "${ORACLE_EDITION}" ]; then
     fi
 fi
 
-echo "ORACLE EDITION: $CURRENT_EDITION}"
+echo "ORACLE EDITION: $CURRENT_EDITION"
 touch "$ORACLE_HOME"/install/.docker_"${CURRENT_EDITION,,}"

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/runOracle.sh
@@ -13,19 +13,19 @@
 ########### Move DB files ############
 function moveFiles {
 
-   if [ ! -d $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID ]; then
-      mkdir -p $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/
+   if [ ! -d "$ORACLE_BASE"/oradata/dbconfig/"$ORACLE_SID" ]; then
+      mkdir -p "$ORACLE_BASE"/oradata/dbconfig/"$ORACLE_SID"/
    fi;
 
-   mv $ORACLE_BASE_CONFIG/dbs/spfile$ORACLE_SID.ora $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/
-   mv $ORACLE_BASE_CONFIG/dbs/orapw$ORACLE_SID $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/
-   mv $ORACLE_BASE_HOME/network/admin/sqlnet.ora $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/
-   mv $ORACLE_BASE_HOME/network/admin/listener.ora $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/
-   mv $ORACLE_BASE_HOME/network/admin/tnsnames.ora $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/
-   mv $ORACLE_HOME/install/.docker_* $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/
+   mv "$ORACLE_BASE_CONFIG"/dbs/spfile"$ORACLE_SID".ora "$ORACLE_BASE"/oradata/dbconfig/"$ORACLE_SID"/
+   mv "$ORACLE_BASE_CONFIG"/dbs/orapw"$ORACLE_SID" "$ORACLE_BASE"/oradata/dbconfig/"$ORACLE_SID"/
+   mv "$ORACLE_BASE_HOME"/network/admin/sqlnet.ora "$ORACLE_BASE"/oradata/dbconfig/"$ORACLE_SID"/
+   mv "$ORACLE_BASE_HOME"/network/admin/listener.ora "$ORACLE_BASE"/oradata/dbconfig/"$ORACLE_SID"/
+   mv "$ORACLE_BASE_HOME"/network/admin/tnsnames.ora "$ORACLE_BASE"/oradata/dbconfig/"$ORACLE_SID"/
+   mv "$ORACLE_HOME"/install/.docker_* "$ORACLE_BASE"/oradata/dbconfig/"$ORACLE_SID"/
 
    # oracle user does not have permissions in /etc, hence cp and not mv
-   cp /etc/oratab $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/
+   cp /etc/oratab "$ORACLE_BASE"/oradata/dbconfig/"$ORACLE_SID"/
    
    symLinkFiles;
 }
@@ -33,28 +33,28 @@ function moveFiles {
 ########### Symbolic link DB files ############
 function symLinkFiles {
 
-   if [ ! -L $ORACLE_BASE_CONFIG/dbs/spfile$ORACLE_SID.ora ]; then
-      ln -s $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/spfile$ORACLE_SID.ora $ORACLE_BASE_CONFIG/dbs/spfile$ORACLE_SID.ora
+   if [ ! -L "$ORACLE_BASE_CONFIG"/dbs/spfile"$ORACLE_SID".ora ]; then
+      ln -s "$ORACLE_BASE"/oradata/dbconfig/"$ORACLE_SID"/spfile"$ORACLE_SID".ora "$ORACLE_BASE_CONFIG"/dbs/spfile"$ORACLE_SID".ora
    fi;
    
-   if [ ! -L $ORACLE_BASE_CONFIG/dbs/orapw$ORACLE_SID ]; then
-      ln -s $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/orapw$ORACLE_SID $ORACLE_BASE_CONFIG/dbs/orapw$ORACLE_SID
+   if [ ! -L "$ORACLE_BASE_CONFIG"/dbs/orapw"$ORACLE_SID" ]; then
+      ln -s "$ORACLE_BASE"/oradata/dbconfig/"$ORACLE_SID"/orapw"$ORACLE_SID" "$ORACLE_BASE_CONFIG"/dbs/orapw"$ORACLE_SID"
    fi;
    
-   if [ ! -L $ORACLE_BASE_HOME/network/admin/sqlnet.ora ]; then
-      ln -s $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/sqlnet.ora $ORACLE_BASE_HOME/network/admin/sqlnet.ora
+   if [ ! -L "$ORACLE_BASE_HOME"/network/admin/sqlnet.ora ]; then
+      ln -s "$ORACLE_BASE"/oradata/dbconfig/"$ORACLE_SID"/sqlnet.ora "$ORACLE_BASE_HOME"/network/admin/sqlnet.ora
    fi;
 
-   if [ ! -L $ORACLE_BASE_HOME/network/admin/listener.ora ]; then
-      ln -s $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/listener.ora $ORACLE_BASE_HOME/network/admin/listener.ora
+   if [ ! -L "$ORACLE_BASE_HOME"/network/admin/listener.ora ]; then
+      ln -s "$ORACLE_BASE"/oradata/dbconfig/"$ORACLE_SID"/listener.ora "$ORACLE_BASE_HOME"/network/admin/listener.ora
    fi;
 
-   if [ ! -L $ORACLE_BASE_HOME/network/admin/tnsnames.ora ]; then
-      ln -s $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/tnsnames.ora $ORACLE_BASE_HOME/network/admin/tnsnames.ora
+   if [ ! -L "$ORACLE_BASE_HOME"/network/admin/tnsnames.ora ]; then
+      ln -s "$ORACLE_BASE"/oradata/dbconfig/"$ORACLE_SID"/tnsnames.ora "$ORACLE_BASE_HOME"/network/admin/tnsnames.ora
    fi;
 
    # oracle user does not have permissions in /etc, hence cp and not ln 
-   cp $ORACLE_BASE/oradata/dbconfig/$ORACLE_SID/oratab /etc/oratab
+   cp "$ORACLE_BASE"/oradata/dbconfig/"$ORACLE_SID"/oratab /etc/oratab
 
 }
 
@@ -119,17 +119,18 @@ trap _term SIGTERM
 if [ "${DG_OBSERVER_ONLY}" = "true" ]; then
    if [ -z "${DG_OBSERVER_NAME}" ]; then
       # Auto generate the observer name if not given
-      export DG_OBSERVER_NAME="observer-`openssl rand -hex 4`"
+      DG_OBSERVER_NAME="observer-$(openssl rand -hex 4)"
+      export DB_OBSERVER_NAME
    fi 
    export DG_OBSERVER_DIR=${ORACLE_BASE}/oradata/${DG_OBSERVER_NAME}
 
    # Calling the script to create observer
-   $ORACLE_BASE/$CREATE_OBSERVER_FILE $DG_OBSERVER_NAME $PRIMARY_DB_CONN_STR $ORACLE_PWD $DG_OBSERVER_DIR
+   "$ORACLE_BASE"/"$CREATE_OBSERVER_FILE" "$DG_OBSERVER_NAME" "$PRIMARY_DB_CONN_STR" "${ORACLE_PWD:?'ORACLE_PWD not set. Exiting...'}" "$DG_OBSERVER_DIR"
 
    if [ ! -f "$DG_OBSERVER_DIR/observer.log" ]; then
       # Display the content of nohup.out to show errors
       if [ -f "$DG_OBSERVER_DIR/nohup.out" ]; then
-         cat $DG_OBSERVER_DIR/nohup.out
+         cat "$DG_OBSERVER_DIR"/nohup.out
          echo "Observer is not able to start. Exiting..."
       else
          echo "Observer creation and startup fail !! Exiting..."
@@ -138,13 +139,13 @@ if [ "${DG_OBSERVER_ONLY}" = "true" ]; then
    else
       # Tail on observer log and wait (otherwise container will exit)
       echo "The following output is now a tail of the observer.log:"
-      tail -f $DG_OBSERVER_DIR/observer.log &
+      tail -f "$DG_OBSERVER_DIR"/observer.log &
       childPID=$!
       wait $childPID
 
       # Show nohup output and exit
       echo "Exiting..."
-      cat $DG_OBSERVER_DIR/nohup.out
+      cat "$DG_OBSERVER_DIR"/nohup.out
       exit 0;
    fi
 fi
@@ -173,7 +174,8 @@ else
 fi;
 
 # Read-only Oracle Home Config
-export ORACLE_BASE_CONFIG=$($ORACLE_HOME/bin/orabaseconfig)
+ORACLE_BASE_CONFIG=$("$ORACLE_HOME"/bin/orabaseconfig)
+export ORACLE_BASE_CONFIG
 
 # Default for ORACLE PDB
 export ORACLE_PDB=${ORACLE_PDB:-ORCLPDB1}
@@ -189,69 +191,67 @@ export ORACLE_CHARACTERSET=${ORACLE_CHARACTERSET:-AL32UTF8}
 . "$ORACLE_BASE/$RELINK_BINARY_FILE"
 
 # Check whether database already exists
-if [ -f $ORACLE_BASE/oradata/.${ORACLE_SID}${CHECKPOINT_FILE_EXTN} ]; then
+if [ -f "$ORACLE_BASE"/oradata/.${ORACLE_SID}"${CHECKPOINT_FILE_EXTN}" ]; then
    symLinkFiles;
    
    # Make sure audit file destination exists
-   if [ ! -d $ORACLE_BASE/admin/$ORACLE_SID/adump ]; then
-      mkdir -p $ORACLE_BASE/admin/$ORACLE_SID/adump
+   if [ ! -d "$ORACLE_BASE"/admin/$ORACLE_SID/adump ]; then
+      mkdir -p "$ORACLE_BASE"/admin/$ORACLE_SID/adump
    fi;
    
    # Start database
-   $ORACLE_BASE/$START_FILE;
+   "$ORACLE_BASE"/"$START_FILE";
    
 else
   # Remove database config files, if they exist
-  rm -f $ORACLE_BASE_CONFIG/dbs/spfile$ORACLE_SID.ora
-  rm -f $ORACLE_BASE_CONFIG/dbs/orapw$ORACLE_SID
-  rm -f $ORACLE_BASE_HOME/network/admin/sqlnet.ora
-  rm -f $ORACLE_BASE_HOME/network/admin/listener.ora
-  rm -f $ORACLE_BASE_HOME/network/admin/tnsnames.ora
+  rm -f "$ORACLE_BASE_CONFIG"/dbs/spfile$ORACLE_SID.ora
+  rm -f "$ORACLE_BASE_CONFIG"/dbs/orapw$ORACLE_SID
+  rm -f "$ORACLE_BASE_HOME"/network/admin/sqlnet.ora
+  rm -f "$ORACLE_BASE_HOME"/network/admin/listener.ora
+  rm -f "$ORACLE_BASE_HOME"/network/admin/tnsnames.ora
 
   # Clean up incomplete database
-  rm -rf $ORACLE_BASE/oradata/$ORACLE_SID
+  rm -rf "$ORACLE_BASE"/oradata/$ORACLE_SID
   cp /etc/oratab oratab.bkp
   sed "/$ORACLE_SID/d" oratab.bkp > /etc/oratab
   rm -f oratab.bkp
-  rm -rf $ORACLE_BASE/cfgtoollogs/dbca/$ORACLE_SID
-  rm -rf $ORACLE_BASE/admin/$ORACLE_SID
+  rm -rf "$ORACLE_BASE"/cfgtoollogs/dbca/$ORACLE_SID
+  rm -rf "$ORACLE_BASE"/admin/$ORACLE_SID
 
   # clean up zombie shared memory/semaphores
   ipcs -m | awk ' /[0-9]/ {print $2}' | xargs -n1 ipcrm -m 2> /dev/null
   ipcs -s | awk ' /[0-9]/ {print $2}' | xargs -n1 ipcrm -s 2> /dev/null
 
   # Create database
-  $ORACLE_BASE/$CREATE_DB_FILE $ORACLE_SID $ORACLE_PDB $ORACLE_PWD || exit 1;
+  "$ORACLE_BASE"/"$CREATE_DB_FILE" $ORACLE_SID "$ORACLE_PDB" "$ORACLE_PWD" || exit 1;
 
   # Check whether database is successfully created
-  $ORACLE_BASE/$CHECK_DB_FILE
-  if [ $? -eq 0 ]; then
+  if "$ORACLE_BASE"/"$CHECK_DB_FILE"; then
     # Create a checkpoint file if database is successfully created
-    touch $ORACLE_BASE/oradata/.${ORACLE_SID}${CHECKPOINT_FILE_EXTN}
+    touch "$ORACLE_BASE"/oradata/.${ORACLE_SID}"${CHECKPOINT_FILE_EXTN}"
   fi
 
   # Move database operational files to oradata
   moveFiles;
 
   # Execute setup script for extensions
-  $ORACLE_BASE/$USER_SCRIPTS_FILE $ORACLE_BASE/scripts/extensions/setup
+  "$ORACLE_BASE"/"$USER_SCRIPTS_FILE" "$ORACLE_BASE"/scripts/extensions/setup
   
   # Execute custom provided setup scripts
-  $ORACLE_BASE/$USER_SCRIPTS_FILE $ORACLE_BASE/scripts/setup
+  "$ORACLE_BASE"/"$USER_SCRIPTS_FILE" "$ORACLE_BASE"/scripts/setup
 fi;
 
 # Check whether database is up and running
-$ORACLE_BASE/$CHECK_DB_FILE
-if [ $? -eq 0 ]; then
+if "$ORACLE_BASE"/"$CHECK_DB_FILE"; then
   echo "#########################"
   echo "DATABASE IS READY TO USE!"
   echo "#########################"
 
   # Execute startup script for extensions
-  $ORACLE_BASE/$USER_SCRIPTS_FILE $ORACLE_BASE/scripts/extensions/startup
+  "$ORACLE_BASE"/"$USER_SCRIPTS_FILE" "$ORACLE_BASE"/scripts/extensions/startup
 
   # Execute custom provided startup scripts
-  $ORACLE_BASE/$USER_SCRIPTS_FILE $ORACLE_BASE/scripts/startup
+  "$ORACLE_BASE"/"$USER_SCRIPTS_FILE" "$ORACLE_BASE"/scripts/startup
   
 else
   echo "#####################################"
@@ -264,6 +264,6 @@ fi;
 
 # Tail on alert log and wait (otherwise container will exit)
 echo "The following output is now a tail of the alert.log:"
-tail -f $ORACLE_BASE/diag/rdbms/*/*/trace/alert*.log &
+tail -f "$ORACLE_BASE"/diag/rdbms/*/*/trace/alert*.log &
 childPID=$!
 wait $childPID

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/runUserScripts.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/runUserScripts.sh
@@ -19,15 +19,15 @@ if [ -z "$SCRIPTS_ROOT" ]; then
 fi;
 
 # Execute custom provided files (only if directory exists and has files in it)
-if [ -d "$SCRIPTS_ROOT" ] && [ -n "$(ls -A $SCRIPTS_ROOT)" ]; then
+if [ -d "$SCRIPTS_ROOT" ] && [ -n "$(ls -A "$SCRIPTS_ROOT")" ]; then
 
   echo "";
   echo "Executing user defined scripts"
 
-  for f in $SCRIPTS_ROOT/*; do
+  for f in "$SCRIPTS_ROOT"/*; do
       case "$f" in
           *.sh)     echo "$0: running $f"; . "$f" ;;
-          *.sql)    echo "$0: running $f"; echo "exit" | $ORACLE_HOME/bin/sqlplus -s "/ as sysdba" @"$f"; echo ;;
+          *.sql)    echo "$0: running $f"; echo "exit" | "$ORACLE_HOME"/bin/sqlplus -s "/ as sysdba" @"$f"; echo ;;
           *)        echo "$0: ignoring $f" ;;
       esac
       echo "";

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/setPassword.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/setPassword.sh
@@ -11,8 +11,8 @@
 # 
 
 ORACLE_PWD=$1
-ORACLE_SID="`grep $ORACLE_HOME /etc/oratab | cut -d: -f1`"
-ORACLE_PDB="`ls -dl $ORACLE_BASE/oradata/$ORACLE_SID/*/ | grep -v -e pdbseed -e $ARCHIVELOG_DIR_NAME| awk '{print $9}' | cut -d/ -f6`"
+ORACLE_SID="$(grep "$ORACLE_HOME" /etc/oratab | cut -d: -f1)"
+ORACLE_PDB="$(ls -dl "$ORACLE_BASE"/oradata/"$ORACLE_SID"/*/ | grep -v -e pdbseed -e "$ARCHIVELOG_DIR_NAME"| awk '{print $9}' | cut -d/ -f6)"
 ORAENV_ASK=NO
 source oraenv
 

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/setupLinuxEnv.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/setupLinuxEnv.sh
@@ -13,16 +13,16 @@
 # Setup filesystem and oracle user
 # Adjust file permissions, go to /opt/oracle as user 'oracle' to proceed with Oracle installation
 # ------------------------------------------------------------
-mkdir -p $ORACLE_BASE/scripts/setup && \
-mkdir $ORACLE_BASE/scripts/startup && \
-mkdir -p $ORACLE_BASE/scripts/extensions/setup && \
-mkdir $ORACLE_BASE/scripts/extensions/startup && \
-ln -s $ORACLE_BASE/scripts /docker-entrypoint-initdb.d && \
-mkdir $ORACLE_BASE/oradata && \
-mkdir -p $ORACLE_HOME && \
-chmod ug+x $ORACLE_BASE/*.sh && \
+mkdir -p "$ORACLE_BASE"/scripts/setup && \
+mkdir "$ORACLE_BASE"/scripts/startup && \
+mkdir -p "$ORACLE_BASE"/scripts/extensions/setup && \
+mkdir "$ORACLE_BASE"/scripts/extensions/startup && \
+ln -s "$ORACLE_BASE"/scripts /docker-entrypoint-initdb.d && \
+mkdir "$ORACLE_BASE"/oradata && \
+mkdir -p "$ORACLE_HOME" && \
+chmod ug+x "$ORACLE_BASE"/*.sh && \
 yum -y install oracle-database-preinstall-21c openssl && \
 rm -rf /var/cache/yum && \
-ln -s $ORACLE_BASE/$PWD_FILE /home/oracle/ && \
+ln -s "$ORACLE_BASE"/"$PWD_FILE" /home/oracle/ && \
 echo oracle:oracle | chpasswd && \
-chown -R oracle:dba $ORACLE_BASE
+chown -R oracle:dba "$ORACLE_BASE"

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/startDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/startDB.sh
@@ -13,7 +13,7 @@
 
 # Check that ORACLE_HOME is set
 if [ "$ORACLE_HOME" == "" ]; then
-  script_name=`basename "$0"`
+  script_name=$(basename "$0")
   echo "$script_name: ERROR - ORACLE_HOME is not set. Please set ORACLE_HOME and PATH before invoking this script."
   exit 1;
 fi;


### PR DESCRIPTION
Static analysis of 21c scripts performed by ShellCheck utility. In this PR, incorporated all the suggestions generated by the tool without breaking the functionality.
Mostly issues were:

- Using double quotes to prevent word splitting
- Not using legacy backtick(``) notation, instead using $() notation.