### PR TITLE
Update the NoSQL Image

### DIFF
--- a/.github/workflows/build-and-push-nosql-image.yml
+++ b/.github/workflows/build-and-push-nosql-image.yml
@@ -1,21 +1,21 @@
-name: Build and publish NoSQL 19.5-ce container image to GitHub Container Registry
+name: Build and publish NoSQL container image to GitHub Container Registry
 
 on:
   push:
     branches:
       - main
     paths:
-      - 'NoSQL/19.5-ce/*'
+      - 'NoSQL/ce/*'
       - '.github/workflows/build-and-push-nosql-image.yml'
     workflow_dispatch:
 
 env:
   IMAGE_NAME: nosql
-  TAG: 19.5-ce
+  TAG: ce
 
 jobs:
   push:
-    name: Build and push NoSQL 19.5-ce image
+    name: Build and push NoSQL ce image
 
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
@@ -32,11 +32,22 @@ jobs:
           REPO_OWNER=${{ github.repository_owner }}
           echo "::set-output name=repo-owner::${REPO_OWNER,,}"
 
-      - name: Build NoSQL 19.5-ce image
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m')"
+         
+      - name: Build NoSQL ce image
         run: |
-          cd NoSQL/19.5-ce
+          cd NoSQL/ce
           docker build --tag ghcr.io/${{ steps.repo-owner.outputs.repo-owner }}/$IMAGE_NAME:$TAG .
+          docker tag ghcr.io/${{ steps.repo-owner.outputs.repo-owner }}/$IMAGE_NAME:$TAG ghcr.io/${{ steps.repo-owner.outputs.repo-owner }}/$IMAGE_NAME:latest-ce
+        env:
+          TAG: ${{ steps.date.outputs.date }}-ce
 
       - name: Push image to GitHub Container Registry
         run: |
           docker push ghcr.io/${{ steps.repo-owner.outputs.repo-owner }}/$IMAGE_NAME:$TAG
+          docker push ghcr.io/${{ steps.repo-owner.outputs.repo-owner }}/$IMAGE_NAME:latest-ce
+        env:
+          TAG: ${{ steps.date.outputs.date }}-ce
+          

--- a/NoSQL/README.md
+++ b/NoSQL/README.md
@@ -162,7 +162,7 @@ In this case, You need to publish all internal ports and the KV_PROXY_PORT.
 - 8080 KV_PROXY_PORT
 
 This hostname must be resolvable from the host outside the container. 
-It could be an alias to the host running the docker commands (e.g nosql-container-host).
+It could be an alias to the host running the docker commands.
 
 ```shell
 $ cat /etc/hosts

--- a/NoSQL/README.md
+++ b/NoSQL/README.md
@@ -38,7 +38,7 @@ The steps outlined below are using Oracle NoSQL Database community edition, if
 you are using Oracle NoSQL Database Enterprise Edition, please use the
 appropriate image name.
 
-Start up KVLite in a Docker container. You must give it a name and provide a hostname. Startup of
+Start up KVLite in a container. You must give it a name and provide a hostname. Startup of
 KVLite is the default `CMD` of the image:
 
 ```shell
@@ -111,7 +111,7 @@ $ docker run --rm -ti --link kvlite:store oracle/nosql:ce \
 
 ## Using Oracle NoSQL Command-Line from an external host
 
-Start up KVLite in a Docker container. You must give it a name 
+Start up KVLite in a container. You must give it a name 
 and provide a hostname (resolvable from the external host - an alias to the container host). 
 You need to publish all internal ports.
 
@@ -128,15 +128,16 @@ instance:
 $ cat /etc/hosts
 10.0.0.143 nosql-container-host
 10.0.0.143 kvlite-nosql-container-host
-
-
+```
+```shell
 $ ping kvlite-nosql-container-host
 
 PING kvlite-nosql-container-host (10.0.0.143) 56(84) bytes of data.
 64 bytes from nosql-container-host (10.0.0.143): icmp_seq=1 ttl=64 time=0.259 ms
 64 bytes from nosql-container-host (10.0.0.143): icmp_seq=2 ttl=64 time=0.241 ms
 64 bytes from nosql-container-host (10.0.0.143): icmp_seq=3 ttl=64 time=0.192 ms
