### PR TITLE
fix: install the correct version of Python

### DIFF
--- a/OracleLinuxDevelopers/oraclelinux8/python/3.8/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/python/3.8/Dockerfile
@@ -5,8 +5,9 @@
 # so that any automation that relied on microdnf continues to work
 FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
-RUN dnf -y module enable python38 && \
-    dnf -y install python36 python3-pip python3-setuptools && \
+RUN dnf -y module disable python36 && \
+    dnf -y module enable python38 && \
+    dnf -y install python38 python38-pip python38-setuptools python38-wheel && \
     rm -rf /var/cache/dnf
 
 CMD ["/bin/python3", "-V"]

--- a/OracleLinuxDevelopers/oraclelinux8/python/3.9/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/python/3.9/Dockerfile
@@ -5,8 +5,9 @@
 # so that any automation that relied on microdnf continues to work
 FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
-RUN dnf -y module enable python39 && \
-    dnf -y install python36 python3-pip python3-setuptools && \
+RUN dnf -y module disable python36 && \
+    dnf -y module enable python39 && \
+    dnf -y install python39 python39-pip python39-setuptools python39-wheel && \
     rm -rf /var/cache/dnf
 
 CMD ["/bin/python3", "-V"]


### PR DESCRIPTION
We should probably add some tests to check that the version of Python indicated by the tag is the version of Python actually installed in the image.

Signed-off-by: Avi Miller <avi.miller@oracle.com>