### PR TITLE
Fix: Oracle XE 18c image build appears to hang

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/18.4.0/Dockerfile.xe
+++ b/OracleDatabase/SingleInstance/dockerfiles/18.4.0/Dockerfile.xe
@@ -58,9 +58,9 @@ RUN chmod ug+x $INSTALL_DIR/*.sh && \
     sync && \
     $INSTALL_DIR/$CHECK_SPACE_FILE && \
     cd $INSTALL_DIR && \
-    yum -y install openssl oracle-database-preinstall-18c && \
+    yum -y install expect openssl oracle-database-preinstall-18c && \
     sed -i -e 's/\(oracle\s\+hard\s\+nofile\)/# \1/' /etc/security/limits.d/oracle-database-preinstall-18c.conf && \
-    yum -y localinstall $INSTALL_FILE_1 && \
+    unbuffer yum -y localinstall $INSTALL_FILE_1 && \
     rm -rf /var/cache/yum && \
     rm -rf /var/tmp/yum-* && \
     mkdir -p $ORACLE_BASE/scripts/setup && \

--- a/OracleDatabase/SingleInstance/dockerfiles/18.4.0/Dockerfile.xe
+++ b/OracleDatabase/SingleInstance/dockerfiles/18.4.0/Dockerfile.xe
@@ -1,6 +1,6 @@
 # LICENSE UPL 1.0
 #
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 #
 # ORACLE DOCKERFILES PROJECT
 # --------------------------
@@ -60,7 +60,8 @@ RUN chmod ug+x $INSTALL_DIR/*.sh && \
     cd $INSTALL_DIR && \
     yum -y install expect openssl oracle-database-preinstall-18c && \
     sed -i -e 's/\(oracle\s\+hard\s\+nofile\)/# \1/' /etc/security/limits.d/oracle-database-preinstall-18c.conf && \
-    unbuffer yum -y localinstall $INSTALL_FILE_1 && \
+    unbuffer yum -y install $INSTALL_FILE_1 && \
+    yum -y remove expect && \
     rm -rf /var/cache/yum && \
     rm -rf /var/tmp/yum-* && \
     mkdir -p $ORACLE_BASE/scripts/setup && \


### PR DESCRIPTION
close #1797 

Using `unbuffer` utility from `expect` package to show progress when 18c XE image is being built, so it does not appear to be hanged.

Signed-off-by: abhisbyk <abhishek.by.kumar@oracle.com>