### PR TITLE
Add golang 1.17 for OL7 to README, remove 1.15

### DIFF
--- a/OracleLinuxDevelopers/README.md
+++ b/OracleLinuxDevelopers/README.md
@@ -36,8 +36,8 @@ Oracle Database along with the appropriate Oracle Instant Client packages.
 
 ### Go
 
-* [`oraclelinux7-golang:1.15`](oraclelinux7/golang/1.15/Dockerfile)
 * [`oraclelinux7-golang:1.16`](oraclelinux7/golang/1.16/Dockerfile)
+* [`oraclelinux7-golang:1.17`](oraclelinux7/golang/1.17/Dockerfile)
 
 ### Node.js
 


### PR DESCRIPTION
Signed-off-by: Sergio Leunissen <sergio.leunissen@oracle.com>
