### PR TITLE
Use php-oci8-21c

### DIFF
--- a/OracleLinuxDevelopers/oraclelinux7/php/7.4-apache-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/php/7.4-apache-oracledb/Dockerfile
@@ -2,9 +2,9 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-RUN yum -y install oracle-php-release-el7 oracle-release-el7 && \
+RUN yum -y install oracle-php-release-el7 oracle-release-el7 oracle-instantclient-release-el7 && \
     yum -y install httpd \
-                   oracle-instantclient19.5-basic \
+                   oracle-instantclient-basic \
                    php \
                    php-cli \
                    php-json \
@@ -12,7 +12,7 @@ RUN yum -y install oracle-php-release-el7 oracle-release-el7 && \
                    php-mysqlnd \
                    php-pdo \
                    php-xml \
-                   php-oci8-19c \
+                   php-oci8-21c \
                    unzip && \
     rm -rf /var/cache/yum/* && \
     # Redirect logging for container usage


### PR DESCRIPTION
As mentioned in https://github.com/oracle/docker-images/issues/2266, before this change the php-oci8 breaks after `yum update`.
With this patch it will continue to work.
See also https://blogs.oracle.com/opal/post/in-place-updates-with-oracle-instant-client-21c-rpms-on-linux, where this oracle-instantclient-release-el7 is listed.

I read https://github.com/oracle/docker-images/blob/53c66772f0d74a7dc102694c331ccec790064e5f/CONTRIBUTING.md and https://oca.opensource.oracle.com/, but frankly I don't know who to ask in my company to sign a Company Agreement.
It's also such a tiny patch it shouldn't even be necessary.