### PR TITLE
Automatically use the allocated memory

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
@@ -165,18 +165,11 @@ sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" "$ORACLE_BASE"/db
 
 # If both INIT_SGA_SIZE & INIT_PGA_SIZE aren't provided by user
 if [[ "${INIT_SGA_SIZE}" == "" && "${INIT_PGA_SIZE}" == "" ]]; then
-    # If there is greater than 8 CPUs default back to dbca memory calculations
-    # dbca will automatically pick 40% of available memory for Oracle DB
-    # The minimum of 2G is for small environments to guarantee that Oracle has enough memory to function
-    # However, bigger environment can and should use more of the available memory
-    # This is due to Github Issue #307
-    if [ "$(nproc)" -gt 8 ]; then
-        sed -i -e "s|totalMemory=2048||g" "$ORACLE_BASE"/dbca.rsp
-    fi;
+    sed -i -e "s|totalMemory=.*|totalMemory=${ALLOCATED_MEMORY?}|g" "$ORACLE_BASE"/dbca.rsp
 else
-    sed -i -e "s|totalMemory=2048||g" "$ORACLE_BASE"/dbca.rsp
+    sed -i -e "s|totalMemory=.*||g" "$ORACLE_BASE"/dbca.rsp
     sed -i -e "s|initParams=.*|&,sga_target=${INIT_SGA_SIZE}M,pga_aggregate_target=${INIT_PGA_SIZE}M|g" "$ORACLE_BASE"/dbca.rsp
-fi;
+fi
 
 # Create network related config files (sqlnet.ora, listener.ora)
 setupNetworkConfig;

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
@@ -271,18 +271,11 @@ fi
 
 # If both INIT_SGA_SIZE & INIT_PGA_SIZE aren't provided by user
 if [[ "${INIT_SGA_SIZE}" == "" && "${INIT_PGA_SIZE}" == "" ]]; then
-    # If there is greater than 8 CPUs default back to dbca memory calculations
-    # dbca will automatically pick 40% of available memory for Oracle DB
-    # The minimum of 2G is for small environments to guarantee that Oracle has enough memory to function
-    # However, bigger environment can and should use more of the available memory
-    # This is due to Github Issue #307
-    if [ "$(nproc)" -gt 8 ]; then
-        sed -i -e "s|totalMemory=2048||g" "$ORACLE_BASE"/dbca.rsp
-    fi;
+    sed -i -e "s|totalMemory=.*|totalMemory=${ALLOCATED_MEMORY?}|g" "$ORACLE_BASE"/dbca.rsp
 else
-    sed -i -e "s|totalMemory=2048||g" "$ORACLE_BASE"/dbca.rsp
+    sed -i -e "s|totalMemory=.*||g" "$ORACLE_BASE"/dbca.rsp
     sed -i -e "s|initParams=.*|&,sga_target=${INIT_SGA_SIZE}M,pga_aggregate_target=${INIT_PGA_SIZE}M|g" "$ORACLE_BASE"/dbca.rsp
-fi;
+fi
 
 # Create network related config files (sqlnet.ora, tnsnames.ora, listener.ora)
 setupNetworkConfig;

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/runOracle.sh
@@ -120,14 +120,16 @@ else
   memory=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 fi
 
+export ALLOCATED_MEMORY=$((memory/1024/1024))
+
 # Github issue #219: Prevent integer overflow,
-# only check if memory digits are less than 11 (single GB range and below) 
+# only check if memory digits are less than 11 (single GB range and below)
 if [[ ${memory} != "max" && ${#memory} -lt 11 && ${memory} -lt 2147483648 ]]; then
-    echo "Error: The container doesn't have enough memory allocated."
-    echo "A database container needs at least 2 GB of memory."
-    echo "You currently only have $((memory/1024/1024)) MB allocated to the container."
-    exit 1;
-fi;
+   echo "Error: The container doesn't have enough memory allocated."
+   echo "A database container needs at least 2 GB of memory."
+   echo "You currently only have $ALLOCATED_MEMORY MB allocated to the container."
+   exit 1;
+fi
 
 # Check that hostname doesn't container any "_"
 # Github issue #711


### PR DESCRIPTION
This is another take on https://github.com/oracle/docker-images/pull/2239, which does not remove the existing INIT_SGA_SIZE and INIT_PGA_SIZE parameters, but still solves the issue reported at https://github.com/oracle/docker-images/pull/2238 (because now the total memory configuration is re-assessed on every container start).

And also, it brings all the benefits listed on https://github.com/oracle/docker-images/pull/2239 about the memory allocation.