### PR TITLE
Fix Node.js 14 Dockerfile

### DIFF
--- a/OracleLinuxDevelopers/oraclelinux7/nodejs/14/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/nodejs/14/Dockerfile
@@ -6,4 +6,4 @@ RUN yum -y install oracle-nodejs-release-el7 && \
     yum -y install nodejs && \
     rm -rf /var/cache/yum/*
 
-CMD ["/bin/node", "-v"
+CMD ["/bin/node", "-v"]


### PR DESCRIPTION
There was a missing closing bracket for the command in the Node.js 14 Dockerfile.