### PR TITLE
updated versions to Oct 2021 CPU releases

### DIFF
--- a/OracleJava/11/Dockerfile
+++ b/OracleJava/11/Dockerfile
@@ -39,8 +39,8 @@ ENV LANG en_US.UTF-8
 # Environment variables for the builder image.  
 # Required to validate that you are using the correct file
 
-ENV JAVA_PKG=jdk-11.0.12_linux-x64_bin.tar.gz \
-	JAVA_SHA256=d5d45826f835bd1ea069f9ff8bcd0f23c9f05c8d063b7df821960cfa765ed2cb \
+ENV JAVA_PKG=jdk-11.0.13_linux-x64_bin.tar.gz \
+	JAVA_SHA256=f4f115f0cd46a604af9b9627d6b654bc2061a352840e9b95883f1b4959fe26f9 \
 	JAVA_HOME=/usr/java/jdk-11
 
 ##
@@ -56,7 +56,7 @@ FROM oraclelinux:7-slim
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
-ENV JAVA_VERSION=11.0.12 \
+ENV JAVA_VERSION=11.0.13 \
 	JAVA_HOME=/usr/java/jdk-11
 
 ENV	PATH $JAVA_HOME/bin:$PATH	

--- a/OracleJava/11/Dockerfile.8
+++ b/OracleJava/11/Dockerfile.8
@@ -37,8 +37,8 @@ ENV LANG en_US.UTF-8
 # Environment variables for the builder image.  
 # Required to validate that you are using the correct file
 
-ENV JAVA_PKG=jdk-11.0.12_linux-x64_bin.tar.gz \
-	JAVA_SHA256=d5d45826f835bd1ea069f9ff8bcd0f23c9f05c8d063b7df821960cfa765ed2cb \
+ENV JAVA_PKG=jdk-11.0.13_linux-x64_bin.tar.gz \
+	JAVA_SHA256=f4f115f0cd46a604af9b9627d6b654bc2061a352840e9b95883f1b4959fe26f9 \
 	JAVA_HOME=/usr/java/jdk-11
 
 ##
@@ -54,7 +54,7 @@ FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
-ENV JAVA_VERSION=11.0.12 \
+ENV JAVA_VERSION=11.0.13 \
 	JAVA_HOME=/usr/java/jdk-11
 
 ENV	PATH $JAVA_HOME/bin:$PATH	

--- a/OracleJava/8/Dockerfile
+++ b/OracleJava/8/Dockerfile
@@ -41,8 +41,8 @@ ENV LANG en_US.UTF-8
 # Environment variables for the builder image.  
 # Required to validate that you are using the correct file
 
-ENV JAVA_PKG=server-jre-8u301-linux-x64.tar.gz \
-	JAVA_SHA256=fe1cbfbb4d67a3bd5a9491de3c13ab2870043bad8b5e6654b22432126231f482 \
+ENV JAVA_PKG=server-jre-8u311-linux-x64.tar.gz \
+	JAVA_SHA256=4132d53f500fea109386a5734dc156468558d792082cfbd39f0a097e6f55e710 \
 	JAVA_HOME=/usr/java/jdk-8
 
 COPY $JAVA_PKG /tmp/jdk.tgz
@@ -58,7 +58,7 @@ FROM oraclelinux:7-slim
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
-ENV JAVA_VERSION=1.8.0_301 \
+ENV JAVA_VERSION=1.8.0_311 \
 	JAVA_HOME=/usr/java/jdk-8 
 	
 ENV	PATH $JAVA_HOME/bin:$PATH

--- a/OracleJava/8/Dockerfile.8
+++ b/OracleJava/8/Dockerfile.8
@@ -37,8 +37,8 @@ ENV LANG en_US.UTF-8
 # Environment variables for the builder image.  
 # Required to validate that you are using the correct file
 
-ENV JAVA_PKG=server-jre-8u301-linux-x64.tar.gz \
-	JAVA_SHA256=fe1cbfbb4d67a3bd5a9491de3c13ab2870043bad8b5e6654b22432126231f482 \
+ENV JAVA_PKG=server-jre-8u311-linux-x64.tar.gz \
+	JAVA_SHA256=4132d53f500fea109386a5734dc156468558d792082cfbd39f0a097e6f55e710 \
 	JAVA_HOME=/usr/java/jdk-8
 
 COPY $JAVA_PKG /tmp/jdk.tgz
@@ -54,7 +54,7 @@ FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
-ENV JAVA_VERSION=1.8.0_301 \
+ENV JAVA_VERSION=1.8.0_311 \
 	JAVA_HOME=/usr/java/jdk-8 
 	
 ENV	PATH $JAVA_HOME/bin:$PATH

--- a/OracleOpenJDK/17/Dockerfile
+++ b/OracleOpenJDK/17/Dockerfile
@@ -25,7 +25,7 @@ FROM oraclelinux:8
 
 MAINTAINER Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>
 
-ENV JAVA_PKG=https://download.java.net/java/GA/jdk17/0d483333a00540d886896bac774ff48b/35/GPL/openjdk-17_linux-x64_bin.tar.gz \
+ENV JAVA_PKG=https://download.java.net/java/GA/jdk17.0.1/2a2082e5a09d4267845be086888add4f/12/GPL/openjdk-17.0.1_linux-x64_bin.tar.gz \
 	JAVA_HOME=/usr/java/jdk-17 \
 	LANG=en_US.UTF-8
 


### PR DESCRIPTION
Changed version number and checksum for OpenJDK 17, JDK 11, and Server JRE 8.
Signed-off-by: Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>