### PR TITLE
Add INIT_SGA_PERCENTAGE for smarter memory allocation

### DIFF
--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -70,8 +70,7 @@ To run your Oracle Database image use the `docker run` command as follows:
     -e ORACLE_SID=<your SID> \
     -e ORACLE_PDB=<your PDB name> \
     -e ORACLE_PWD=<your database passwords> \
-    -e INIT_SGA_SIZE=<your database SGA memory in MB> \
-    -e INIT_PGA_SIZE=<your database PGA memory in MB> \
+    -e INIT_SGA_PERCENTAGE=<memory percentage of your database SGA> \
     -e ORACLE_EDITION=<your database edition> \
     -e ORACLE_CHARACTERSET=<your character set> \
     -e ENABLE_ARCHIVELOG=true \
@@ -85,11 +84,9 @@ To run your Oracle Database image use the `docker run` command as follows:
        -e ORACLE_SID: The Oracle Database SID that should be used (default: ORCLCDB).
        -e ORACLE_PDB: The Oracle Database PDB name that should be used (default: ORCLPDB1).
        -e ORACLE_PWD: The Oracle Database SYS, SYSTEM and PDB_ADMIN password (default: auto generated).
-       -e INIT_SGA_SIZE:
-                      The total memory in MB that should be used for all SGA components (optional).
-                      Supported 19.3 onwards.
-       -e INIT_PGA_SIZE:
-                      The target aggregate PGA memory in MB that should be used for all server processes attached to the instance (optional).
+       -e INIT_SGA_PERCENTAGE:
+                      The total memory percentage that should be used for all SGA components (default: 75).
+                      The rest will automatically be set for the PGA, which is 25% by default.
                       Supported 19.3 onwards.
        -e ORACLE_EDITION:
                       The Oracle Database Edition (enterprise/standard).

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
@@ -56,6 +56,7 @@ ENV ORACLE_BASE=/opt/oracle \
     USER_SCRIPTS_FILE="runUserScripts.sh" \
     INSTALL_DB_BINARIES_FILE="installDBBinaries.sh" \
     RELINK_BINARY_FILE="relinkOracleBinary.sh" \
+    INIT_SGA_PERCENTAGE="75" \
     SLIMMING=$SLIMMING \
     ENABLE_ARCHIVELOG=false \
     ARCHIVELOG_DIR_NAME=archive_logs \

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
@@ -69,11 +69,11 @@ export ORACLE_PDB=${2:-ORCLPDB1}
 # Setting up file creation mask for newly created files (dbca response templates)
 umask 177
 
-# Checking if only one of INIT_SGA_SIZE & INIT_PGA_SIZE is provided by the user
-if [[ "${INIT_SGA_SIZE}" != "" && "${INIT_PGA_SIZE}" == "" ]] || [[ "${INIT_SGA_SIZE}" == "" && "${INIT_PGA_SIZE}" != "" ]]; then
-   echo "ERROR: Provide both the values, INIT_SGA_SIZE and INIT_PGA_SIZE or neither of them. Exiting.";
+# Checking if INIT_SGA_PERCENTAGE is valid
+if [[ -z "${INIT_SGA_PERCENTAGE}" || "${INIT_SGA_PERCENTAGE}" -gt 0 && "${INIT_SGA_PERCENTAGE}" -lt 100 ]]; then
+   echo "ERROR: INIT_SGA_PERCENTAGE must be greater than 0 and lower than 100. Exiting.";
    exit 1;
-fi;
+fi
 
 # If wallet is present for database credentials then prepare dbca options to use
 if [[ -n "${WALLET_DIR}" ]] && [[ -f $WALLET_DIR/ewallet.p12 ]]; then
@@ -163,20 +163,16 @@ else
 fi
 sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" "$ORACLE_BASE"/dbca.rsp
 
-# If both INIT_SGA_SIZE & INIT_PGA_SIZE aren't provided by user
-if [[ "${INIT_SGA_SIZE}" == "" && "${INIT_PGA_SIZE}" == "" ]]; then
-    # If there is greater than 8 CPUs default back to dbca memory calculations
-    # dbca will automatically pick 40% of available memory for Oracle DB
-    # The minimum of 2G is for small environments to guarantee that Oracle has enough memory to function
-    # However, bigger environment can and should use more of the available memory
-    # This is due to Github Issue #307
-    if [ "$(nproc)" -gt 8 ]; then
-        sed -i -e "s|totalMemory=2048||g" "$ORACLE_BASE"/dbca.rsp
-    fi;
-else
+# If INIT_SGA_PERCENTAGE isn't disabled by user we allocate based on its value
+# shellcheck disable=SC2153
+if [[ -n "${INIT_SGA_PERCENTAGE}" ]]; then
+    INIT_PGA_PERCENTAGE=$((100 - INIT_SGA_PERCENTAGE))
+    INIT_SGA_SIZE=$((ALLOCATED_MEMORY * INIT_SGA_PERCENTAGE / 100))
+    INIT_PGA_SIZE=$((ALLOCATED_MEMORY * INIT_PGA_PERCENTAGE / 100))
+
     sed -i -e "s|totalMemory=2048||g" "$ORACLE_BASE"/dbca.rsp
     sed -i -e "s|initParams=.*|&,sga_target=${INIT_SGA_SIZE}M,pga_aggregate_target=${INIT_PGA_SIZE}M|g" "$ORACLE_BASE"/dbca.rsp
