### PR TITLE
fix for issues 2077,2051 and build script fixes

### DIFF
--- a/OracleSOASuite/dockerfiles/12.2.1.4/Dockerfile
+++ b/OracleSOASuite/dockerfiles/12.2.1.4/Dockerfile
@@ -104,7 +104,8 @@ LABEL maintainer="Sambasiva Battagiri <sambasiva.battagiri@oracle.com>"
 # Install the required packages
 # -----------------------------
 USER root
-RUN yum install -y hostname ant && \
+ENV PATH=$PATH:/u01/oracle/container-scripts:/u01/oracle/oracle_common/modules/thirdparty/org.apache.ant/1.10.5.0.0/apache-ant-1.10.5/bin
+RUN yum install -y hostname && \
     rm -rf /var/cache/yum
 
 COPY --from=builder --chown=oracle:root /u01 /u01

--- a/OracleSOASuite/dockerfiles/12.2.1.4/README.md
+++ b/OracleSOASuite/dockerfiles/12.2.1.4/README.md
@@ -179,7 +179,7 @@ ADMIN_PASSWORD=<admin_password>
 DOMAIN_NAME=soainfra
 DOMAIN_TYPE=<soa/osb/soaosb>
 ADMIN_HOST=<Administration Server hostname>
-ADMIN_PORT=<port number where Administration Server is running>
+ADMIN_PORT=<Node port number mapping Administration Server container port `7001`>
 PERSISTENCE_STORE=<jdbc | file>
 ```
 >IMPORTANT: `DOMAIN_TYPE` must be carefully chosen and specified depending on the use case. It can't be changed once you proceed.
@@ -202,8 +202,6 @@ ADMIN_PORT=7001
 PERSISTENCE_STORE=jdbc
 ```
 If `PERSISTENCE_STORE` is not specified, the default value is `jdbc`. When `PERSISTENCE_STORE=jdbc`, a JDBC persistence store will be configured for all servers for TLOG + SOAJMS/UMSJMS servers. If `PERSISTENCE_STORE=file`, file-based persistence stores will be used instead.
-
-> IMPORTANT: In the Administration Server's environment variables file, the `ADMIN_PORT` value must be `7001`.
 
 To start a Docker container with a SOA domain and the WebLogic Server Administration Server, use the `docker run` command and pass the `adminserver.env.list` file.
 
@@ -236,13 +234,16 @@ Create an environment variables file specific to each Managed Server in the clus
 MANAGED_SERVER=<Managed Server name, either soa_server1 or soa_server2>
 DOMAIN_NAME=soainfra
 ADMIN_HOST=<Administration Server hostname>
-ADMIN_PORT=<port number where Administration Server is running>
+ADMIN_PORT=<Node port number mapping Administration Server container port `7001`>
 ADMIN_PASSWORD=<admin_password>
 MANAGED_SERVER_CONTAINER=true
-MANAGEDSERVER_PORT=<port number where Managed Server is running>
+MANAGEDSERVER_PORT=<Container port number where Managed Server is running>
 ```
 
->IMPORTANT: In the Managed Servers environment variables file, the `MANAGED_SERVER` value must be `soa_server1` or `soa_server2` for the  `soa` and `soaosb` domain type. Also, `MANAGEDSERVER_PORT` must be `8001` for `soa_server1` or `8002` for `soa_server2`.
+>IMPORTANT: In the Managed Servers environment variables file
+> - `MANAGED_SERVER` value must be `soa_server1` or `soa_server2` for the  `soa` and `soaosb` domain type.
+> - `MANAGEDSERVER_PORT` must be `8001` for `soa_server1` or `8002` for `soa_server2`.
+> - `ADMIN_PORT` must match the **node** port mapping the Administration Server container port `7001`.
 
 Example for `soaserver1.env.list`:
 ``` bash
@@ -302,13 +303,16 @@ Create an environment variables file specific to each Managed Server in the clus
 MANAGED_SERVER=<Managed Server name, either osb_server1 or osb_server2>
 DOMAIN_NAME=soainfra
 ADMIN_HOST=<Administration Server hostname>
-ADMIN_PORT=<port number where Administration Server is running>
+ADMIN_PORT=<Node port number mapping Administration Server container port `7001`>
 ADMIN_PASSWORD=<admin_password>
 MANAGED_SERVER_CONTAINER=true
