### PR TITLE
NOSQL - Update kv version and doc

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 /.github/*.yml             @Djelibeybi
 /.github/workflows         @Djelibeybi @AmedeeBulle
 /GraalVM/                  @mzachh
-/NoSQL/                    @Djelibeybi
+/NoSQL/                    @dario-vega @mikebrey
 /OracleAccessManagement/   @pratdash-orcl
 /OracleBI/                 @sjvp
 /OracleCoherence/          @thegridman

--- a/NoSQL/19.5-ce/Dockerfile
+++ b/NoSQL/19.5-ce/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Oracle and/or its affiliates.u
+# Copyright (c) 2022 Oracle and/or its affiliates.u
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 #
 FROM openjdk:14-oraclelinux7

--- a/NoSQL/19.5-ce/Dockerfile
+++ b/NoSQL/19.5-ce/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Oracle and/or its affiliates.u
+# Copyright (c) 2020, 2022 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 #
 FROM openjdk:14-oraclelinux7

--- a/NoSQL/19.5-ce/Dockerfile
+++ b/NoSQL/19.5-ce/Dockerfile
@@ -5,8 +5,8 @@ FROM openjdk:14-oraclelinux7
 
 LABEL org.opencontainers.image.source = "https://github.com/oracle/docker-images"
 
-ENV VERSION="19.5.19" \
-    KVHOME=/kv-19.5.19 \
+ENV VERSION="19.5.25" \
+    KVHOME=/kv-19.5.25 \
     PACKAGE="kv-ce" \
     EXTENSION="zip" \
     BASE_URL="http://download.oracle.com/otn-pub/otn_software/nosql-database/" \

--- a/NoSQL/README.md
+++ b/NoSQL/README.md
@@ -112,18 +112,14 @@ The Oracle NoSQL Database Proxy is a server that accepts requests from Oracle No
 The Oracle NoSQL Database drivers can be used to access either the Oracle NoSQL Database Cloud Service or an on-premises installation via the Oracle NoSQL Database Proxy. 
 Since the drivers and APIs are identical, applications can be moved between these two options. 
 
-You can deploy a docker Oracle NoSQL Database store first for a prototype project, and move forward to Oracle NoSQL Database cluster for a production project.
+You can deploy a container-based Oracle NoSQL Database store first for a prototype project, and move forward to Oracle NoSQL Database cluster for a production project.
 
-Here is a snippet showing the connection from a Node.js program, the HTTP proxy is automatically started in this docker image
+Here is a snippet showing the connection from a Node.js program.
 
 ````
-/*
-* EDIT: if the endpoint does not reflect how the Proxy
-* Server has been started, modify it accordingly.
-*/
 return new NoSQLClient({
   serviceType: ServiceType.KVSTORE,
-  endpoint: 'docker-host-container-nosql:8081'
+  endpoint: 'nosql-container-host:8080'
 });
 ````
 

