### PR TITLE
Removed ORACLE_SID from env variables in k8s extension

### DIFF
--- a/OracleDatabase/SingleInstance/extensions/k8s/Dockerfile
+++ b/OracleDatabase/SingleInstance/extensions/k8s/Dockerfile
@@ -25,8 +25,7 @@ ARG EXTENSION_NAME=k8s
 
 # Environment variables required for this build (do NOT change)
 # -------------------------------------------------------------
-ENV ORACLE_SID=ORCLCDB \
-    STARTUP_FILE=startUp.sh \
+ENV STARTUP_FILE=startUp.sh \
     SHUT_DB_FILE=shutDown.sh \
     LOCKING_SCRIPT=lock.py \
     SWAP_LOCK_FILE=swapLocks.sh \


### PR DESCRIPTION
Extending the image for prebuilt db with a k8s extended image is defaulting ORACLE_SID to ORCLCDB
So removed it as env