### PR TITLE
Bugfix: listener fail to restart 21c XE

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/Dockerfile.xe
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/Dockerfile.xe
@@ -37,7 +37,7 @@ LABEL "provider"="Oracle"                                               \
 # -------------------------------------------------------------
 ENV ORACLE_BASE=/opt/oracle \
     ORACLE_HOME=/opt/oracle/product/21c/dbhomeXE \
-    ORACLE_BASE_HOME=/opt/oracle/product/21c/dbhomeXE \
+    ORACLE_BASE_HOME=/opt/oracle/homes/OraDBHome21cXE \
     ORACLE_SID=XE \
     INSTALL_FILE_1="https://download.oracle.com/otn-pub/otn_software/db-express/oracle-database-xe-21c-1.0-1.ol7.x86_64.rpm" \
     RUN_FILE="runOracle.sh" \

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
@@ -64,7 +64,7 @@ SID_LIST_LISTENER =
   (SID_LIST =
     (SID_DESC =
       (SID_NAME = PLSExtProc)
-      (ORACLE_HOME = $ORACLE_BASE_HOME)
+      (ORACLE_HOME = $ORACLE_HOME)
       (PROGRAM = extproc)
     )
   )


### PR DESCRIPTION
Close #2214 

Due to wrong location of ORACLE_BASE_HOME env var, listener was not able to restart either after snapshoting the image using `docker commit` and restarting it. This issue is fixed in this PR.

Signed-off-by: abhisbyk <abhishek.by.kumar@oracle.com>