-fi;
+fi
 
 # Create network related config files (sqlnet.ora, listener.ora)
 setupNetworkConfig;

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -118,12 +118,14 @@ else
    memory=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 fi
 
+export ALLOCATED_MEMORY=$((memory/1024/1024))
+
 # Github issue #219: Prevent integer overflow,
 # only check if memory digits are less than 11 (single GB range and below)
 if [[ ${memory} != "max" && ${#memory} -lt 11 && ${memory} -lt 2147483648 ]]; then
    echo "Error: The container doesn't have enough memory allocated."
    echo "A database container needs at least 2 GB of memory."
-   echo "You currently only have $((memory/1024/1024)) MB allocated to the container."
+   echo "You currently only have $ALLOCATED_MEMORY MB allocated to the container."
    exit 1;
 fi
 

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/Dockerfile
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/Dockerfile
@@ -57,6 +57,7 @@ ENV ORACLE_BASE=/opt/oracle \
     USER_SCRIPTS_FILE="runUserScripts.sh" \
     INSTALL_DB_BINARIES_FILE="installDBBinaries.sh" \
     RELINK_BINARY_FILE="relinkOracleBinary.sh" \
+    INIT_SGA_PERCENTAGE="75" \
     SLIMMING=$SLIMMING \
     ENABLE_ARCHIVELOG=false \
     ARCHIVELOG_DIR_NAME=archive_logs \

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/Dockerfile.xe
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/Dockerfile.xe
@@ -50,7 +50,8 @@ ENV ORACLE_BASE=/opt/oracle \
     SETUP_LINUX_FILE="setupLinuxEnv.sh" \
     INSTALL_DIR="$HOME/install" \
     ORACLE_DOCKER_INSTALL="true" \
-    CHECKPOINT_FILE_EXTN=".created"
+    CHECKPOINT_FILE_EXTN=".created" \
+    INIT_SGA_PERCENTAGE="75"
 
 # Use second ENV so that variable get substituted
 ENV PATH=$ORACLE_HOME/bin:$PATH

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/runOracle.sh
@@ -120,14 +120,16 @@ else
   memory=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 fi
 
+export ALLOCATED_MEMORY=$((memory/1024/1024))
+
 # Github issue #219: Prevent integer overflow,
-# only check if memory digits are less than 11 (single GB range and below) 
+# only check if memory digits are less than 11 (single GB range and below)
 if [[ ${memory} != "max" && ${#memory} -lt 11 && ${memory} -lt 2147483648 ]]; then
     echo "Error: The container doesn't have enough memory allocated."
     echo "A database container needs at least 2 GB of memory."
-    echo "You currently only have $((memory/1024/1024)) MB allocated to the container."
+    echo "You currently only have $ALLOCATED_MEMORY MB allocated to the container."
     exit 1;
-fi;
+fi
 
 # Check that hostname doesn't container any "_"
 # Github issue #711

--- a/OracleDatabase/SingleInstance/extensions/prebuiltdb/Dockerfile
+++ b/OracleDatabase/SingleInstance/extensions/prebuiltdb/Dockerfile
@@ -32,4 +32,6 @@ ENV ORACLE_PDB=${ORACLE_PDB:-ORCLPDB1}
 ENV ORACLE_PWD=${ORACLE_PWD}
 
 # Creating the database
-RUN $ORACLE_BASE/$RUN_FILE --nowait
+# We disable INIT_SGA_PERCENTAGE so that the prebuiltdb does not store data about
+# the memory of the builder inside of the container.
+RUN INIT_SGA_PERCENTAGE="" $ORACLE_BASE/$RUN_FILE --nowait


### PR DESCRIPTION
This is another take for the issue reported in https://github.com/oracle/docker-images/pull/2238.

I believe this is a much better and cleaner approach than the one used in https://github.com/oracle/docker-images/pull/1742, and that's why it replaces the existing one.

Furthermore, now the default configuration is smarter. If the user allocates 3GB for the container, it will be used. Previously, to make use of more than 2GB, the user would have
to:

1. Know that the default configuration is limited to 2GB. This is already something that most users would not know.
2. Allocate more than 2GB by tweaking INIT_SGA_SIZE and INIT_PGA_SIZE, which in turn would require some manual calculations as well (which is always error prone).

Some more caveats are:

3. The user would need to remember to re-do these calculations everytime the memory allocated for the container is changed.
