### PR TITLE
Security fixes in 19c

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
@@ -1,6 +1,6 @@
 # LICENSE UPL 1.0
 #
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 #
 # ORACLE DOCKERFILES PROJECT
 # --------------------------

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/checkDBStatus.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/checkDBStatus.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1982-2021 Oracle and/or its affiliates. All rights reserved.
 #
 # Since: May, 2017
 # Author: gerald.venzl@oracle.com

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/checkSpace.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/checkSpace.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1982-2021 Oracle and/or its affiliates. All rights reserved.
 #
 # Since: January, 2017
 # Author: gerald.venzl@oracle.com

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1982-2021 Oracle and/or its affiliates. All rights reserved.
 # 
 # Since: November, 2016
 # Author: gerald.venzl@oracle.com

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/db_inst.rsp
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/db_inst.rsp
@@ -1,5 +1,5 @@
 ####################################################################
-## Copyright(c) Oracle Corporation 1998,2017. All rights reserved.##
+## Copyright(c) Oracle Corporation 1998,2021. All rights reserved.##
 ##                                                                ##
 ## Specify values for the variables listed below to customize     ##
 ## your installation.                                             ##

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/dbca.rsp.tmpl
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/dbca.rsp.tmpl
@@ -2,7 +2,7 @@
 ##                                                                          ##
 ##                            DBCA response file                            ##
 ##                            ------------------                            ##
-## Copyright(c) Oracle Corporation 1998,2017. All rights reserved.          ##
+## Copyright(c) Oracle Corporation 1998,2021. All rights reserved.          ##
 ##                                                                          ##
 ## Specify values for the variables listed below to customize 			    ##
 ## your installation.                                         			    ##

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/installDBBinaries.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/installDBBinaries.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1982-2021 Oracle and/or its affiliates. All rights reserved.
 #
 # Since: December, 2016
 # Author: gerald.venzl@oracle.com

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/relinkOracleBinary.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/relinkOracleBinary.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # LICENSE UPL 1.0
 #
-# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # Since: March, 2020
 # Author: rishabh.y.gupta@oracle.com

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1982-2021 Oracle and/or its affiliates. All rights reserved.
 # 
 # Since: November, 2016
 # Author: gerald.venzl@oracle.com

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runUserScripts.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runUserScripts.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1982-2021 Oracle and/or its affiliates. All rights reserved.
 #
 # Since: July, 2017
 # Author: gerald.venzl@oracle.com

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/setPassword.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/setPassword.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1982-2021 Oracle and/or its affiliates. All rights reserved.
 # 
 # Since: November, 2016
 # Author: gerald.venzl@oracle.com

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/setupLinuxEnv.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/setupLinuxEnv.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1982-2021 Oracle and/or its affiliates. All rights reserved.
 #
 # Since: December, 2016
 # Author: gerald.venzl@oracle.com

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/startDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/startDB.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1982-2021 Oracle and/or its affiliates. All rights reserved.
 #
 # Since: November, 2016
 # Author: gerald.venzl@oracle.com


### PR DESCRIPTION
This PR includes the following security fixes:

- Resolution of the issues that came up in the static check analysis of the scripts (i.e. using double quotes to prevent globbing, using $() instead of legacy backtick notation etc).
- Using DBCA `-autoGeneratePasswords` option for generating passwords instead of openssl (in case the user does not provide password using ORACLE_PWD env var).
- Using `umask` for masking file permissions before creating temporary dbca response file.
- Not echoing passwords anywhere.

Additionally, updated the year in copyright section of the scripts.