--- a/NoSQL/README.md
+++ b/NoSQL/README.md
@@ -4,7 +4,7 @@ Sample Docker build files to facilitate installation and environment setup for
 DevOps users. For more information about Oracle NoSQL Database please see the
 [Oracle NoSQL Database documentation](https://docs.oracle.com/en/database/other-databases/nosql-database/index.html).
 
-This project offers sample Dockerfiles for:
+This project offers sample container image configuration files for:
 
 * [Oracle NoSQL Database Community Edition](ce/Dockerfile)
 
@@ -33,13 +33,13 @@ you are using Oracle NoSQL Database Enterprise Edition, please use the
 appropriate image name.
 
 Start up KVLite in a Docker container. You must give it a name. Startup of
-KVLite is the default `CMD` of the Docker image:
+KVLite is the default `CMD` of the image:
 
 ```shell
-docker run --name=kvlite --env KV_PROXY_PORT=8080 -p 8080:8080 oracle/nosql:20.3
+docker run -d --name=kvlite --env KV_PROXY_PORT=8080 -p 8080:8080 oracle/nosql:20.3
 ```
 
-In a second shell, run a second Docker container to ping the kvlite store
+In a second shell, run a second container to ping the kvlite store
 instance:
 
 ```shell
@@ -117,14 +117,14 @@ You can deploy a docker Oracle NoSQL Database store first for a prototype projec
 Here is a snippet showing the connection from a Node.js program, the HTTP proxy is automatically started in this docker image
 
 ````
-    /*
-     * EDIT: if the endpoint does not reflect how the Proxy
-     * Server has been started, modify it accordingly.
-     */
-    return new NoSQLClient({
-        serviceType: ServiceType.KVSTORE,
-        endpoint: 'docker-host-container-nosql:8081'
-    });
+/*
+* EDIT: if the endpoint does not reflect how the Proxy
+* Server has been started, modify it accordingly.
+*/
+return new NoSQLClient({
+  serviceType: ServiceType.KVSTORE,
+  endpoint: 'docker-host-container-nosql:8081'
+});
 ````
 
 ## More information

--- a/NoSQL/README.md
+++ b/NoSQL/README.md
@@ -82,7 +82,7 @@ $ docker run --rm -ti --link kvlite:store oracle/nosql:20.3 \
 ```
 
 You can also use the Oracle SQL Shell Command Line Interface (CLI). Start the
-following container (keep container `kvlite` running):
+following container:
 
 ```shell
 $ docker run --rm -ti --link kvlite:store oracle/nosql:20.3 \

--- a/NoSQL/README.md
+++ b/NoSQL/README.md
@@ -51,7 +51,7 @@ Note the required use of `--link` for proper hostname check (actual KVLite
 container is named `kvlite`; alias is `store`).
 
 You can also use the Oracle NoSQL Command Line Interface (CLI). Start the
-following container (keep container `kvlite` running):
+following container:
 
 ```shell
 

--- a/NoSQL/ce/Dockerfile
+++ b/NoSQL/ce/Dockerfile
@@ -22,10 +22,9 @@ RUN curl -OLs  $DOWNLOAD_LINK  && \
 
 WORKDIR "kv-$KV_VERSION"
 
-RUN echo "KVHOST=\`hostname\`" >start-kvlite.sh  && \
-    echo "java -jar lib/kvstore.jar kvlite  -secure-config disable -root /kvroot &" >>start-kvlite.sh && \
-    echo "java -jar lib/httpproxy.jar -helperHosts \$KVHOST:5000 -storeName kvstore -httpPort \$KV_PROXY_PORT -verbose true" >>start-kvlite.sh
+COPY start-kvlite.sh .
+RUN chmod +x start-kvlite.sh
 
 VOLUME ["/kvroot"]
 
-CMD sh start-kvlite.sh
+CMD ["bash", "-c", "./start-kvlite.sh"]

--- a/NoSQL/ce/Dockerfile
+++ b/NoSQL/ce/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Oracle and/or its affiliates
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 #
-FROM openjdk:14-oraclelinux8
+FROM openjdk:17-oraclelinux8
 
 LABEL org.opencontainers.image.source = "https://github.com/oracle/docker-images"
 
@@ -17,7 +17,8 @@ RUN microdnf install unzip hostname && \
     microdnf clean all
 
 RUN curl -OLs  $DOWNLOAD_LINK  && \
-    unzip $DOWNLOAD_FILE $UNZIPPED_ONLY_LIB/*
+    unzip $DOWNLOAD_FILE $UNZIPPED_ONLY_LIB/* && \
+    rm -f $DOWNLOAD_FILE
 
 WORKDIR "kv-$KV_VERSION"
 

--- a/NoSQL/ce/Dockerfile
+++ b/NoSQL/ce/Dockerfile
@@ -1,0 +1,31 @@
+# Copyright (c) 2021 Oracle and/or its affiliates
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+#
+FROM openjdk:14-oraclelinux8
+
+LABEL org.opencontainers.image.source = "https://github.com/oracle/docker-images"
+
+ARG KV_VERSION=20.3.19
+ARG DOWNLOAD_ROOT=http://download.oracle.com/otn-pub/otn_software/nosql-database
+ARG DOWNLOAD_FILE=kv-ce-$KV_VERSION.zip
+ARG DOWNLOAD_LINK=$DOWNLOAD_ROOT/$DOWNLOAD_FILE
+ARG UNZIPPED_ONLY_LIB=kv-$KV_VERSION/lib
+
+ENV KV_PROXY_PORT 8080
+
+RUN microdnf install unzip && \
+    microdnf install hostname &&\
+    microdnf clean all
+
+RUN curl -OLs  $DOWNLOAD_LINK  && \
+    unzip $DOWNLOAD_FILE $UNZIPPED_ONLY_LIB/*
+
+WORKDIR "kv-$KV_VERSION"
+
+RUN echo "KVHOST=\`hostname\`" >start-kvlite.sh  && \
+    echo "java -jar lib/kvstore.jar kvlite  -secure-config disable -root /kvroot &" >>start-kvlite.sh && \
+    echo "java -jar lib/httpproxy.jar -helperHosts \$KVHOST:5000 -storeName kvstore -httpPort \$KV_PROXY_PORT -verbose true" >>start-kvlite.sh
+
+VOLUME ["/kvroot"]
+
+CMD sh start-kvlite.sh

--- a/NoSQL/ce/Dockerfile
+++ b/NoSQL/ce/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2022 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 #
 FROM openjdk:17-oraclelinux8

--- a/NoSQL/ce/Dockerfile
+++ b/NoSQL/ce/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Oracle and/or its affiliates
+# Copyright (c) 2021, 2022 Oracle and/or its affiliates
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 #
 FROM openjdk:17-oraclelinux8

--- a/NoSQL/ce/Dockerfile
+++ b/NoSQL/ce/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Oracle and/or its affiliates
+# Copyright (c) 2022 Oracle and/or its affiliates
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 #
 FROM openjdk:14-oraclelinux8
@@ -13,8 +13,7 @@ ARG UNZIPPED_ONLY_LIB=kv-$KV_VERSION/lib
 
 ENV KV_PROXY_PORT 8080
 
-RUN microdnf install unzip && \
-    microdnf install hostname &&\
+RUN microdnf install unzip hostname && \
     microdnf clean all
 
 RUN curl -OLs  $DOWNLOAD_LINK  && \

--- a/NoSQL/ce/Dockerfile
+++ b/NoSQL/ce/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, 2022 Oracle and/or its affiliates
+# Copyright (c) 2021, 2022 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 #
 FROM openjdk:17-oraclelinux8

--- a/NoSQL/ce/start-kvlite.sh
+++ b/NoSQL/ce/start-kvlite.sh
@@ -1,0 +1,7 @@
+# Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+#
+
+KVHOST=`hostname`
+java -jar lib/kvstore.jar kvlite  -secure-config disable -root /kvroot &
+java -jar lib/httpproxy.jar -helperHosts $KVHOST:5000 -storeName kvstore -httpPort $KV_PROXY_PORT -verbose true

--- a/NoSQL/ce/start-kvlite.sh
+++ b/NoSQL/ce/start-kvlite.sh
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2022 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 #
 


### PR DESCRIPTION
This PR updates the Oracle NoSQL Dockerfile to align with the latest version and bundles. 

- Currently, this GitHub uses the bundle kv-ce-19.5.19.zip to build the docker image. Our last bundle for this version is kv-ce-19.5.25.zip. 
- We created a new directory ce. It contains the Dockerfile for the latest Oracle NoSQL version, 20.3.
- In this new version, we are also adding HTTP PROXY support
- I also explicitly set the base image to the Oracle Linux-based 8 variant of the official OpenJDK image.

Finally, I updated CODEOWNERS to switch the owner of /NoSQL to @dario-vega and @mikebrey. 

Signed-off-by: Dario Vega dario.vega@oracle.com