### PR TITLE
setPassword script condition for prebuiltdb extended image

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/setPassword.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/setPassword.sh
@@ -10,6 +10,11 @@
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 # 
 
+if [ -e "${ORACLE_BASE}/oradata/${ORACLE_SID}/.prebuiltdb" ] && [ -n "${ORACLE_PWD}" ] && [ "${ORACLE_PWD}" != "$1" ]; then
+      echo "Unable to change the password for prebuiltdb. The password is already there in the environment. Exiting..."
+      exit 1
+fi
+
 ORACLE_PWD=$1
 ORACLE_SID="$(grep "$ORACLE_HOME" /etc/oratab | cut -d: -f1)"
 ORACLE_PDB="$(ls -dl "$ORACLE_BASE"/oradata/"$ORACLE_SID"/*/ | grep -v -e pdbseed -e "${ARCHIVELOG_DIR_NAME:-archive_logs}"| awk '{print $9}' | cut -d/ -f6)"

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/setPassword.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/setPassword.sh
@@ -11,7 +11,7 @@
 # 
 
 if [ -e "${ORACLE_BASE}/oradata/${ORACLE_SID}/.prebuiltdb" ] && [ -n "${ORACLE_PWD}" ] && [ "${ORACLE_PWD}" != "$1" ]; then
-      echo "Unable to change the password for prebuiltdb. The password is already there in the environment. Exiting..."
+      echo "WARNING: The database password can not be changed for this container having a prebuilt database. The original password exists in the container environment. Your new password has been ignored !"
       exit 1
 fi
 

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/setPassword.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/setPassword.sh
@@ -11,7 +11,7 @@
 # 
 
 if [ -e "${ORACLE_BASE}/oradata/${ORACLE_SID}/.prebuiltdb" ] && [ -n "${ORACLE_PWD}" ] && [ "${ORACLE_PWD}" != "$1" ]; then
-      echo "WARNING: The database password can not be changed for this container having a prebuilt database. The original password exists in the container environment. Your new password has been ignored !"
+      echo "WARNING: The database password can not be changed for this container having a prebuilt database. The original password exists in the container environment. Your new password has been ignored!"
       exit 1
 fi
 


### PR DESCRIPTION
If `ORACLE_PWD` is passed in `docker run` command while running the database container image extended with **prebuiltdb** extension, don't allow user to change the password using `setPassword.sh` script. As the password is in the environment and if the container is restarted, then the changed password will not persist. The password will revert back to the one which exists in the environment.

Signed-off-by: abhisbyk <abhishek.by.kumar@oracle.com>