### PR TITLE
Include local_listener fix for 12.2.0.1

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/12.2.0.1/createDB.sh
@@ -77,6 +77,7 @@ echo "$ORACLE_PDB=
 # Remove second control file, fix local_listener, make PDB auto open, enable EM global port
 sqlplus / as sysdba << EOF
    ALTER SYSTEM SET control_files='$ORACLE_BASE/oradata/$ORACLE_SID/control01.ctl' scope=spfile;
+   ALTER SYSTEM SET local_listener='';
    ALTER PLUGGABLE DATABASE $ORACLE_PDB SAVE STATE;
    EXEC DBMS_XDB_CONFIG.SETGLOBALPORTENABLED (TRUE);
    exit;


### PR DESCRIPTION
Docker database 12.2.0.1 didn't contain local_listener fix.
This fix is already included from version 18.