### PR TITLE
Password change while running prebuiltdb extended image

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -224,6 +224,11 @@ if [ -f "$ORACLE_BASE"/oradata/.${ORACLE_SID}"${CHECKPOINT_FILE_EXTN}" ] && [ -d
    
    # Start database
    "$ORACLE_BASE"/"$START_FILE";
+
+   # In case of the prebuiltdb extended image container, provision changing password by ORACLE_PWD
+   if [ -n "${ORACLE_PWD}" ] && [ -e "${ORACLE_BASE}/oradata/${ORACLE_SID}/.prebuiltdb" ]; then
+      "${ORACLE_BASE}"/"${PWD_FILE}" "${ORACLE_PWD}"
+   fi
    
 else
   undoSymLinkFiles;
@@ -291,6 +296,8 @@ fi;
 
 # Exiting the script without waiting on the tail logs
 if [ "$1" = "--nowait" ]; then
+   # Creating state-file for identifyig container of the prebuiltdb extended image
+   touch "${ORACLE_BASE}/oradata/${ORACLE_SID}/.prebuiltdb"
    exit $status;
 fi
 

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/runOracle.sh
@@ -243,7 +243,8 @@ if [ -f "$ORACLE_BASE"/oradata/.${ORACLE_SID}"${CHECKPOINT_FILE_EXTN}" ] && [ -d
       "$ORACLE_BASE"/"$START_FILE";
    fi
 
-   if [ -n "${ORACLE_PWD}" ]; then
+   # In case of the prebuiltdb extended image container, provision changing password by ORACLE_PWD
+   if [ -n "${ORACLE_PWD}" ] && [ -e "${ORACLE_BASE}/oradata/${ORACLE_SID}/.prebuiltdb" ]; then
       "${ORACLE_BASE}"/"${PWD_FILE}" "${ORACLE_PWD}"
    fi
    
@@ -315,6 +316,8 @@ fi;
 
 # Exiting the script without waiting on the tail logs
 if [ "$1" = "--nowait" ]; then
+   # Creating state-file for identifyig container of the prebuiltdb extended image
+   touch "${ORACLE_BASE}/oradata/${ORACLE_SID}/.prebuiltdb"
    exit $status;
 fi
 

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/runOracle.sh
@@ -242,6 +242,10 @@ if [ -f "$ORACLE_BASE"/oradata/.${ORACLE_SID}"${CHECKPOINT_FILE_EXTN}" ] && [ -d
    else
       "$ORACLE_BASE"/"$START_FILE";
    fi
+
+   if [ -n "${ORACLE_PWD}" ]; then
+      "${ORACLE_BASE}"/"${PWD_FILE}" "${ORACLE_PWD}"
+   fi
    
 else
   undoSymLinkFiles;


### PR DESCRIPTION
Provisioning password change with `ORACLE_PWD` while running the extended image with **prebuiltdb** extension, using `docker run` command.
Created a state-file with location as `${ORACLE_BASE}/oradata/{ORACLE_SID}/.prebuiltdb` to indicate that the image is extended with **prebuiltdb** extension. When this file is present, and `ORACLE_PWD` is passed to `docker run` command, this PR allows to change the password.