### PR TITLE
Podman secret support(mount mode only)

### DIFF
--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -133,10 +133,10 @@ The Oracle Database inside the container also has Oracle Enterprise Manager Expr
 `Podman secret` is supported if the user uses the podman runtime and needs to specify the password to the container securely. The user needs to create a secret first with the name **oracle_pwd**, and then run the container image after specifying the secret in the `run` command. The example commands are as follows:
 ```bash
     # Creating podman secret
-    echo "<Your Password>" | podmaqn create secret oracle_pwd -
+    echo "<Your Password>" | podman create secret oracle_pwd -
 
     # Running the Oracle Database 21c XE image with the secret
-    podman run -dt --name=<container_name> --secret=oracle_pwd oracle/database:21.3.0-xe
+    podman run -d --name=<container_name> --secret=oracle_pwd oracle/database:21.3.0-xe
 ```
 
 #### Selecting the Edition (Supported from 19.3.0 release)

--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -197,13 +197,20 @@ The Oracle Database inside the container also has Oracle Enterprise Manager Expr
 
     https://localhost:5500/em/
 
-On the first startup of the container a random password will be generated for the database if not provided.
-
-**Note:** The ORACLE_SID for Express Edition is always `XE` and cannot be changed, hence there is no ORACLE_SID parameter provided for the XE build.
-
-The password for those accounts can be changed via the `docker exec` command. **Note**, the container has to be running:
+On the first startup of the container a random password will be generated for the database if not provided. The password for those accounts can be changed via the `docker exec` command. **Note**, the container has to be running:
 
     docker exec <container name> /opt/oracle/setPassword.sh <your password>
+
+**Important Notes:** 
+- The ORACLE_SID for Express Edition is always `XE` and cannot be changed, hence there is no ORACLE_SID parameter provided for the XE build.
+- **Oracle Database 21c XE** also support specifying the password (i.e. ORACLE_PWD) securely through `podman secret` (mount mode only). The user needs to create a secret first, and then run the container image after specifying the secret in the `run` command. The example commands are as follows:
+```bash
+    # Creating podman secret
+    echo "<Your Password>" | podman create secret <secret_name> -
+
+    # Running the Oracle Database 21c XE image with the secret
+    podman run -dt --name=<container_name> --secret=<secret_name> oracle/database:21.3.0-xe
+```
 
 #### Running Oracle Database 11gR2 Express Edition in a container
 

--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -129,6 +129,16 @@ The Oracle Database inside the container also has Oracle Enterprise Manager Expr
 
 **NOTE**: Oracle Database bypasses file system level caching for some of the files by using the `O_DIRECT` flag. It is not advised to run the container on a file system that does not support the `O_DIRECT` flag.
 
+#### Securely specifying the password when using Podman (Supported from 21.3.0 onwards)
+`Podman secret` is supported if the user uses the podman runtime and needs to specify the password to the container securely. The user needs to create a secret first with the name **oracle_pwd**, and then run the container image after specifying the secret in the `run` command. The example commands are as follows:
+```bash
+    # Creating podman secret
+    echo "<Your Password>" | podmaqn create secret oracle_pwd -
+
+    # Running the Oracle Database 21c XE image with the secret
+    podman run -dt --name=<container_name> --secret=oracle_pwd oracle/database:21.3.0-xe
+```
+
 #### Selecting the Edition (Supported from 19.3.0 release)
 
 The edition of the database can be changed during runtime by passing the ORACLE_EDITION parameter to the `docker run` command. Therefore, an enterprise container image can be used to run standard edition database and vice-versa. You can find the edition of the running database in the output line:
@@ -201,16 +211,8 @@ On the first startup of the container a random password will be generated for th
 
     docker exec <container name> /opt/oracle/setPassword.sh <your password>
 
-**Important Notes:** 
-- The ORACLE_SID for Express Edition is always `XE` and cannot be changed, hence there is no ORACLE_SID parameter provided for the XE build.
-- **Oracle Database 21c XE** also support specifying the password (i.e. ORACLE_PWD) securely through `podman secret` (mount mode only). The user needs to create a secret first with the name **oracle_pwd**, and then run the container image after specifying the secret in the `run` command. The example commands are as follows:
-```bash
-    # Creating podman secret
-    echo "<Your Password>" | podman create secret oracle_pwd -
-
-    # Running the Oracle Database 21c XE image with the secret
-    podman run -dt --name=<container_name> --secret=oracle_pwd oracle/database:21.3.0-xe
-```
+**Important Note:** 
+The ORACLE_SID for Express Edition is always `XE` and cannot be changed, hence there is no ORACLE_SID parameter provided for the XE build.
 
 #### Running Oracle Database 11gR2 Express Edition in a container
 

--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -203,13 +203,13 @@ On the first startup of the container a random password will be generated for th
 
 **Important Notes:** 
 - The ORACLE_SID for Express Edition is always `XE` and cannot be changed, hence there is no ORACLE_SID parameter provided for the XE build.
