### PR TITLE
fix(developer):  use env to run command line.

### DIFF
--- a/OracleLinuxDevelopers/oraclelinux8/gcc-toolset/11-perftools/entrypoint.sh
+++ b/OracleLinuxDevelopers/oraclelinux8/gcc-toolset/11-perftools/entrypoint.sh
@@ -5,5 +5,5 @@
 if [ "$1" = "interactive-shell" ]; then
     scl enable gcc-toolset-11 -- bash
 else
-    scl enable gcc-toolset-11 -- bash -c "$@"
+    scl enable gcc-toolset-11 -- env -- "$@"
 fi

--- a/OracleLinuxDevelopers/oraclelinux8/gcc-toolset/11-toolchain/entrypoint.sh
+++ b/OracleLinuxDevelopers/oraclelinux8/gcc-toolset/11-toolchain/entrypoint.sh
@@ -5,5 +5,5 @@
 if [ "$1" = "interactive-shell" ]; then
     scl enable gcc-toolset-11 -- bash
 else
-    scl enable gcc-toolset-11 -- bash -c "$@"
+    scl enable gcc-toolset-11 -- env -- "$@"
 fi


### PR DESCRIPTION
Use `env` instead of `bash -c` to run the command line.
`bash` isn't strictly necessary and it is easier to pass argument through `env` 

An alternative would be to use `bash -c "$(printf '%q ' "$@")"` but it is more convoluted and doesn't bring anything...

Fixes #2229

Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>