-MANAGEDSERVER_PORT=<port number where Managed Server is running>
+MANAGEDSERVER_PORT=<Container port number where Managed Server is running>
 ```
 
->IMPORTANT: In the Managed Servers environment variables file the `MANAGED_SERVER` value must be `osb_server1` or `osb_server2` for the `osb` and `soaosb` domain type. Also, `MANAGEDSERVER_PORT` must be `9001` for `osb_server1` or `9002` for `osb_server2`.
+>IMPORTANT: In the Managed Servers environment variables file
+> - `MANAGED_SERVER` value must be `osb_server1` or `osb_server2` for the  `osb` and `soaosb` domain type.
+> - `MANAGEDSERVER_PORT` must be `9001` for `osb_server1` or `9002` for `osb_server2`.
+> - `ADMIN_PORT` must match the **node** port mapping the Administration Server container port `7001`.
 
 Example for `osbserver1.env.list`:
 ``` bash

--- a/OracleSOASuite/dockerfiles/12.2.1.4/container-scripts/createDomainAndStart.sh
+++ b/OracleSOASuite/dockerfiles/12.2.1.4/container-scripts/createDomainAndStart.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 #
-# Copyright (c) 2014, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2014, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 #
@@ -71,8 +71,8 @@ updateListenAddress() {
   mkdir -p ${DOMAIN_HOME}/logs
 
   export thehost=`hostname -I`
-  echo "INFO: Updating the listen address - ${thehost} ${ADMIN_HOST}"
-  cmd="/u01/oracle/oracle_common/common/bin/wlst.sh -skipWLSModuleScanning /u01/oracle/container-scripts/updListenAddress.py $vol_name ${thehost} AdminServer ${ADMIN_HOST}"
+  echo "INFO: Updating the listen address - ${thehost}"
+  cmd="/u01/oracle/oracle_common/common/bin/wlst.sh -skipWLSModuleScanning /u01/oracle/container-scripts/updListenAddress.py $vol_name ${thehost} AdminServer"
   echo ${cmd}
   ${cmd} > ${DOMAIN_HOME}/logs/aslisten.log 2>&1
 }

--- a/OracleSOASuite/dockerfiles/12.2.1.4/container-scripts/get_healthcheck_url.sh
+++ b/OracleSOASuite/dockerfiles/12.2.1.4/container-scripts/get_healthcheck_url.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 #
-#Copyright (c) 2020, Oracle and/or its affiliates.
+#Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 #
 #Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 if [ "$MANAGED_SERVER_CONTAINER" = "true" ] ; then
-   echo "http://{$ADMIN_HOST:$MANAGEDSERVER_PORT}/weblogic/ready" ; 
+   echo "http://$(hostname -i):${MANAGEDSERVER_PORT}/weblogic/ready" ;
 else 
-   echo "http://{$ADMIN_HOST:$ADMIN_PORT}/weblogic/ready" ;
+   echo "http://$(hostname -i):7001/weblogic/ready" ;
 fi
 
 

--- a/OracleSOASuite/dockerfiles/12.2.1.4/container-scripts/soaExtFun.sh
+++ b/OracleSOASuite/dockerfiles/12.2.1.4/container-scripts/soaExtFun.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020 Oracle and/or its affiliates.
+# Copyright (c) 2020, Oracle and/or its affiliates.
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 #

--- a/OracleSOASuite/dockerfiles/12.2.1.4/container-scripts/startAS.sh
+++ b/OracleSOASuite/dockerfiles/12.2.1.4/container-scripts/startAS.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2016, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2016, 2020, Oracle and/or its affiliates.
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 #

--- a/OracleSOASuite/dockerfiles/12.2.1.4/container-scripts/startMS.sh
+++ b/OracleSOASuite/dockerfiles/12.2.1.4/container-scripts/startMS.sh
@@ -63,8 +63,8 @@ LOGFILE=${LOGDIR}/ms.log
 mkdir -p ${LOGDIR}
 
 export thehost=`hostname -I`
-echo "INFO: Updating the listen address - ${thehost} ${ADMIN_HOST}"
-/u01/oracle/oracle_common/common/bin/wlst.sh -skipWLSModuleScanning /u01/oracle/container-scripts/updListenAddress.py $vol_name $thehost ${MANAGED_SERVER} ${ADMIN_HOST} > ${LOGDIR}/mslisten.log 2>&1
+echo "INFO: Updating the listen address - ${thehost}"
+/u01/oracle/oracle_common/common/bin/wlst.sh -skipWLSModuleScanning /u01/oracle/container-scripts/updListenAddress.py $vol_name $thehost ${MANAGED_SERVER} > ${LOGDIR}/mslisten.log 2>&1
 
 # Set boot.properties
 #

