### PR TITLE
Bugfix: Healthcheck fix for dg observer

### DIFF
--- a/OracleDatabase/SingleInstance/extensions/k8s/checkDBLockStatus.sh
+++ b/OracleDatabase/SingleInstance/extensions/k8s/checkDBLockStatus.sh
@@ -11,7 +11,10 @@
 
 export ORACLE_SID=${ORACLE_SID^^}
 
-if "$ORACLE_BASE/$LOCKING_SCRIPT" --check --file "$ORACLE_BASE/oradata/.${ORACLE_SID}.create_lck"; then
+if [ "$DG_OBSERVER_ONLY" = "true" ]; then
+  "$ORACLE_BASE/$CHECK_DB_FILE"
+  exit $?
+elif "$ORACLE_BASE/$LOCKING_SCRIPT" --check --file "$ORACLE_BASE/oradata/.${ORACLE_SID}.create_lck"; then
   exit 1  # create lock held, DB is still initializing
 elif ! "$ORACLE_BASE/$LOCKING_SCRIPT" --check --file "$ORACLE_BASE/oradata/.${ORACLE_SID}.exist_lck"; then
   exit 1 # exist lock not held, DB is still initializing

--- a/OracleDatabase/SingleInstance/extensions/k8s/runOracle.sh
+++ b/OracleDatabase/SingleInstance/extensions/k8s/runOracle.sh
@@ -17,4 +17,6 @@
 
 export ORACLE_SID=${ORACLE_SID^^}
 
-"$ORACLE_BASE/$LOCKING_SCRIPT" --acquire --file "$ORACLE_BASE/oradata/.${ORACLE_SID}.create_lck" --block
+if [ "$DG_OBSERVER_ONLY" = "false" ]; then
+    "$ORACLE_BASE/$LOCKING_SCRIPT" --acquire --file "$ORACLE_BASE/oradata/.${ORACLE_SID}.create_lck" --block
+fi


### PR DESCRIPTION
Close #2221 

After building k8s extension, health-check was failing for DG Observer. Fixed in this PR.

Signed-off-by: abhisbyk <abhishek.by.kumar@oracle.com>