### PR TITLE
Oracle DB 19c Bugfix

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -118,12 +118,14 @@ else
    memory=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 fi
 
+export ALLOCATED_MEMORY=$((memory/1024/1024))
+
 # Github issue #219: Prevent integer overflow,
 # only check if memory digits are less than 11 (single GB range and below)
 if [[ ${memory} != "max" && ${#memory} -lt 11 && ${memory} -lt 2147483648 ]]; then
    echo "Error: The container doesn't have enough memory allocated."
    echo "A database container needs at least 2 GB of memory."
-   echo "You currently only have $((memory/1024/1024)) MB allocated to the container."
+   echo "You currently only have $ALLOCATED_MEMORY MB allocated to the container."
    exit 1;
 fi
 


### PR DESCRIPTION
The bug is with respect to PR #2238 
Respective change is required in 19.3.0 runOracle.sh script, otherwise its causing the 19c container to fail ([Ref](https://github.com/oracle/docker-images/pull/2238#issuecomment-1065252008))

Fixed by adding the required code.
Signed-off-by: abhisbyk <abhishek.by.kumar@oracle.com>