-- **Oracle Database 21c XE** also support specifying the password (i.e. ORACLE_PWD) securely through `podman secret` (mount mode only). The user needs to create a secret first, and then run the container image after specifying the secret in the `run` command. The example commands are as follows:
+- **Oracle Database 21c XE** also support specifying the password (i.e. ORACLE_PWD) securely through `podman secret` (mount mode only). The user needs to create a secret first with the name **oracle_pwd**, and then run the container image after specifying the secret in the `run` command. The example commands are as follows:
 ```bash
     # Creating podman secret
-    echo "<Your Password>" | podman create secret <secret_name> -
+    echo "<Your Password>" | podman create secret oracle_pwd -
 
     # Running the Oracle Database 21c XE image with the secret
-    podman run -dt --name=<container_name> --secret=<secret_name> oracle/database:21.3.0-xe
+    podman run -dt --name=<container_name> --secret=oracle_pwd oracle/database:21.3.0-xe
 ```
 
 #### Running Oracle Database 11gR2 Express Edition in a container

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/checkDBStatus.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/checkDBStatus.sh
@@ -73,6 +73,11 @@ EOF
 ################ MAIN #######################
 #############################################
 
+# Setting up ORACLE_PWD if podman secret is passed on
+if [ -e '/run/secrets/oracle_pwd' ]; then
+   export ORACLE_PWD="$(cat '/run/secrets/oracle_pwd')"
+fi
+
 # Sanitizing env for XE Database
 if [ "${ORACLE_SID}" = "XE" ]; then
    unset DG_OBSERVER_ONLY

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
@@ -148,8 +148,6 @@ if [ "${ORACLE_SID}" = "XE" ]; then
   # Auto generate ORACLE PWD if not passed on
   export ORACLE_PWD=${ORACLE_PWD:-"$(openssl rand -hex 8)"}
   
-  
-  
   # Set character set
   su -c 'sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" /etc/sysconfig/"$CONF_FILE"'
 

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
@@ -145,8 +145,15 @@ EOF
 
 # Creating database for XE edition
 if [ "${ORACLE_SID}" = "XE" ]; then
-  # Auto generate ORACLE PWD if not passed on
-  export ORACLE_PWD=${ORACLE_PWD:-"$(openssl rand -hex 8)"}
+
+  if [ -e '/run/secrets/oracle_pwd' ]; then
+      export ORACLE_PWD="$(cat '/run/secrets/oracle_pwd')"
+  else
+    # Auto generate ORACLE PWD if not passed on
+    export ORACLE_PWD=${ORACLE_PWD:-"$(openssl rand -hex 8)"}
+  fi
+  
+  
   
   # Set character set
   su -c 'sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" /etc/sysconfig/"$CONF_FILE"'

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
@@ -146,7 +146,7 @@ EOF
 # Creating database for XE edition
 if [ "${ORACLE_SID}" = "XE" ]; then
   # Auto generate ORACLE PWD if not passed on
-   export ORACLE_PWD=${ORACLE_PWD:-"$(openssl rand -hex 8)"}
+  export ORACLE_PWD=${ORACLE_PWD:-"$(openssl rand -hex 8)"}
   
   
   

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
@@ -145,13 +145,8 @@ EOF
 
 # Creating database for XE edition
 if [ "${ORACLE_SID}" = "XE" ]; then
-
-  if [ -e '/run/secrets/oracle_pwd' ]; then
-      export ORACLE_PWD="$(cat '/run/secrets/oracle_pwd')"
-  else
-    # Auto generate ORACLE PWD if not passed on
-    export ORACLE_PWD=${ORACLE_PWD:-"$(openssl rand -hex 8)"}
-  fi
+  # Auto generate ORACLE PWD if not passed on
+   export ORACLE_PWD=${ORACLE_PWD:-"$(openssl rand -hex 8)"}
   
   
   

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/runOracle.sh
@@ -144,6 +144,11 @@ trap _int SIGINT
 # Set SIGTERM handler
 trap _term SIGTERM
 
+# Setting up ORACLE_PWD if podman secret is passed on
+if [ -e '/run/secrets/oracle_pwd' ]; then
+   export ORACLE_PWD="$(cat '/run/secrets/oracle_pwd')"
+fi
+
 # Sanitizing env for XE
 if [ "${ORACLE_SID}" = "XE" ]; then
    export ORACLE_PDB="XEPDB1"


### PR DESCRIPTION
To specify the password securely(for sys, system and pdbadmin accounts), support for podman secrete provided. The user can create a secret using `podman secret create` command. The name of the secrete should be **oracle_pwd**. After this, user can specify this secret using the `--secret=oracle_pwd` option in the `podman run` command.

EDIT: supported from Oracle Database 21.3.0 onwards



Signed-off-by: abhisbyk <abhishek.by.kumar@oracle.com>