-
+```
+```shell
 $ java -jar $KVHOME/lib/kvstore.jar ping -host kvlite-nosql-container-host -port 5000
 ```
 

--- a/NoSQL/README.md
+++ b/NoSQL/README.md
@@ -155,7 +155,15 @@ You can also use the Oracle SQL Shell Command Line Interface (CLI)
 $ java -jar $KVHOME/lib/sql.jar -helper-hosts kvlite-nosql-container-host:5000 -store kvstore
 ````
 
+**Note**: We recommend running NoSQL Command-Line doing a container to container connection. 
+It allows starting the container without publishing all internal ports. In this way, you can run multiple containers in the same host.
 
+We recommend using the SDK drivers that will contact the Oracle NoSQL Database Proxy for your developments.
+
+```shell
+docker run -d --name=kvlite  --hostname=kvlite  --env KV_PROXY_PORT=8080 -p 8080:8080 oracle/nosql:ce
+docker run -d --name=kvlite2 --hostname=kvlite2 --env KV_PROXY_PORT=8080 -p 8081:8080 oracle/nosql:ce
+```
 
 ## Oracle NoSQL Database Proxy
 

--- a/NoSQL/README.md
+++ b/NoSQL/README.md
@@ -155,7 +155,7 @@ KVHOME=$PWD/kv-$KV_VERSION
 
 Start up KVLite in a container. You must give it a name 
 and provide a hostname. 
-In this case, You need to publish all internal ports.
+In this case, You need to publish all internal ports and the KV_PROXY_PORT.
 - 5000 KVPORT
 - 5010-5020 KV_HARANGE
 - 5021-5049 KV_SERVICERANGE

--- a/NoSQL/ce/Dockerfile
+++ b/NoSQL/ce/Dockerfile
@@ -7,20 +7,22 @@ LABEL org.opencontainers.image.source = "https://github.com/oracle/docker-images
 
 ARG KV_VERSION=20.3.19
 ARG DOWNLOAD_ROOT=http://download.oracle.com/otn-pub/otn_software/nosql-database
-ARG DOWNLOAD_FILE=kv-ce-$KV_VERSION.zip
-ARG DOWNLOAD_LINK=$DOWNLOAD_ROOT/$DOWNLOAD_FILE
-ARG UNZIPPED_ONLY_LIB=kv-$KV_VERSION/lib
+ARG DOWNLOAD_FILE="kv-ce-${KV_VERSION}.zip"
+ARG DOWNLOAD_LINK="${DOWNLOAD_ROOT}/${DOWNLOAD_FILE}"
 
 ENV KV_PROXY_PORT 8080
+ENV KV_ADMIN_PORT 5999
 
-RUN microdnf install unzip hostname && \
-    microdnf clean all
+ENV KV_PORT 5000
+ENV KV_HARANGE 5010-5020
+ENV KV_SERVICERANGE 5021-5049
 
-RUN curl -OLs  $DOWNLOAD_LINK  && \
-    unzip $DOWNLOAD_FILE $UNZIPPED_ONLY_LIB/* && \
-    rm -f $DOWNLOAD_FILE
+RUN curl -OLs $DOWNLOAD_LINK  && \
+    jar tf $DOWNLOAD_FILE | grep "kv-$KV_VERSION/lib" > extract.libs && \
+    jar xf $DOWNLOAD_FILE @extract.libs && \
+    rm -f $DOWNLOAD_FILE extract.libs
 
-WORKDIR "kv-$KV_VERSION"
+WORKDIR "/kv-$KV_VERSION"
 
 COPY start-kvlite.sh .
 RUN chmod +x start-kvlite.sh

--- a/NoSQL/ce/start-kvlite.sh
+++ b/NoSQL/ce/start-kvlite.sh
@@ -3,10 +3,7 @@
 # Copyright (c) 2022 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
-+set -ex
+set -e
 
-KVHOST=$HOSTNAME
-_KV_HARANGE=`echo $KV_HARANGE | sed 's/\-/\,/g' `
-_KV_SERVICERANGE=`echo $KV_SERVICERANGE | sed 's/\-/\,/g' `
-java -jar lib/kvstore.jar kvlite -secure-config disable -root /kvroot -host $KVHOST -port $KV_PORT -admin-web-port $KV_ADMIN_PORT -harange $_KV_HARANGE -servicerange $_KV_SERVICERANGE &
-java -jar lib/httpproxy.jar -helperHosts $KVHOST:$KV_PORT -storeName kvstore -httpPort $KV_PROXY_PORT -verbose true
+java -jar lib/kvstore.jar kvlite -secure-config disable -root /kvroot -host "$HOSTNAME" -port "$KV_PORT" -admin-web-port "$KV_ADMIN_PORT" -harange "${KV_HARANGE/\-/\,}" -servicerange ${KV_SERVICERANGE/\-/\,}" &
+java -jar lib/httpproxy.jar -helperHosts "$HOSTNAME:$KV_PORT" -storeName kvstore -httpPort "$KV_PROXY_PORT" -verbose true

--- a/NoSQL/ce/start-kvlite.sh
+++ b/NoSQL/ce/start-kvlite.sh
@@ -1,7 +1,12 @@
+#!/bin/bash
+#
 # Copyright (c) 2022 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
-#
 
-KVHOST=`hostname`
-java -jar lib/kvstore.jar kvlite  -secure-config disable -root /kvroot &
-java -jar lib/httpproxy.jar -helperHosts $KVHOST:5000 -storeName kvstore -httpPort $KV_PROXY_PORT -verbose true
++set -ex
+
+KVHOST=$HOSTNAME
+_KV_HARANGE=`echo $KV_HARANGE | sed 's/\-/\,/g' `
+_KV_SERVICERANGE=`echo $KV_SERVICERANGE | sed 's/\-/\,/g' `
+java -jar lib/kvstore.jar kvlite -secure-config disable -root /kvroot -host $KVHOST -port $KV_PORT -admin-web-port $KV_ADMIN_PORT -harange $_KV_HARANGE -servicerange $_KV_SERVICERANGE &
+java -jar lib/httpproxy.jar -helperHosts $KVHOST:$KV_PORT -storeName kvstore -httpPort $KV_PROXY_PORT -verbose true

--- a/NoSQL/ce/start-kvlite.sh
+++ b/NoSQL/ce/start-kvlite.sh
@@ -5,5 +5,5 @@
 
 set -e
 
-java -jar lib/kvstore.jar kvlite -secure-config disable -root /kvroot -host "$HOSTNAME" -port "$KV_PORT" -admin-web-port "$KV_ADMIN_PORT" -harange "${KV_HARANGE/\-/\,}" -servicerange ${KV_SERVICERANGE/\-/\,}" &
+java -jar lib/kvstore.jar kvlite -secure-config disable -root /kvroot -host "$HOSTNAME" -port "$KV_PORT" -admin-web-port "$KV_ADMIN_PORT" -harange "${KV_HARANGE/\-/\,}" -servicerange "${KV_SERVICERANGE/\-/\,}" &
 java -jar lib/httpproxy.jar -helperHosts "$HOSTNAME:$KV_PORT" -storeName kvstore -httpPort "$KV_PROXY_PORT" -verbose true


### PR DESCRIPTION
This PR updates with some improvements to the Oracle NoSQL CE image.
    Provide a solution to https://github.com/oracle/docker-images/issues/1594 - ADVANCED CONFIGURATION
    Avoid installing new packages - not using anymore `microdnf install unzip hostname`
    When restarting the container, KVLITE refuses to start because of the hostname change. Use -hostname when executing the command run.

Finally, I updated build-and-push-nosql-image.yml
    moving from a release-based tag to a date-based tag
    changing the paths
	
Signed-off-by: Dario Vega dario.vega@oracle.com	