### PR TITLE
feat: add gcc-toolset-11 toolchain and perftool images.

### DIFF
--- a/.github/workflows/build-and-push-dev-images.yml
+++ b/.github/workflows/build-and-push-dev-images.yml
@@ -29,14 +29,14 @@ on:
         required: false
       lang:
         description: List of languages to build
-        default: 'compat, golang, nginx, nodejs, php, python, ruby'
+        default: 'compat, gcc-toolset, golang, nginx, nodejs, php, python, ruby'
         required: false
 
 # Default values for the builds triggered by the push event
 # Note: the "compat" image should *not* be in this list
 env:
   ol: 'oraclelinux7, oraclelinux8'
-  lang: 'golang, nodejs, nginx, php, python, ruby'
+  lang: 'gcc-toolset, golang, nodejs, nginx, php, python, ruby'
 
 jobs:
   prepare:

--- a/OracleLinuxDevelopers/oraclelinux8/gcc-toolset/11-perftools/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/gcc-toolset/11-perftools/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+FROM ghcr.io/oracle/oraclelinux:8
+
+RUN dnf -y install gcc-toolset-11-systemtap \
+                   gcc-toolset-11-valgrind \
+                   gcc-toolset-11-elfutils \
+                   gcc-toolset-11-dyninst && \
+    dnf -y clean all
+
+# Copy the entrypoint script and ensure it's executable
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+
+# Enable the SCL via entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]
+
+# Set the default CMD to start an interactive bash shell
+CMD [ "interactive-shell" ]

--- a/OracleLinuxDevelopers/oraclelinux8/gcc-toolset/11-perftools/entrypoint.sh
+++ b/OracleLinuxDevelopers/oraclelinux8/gcc-toolset/11-perftools/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+if [ "$1" = "interactive-shell" ]; then
+    scl enable gcc-toolset-11 -- bash
+else
+    scl enable gcc-toolset-11 -- bash -c "$@"
+fi

--- a/OracleLinuxDevelopers/oraclelinux8/gcc-toolset/11-toolchain/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/gcc-toolset/11-toolchain/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+FROM ghcr.io/oracle/oraclelinux:8
+
+RUN dnf -y install gcc-toolset-11-gcc \
+                   gcc-toolset-11-gcc-c++ \
+                   gcc-toolset-11-gcc-gfortran \
+                   gcc-toolset-11-gdb && \
+    dnf -y clean all
+
+# Copy the entrypoint script and ensure it's executable
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+
+# Enable the SCL via entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]
+
+# Set the default CMD to start an interactive bash shell
+CMD [ "interactive-shell" ]

--- a/OracleLinuxDevelopers/oraclelinux8/gcc-toolset/11-toolchain/entrypoint.sh
+++ b/OracleLinuxDevelopers/oraclelinux8/gcc-toolset/11-toolchain/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+if [ "$1" = "interactive-shell" ]; then
+    scl enable gcc-toolset-11 -- bash
+else
+    scl enable gcc-toolset-11 -- bash -c "$@"
+fi


### PR DESCRIPTION
Test builds of the images are available via my fork at https://github.com/Djelibeybi/docker-images/pkgs/container/oraclelinux8-gcc-toolset. 

Resolves #2185.

Signed-off-by: Avi Miller <avi.miller@oracle.com>