--- a/OracleSOASuite/dockerfiles/12.2.1.4/container-scripts/updListenAddress.py
+++ b/OracleSOASuite/dockerfiles/12.2.1.4/container-scripts/updListenAddress.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
 #
-# Copyright (c) 2016-2017 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2021, Oracle and/or its affiliates.
 #
-# Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # Updates the listen address for managed server with the IP address of the host.
 # ==============================================
@@ -21,7 +21,6 @@ domain_root = os.environ.get("DOMAIN_ROOT", "/u01/oracle/user_projects/domains")
 vol_name=sys.argv[1]
 manserver_host=sys.argv[2]
 server=sys.argv[3]
-exthost=sys.argv[4]
 
 #
 # Setting domain path
@@ -39,7 +38,6 @@ readDomain(domain_path)
 cd('/')
 cd('/Server/'+server)
 cmo.setListenAddress(manserver_host)
-cmo.setExternalDNSName(exthost)
 
 # Creating domain
 # ===============

--- a/OracleSOASuite/dockerfiles/12.2.1.4/install/b2b.response
+++ b/OracleSOASuite/dockerfiles/12.2.1.4/install/b2b.response
@@ -1,6 +1,8 @@
 # LICENSE UPL 1.0
 #
 # Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 [ENGINE]
 
 #DO NOT CHANGE THIS.

--- a/OracleSOASuite/dockerfiles/12.2.1.4/install/osb.response
+++ b/OracleSOASuite/dockerfiles/12.2.1.4/install/osb.response
@@ -1,6 +1,6 @@
-# LICENSE UPL 1.0
 #
-# Copyright (c) 2016-2017 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 [ENGINE]
 Response File Version=1.0.0.0.0

--- a/OracleSOASuite/dockerfiles/12.2.1.4/install/soasuite.response
+++ b/OracleSOASuite/dockerfiles/12.2.1.4/install/soasuite.response
@@ -1,6 +1,7 @@
 # LICENSE UPL 1.0
 #
-# Copyright (c) 2016-2017 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 [ENGINE]
 
 #DO NOT CHANGE THIS.

--- a/OracleSOASuite/dockerfiles/buildDockerImage.sh
+++ b/OracleSOASuite/dockerfiles/buildDockerImage.sh
@@ -24,7 +24,7 @@ LICENSE Universal Permissive License (UPL), Version 1.0
 Copyright (c) 2016-2017: Oracle and/or its affiliates.
 
 EOF
-exit 0
+exit $1
 }
 
 #=============================================================
@@ -79,7 +79,7 @@ SKIPMD5=0
 while getopts "hsv:" optname; do
   case "$optname" in
     "h")
-      usage
+      usage 0
       ;;
     "s")
       SKIPMD5=1
@@ -89,7 +89,8 @@ while getopts "hsv:" optname; do
       ;;
     *)
       # Should not occur
-      echo "ERROR: Invalid argument. buildDockerImage.sh"
+      echo "ERROR: Invalid argument for buildDockerImage.sh"
+      usage 1
       ;;
   esac
 done
@@ -153,12 +154,14 @@ ${buildCmd} || {
   echo "ERROR: There was an error building the image."
   exit 1
 }
+status=$?
+
 BUILD_END=$(date '+%s')
 BUILD_ELAPSED=`expr $BUILD_END - $BUILD_START`
 
 echo ""
 
-if [ $? -eq 0 ]; then
+if [ ${status} -eq 0 ]; then
   cat << EOF
 INFO: Oracle SOA suite Docker Image for version: $VERSION
       is ready to be extended.


### PR DESCRIPTION
Hi,

This pull request contains the below changes for Oracle SOA Suite docker image scripts. 
Kindly review and merge. 

- Fix for the github issue 2077 (https://github.com/oracle/docker-images/issues/2077) - SOA servers port mapping related changes
- Fix for the github issue 2051 (https://github.com/oracle/docker-images/issues/2051) - Healthcheck related changes
- Copyright corrections
- SOA Docker image build script changes.

Thanks
Samba