### PR TITLE
Support for Containerizing On-premise databases

### DIFF
--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -263,6 +263,26 @@ Once the container has been started you can connect to it just like to any other
     sqlplus sys/<your password>@//localhost:1521/XE as sysdba
     sqlplus system/<your password>@//localhost:1521/XE
 
+### Containerizing an on-premise database (Supported from version 19.3.0 release)
+If the user wants to containerize his/her on-premise database, we support cloning the on-premise databases. The user should use the following steps for successful on-premise database containerization:
+
+- The user needs to create the gold image from his on-premise database. The sample command is as follows:
+```bash
+cd $ORACLE_HOME && ./runInstaller -silent -createGoldImage -destinationLocation '<location for storing the gold image>'
+``` 
+- The gold image created in the step above will have the name like `db_home_2022-03-25_12-43-21PM.zip`. The user needs to transfer it to the `OracleDatabase/SingleInstance/dockerfiles/<version>` directory. The **version** would be the base version of the gold image, e.g. 19.3.0.
+- Further, the user needs to create the container image using this gold image by the following command:
+```bash
+./buildContainerImage.sh -e -v <base-version> -t oracle/database:19-onprem -o '--build-arg INSTALL_FILE_1=db_home_2022-03-25_12-43-21PM.zip'
+```
+- Finally, the user can spin-up a container using the container image created above by cloning the on-premise database and using the following command:
+```bash
+docker run --name <container-name> -e CLONE_DB=true \
+-e ORACLE_PWD=<sys password of the on-prem database> \
+-e PRIMARY_DB_CONN_STR '<the on-prem database connection string in <HOST>:<PORT>/<SERVICE_NAME> format>' \
+oracle/database:19-onprem
+```
+
 ### Deploying Oracle Database on Kubernetes
 
 Helm is a package manager which uses a packaging format called charts. [helm-charts](helm-charts/) directory contains all the relevant files needed to deploy Oracle Database on Kubernetes. For more information on default configuration, installing/uninstalling the Oracle Database chart on Kubernetes, please refer [helm-charts/oracle-db/README.md](helm-charts/oracle-db/README.md).

--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -273,7 +273,7 @@ cd $ORACLE_HOME && ./runInstaller -silent -createGoldImage -destinationLocation 
 - The gold image created in the step above will have the name like `db_home_2022-03-25_12-43-21PM.zip`. Copy this gold image to the `OracleDatabase/SingleInstance/dockerfiles/<version>` directory. The **version** would be the base version of the gold image, e.g. 19.3.0.
 - Create the container image using this gold image by the following sample command:
 ```bash
-./buildContainerImage.sh -e -v 19.3.0 -t oracle/database:19-onprem -o '--build-arg INSTALL_FILE_1=db_home_2022-03-25_12-43-21PM.zip'
+./buildContainerImage.sh -i -e -v 19.3.0 -t oracle/database:19-onprem -o '--build-arg INSTALL_FILE_1=db_home_2022-03-25_12-43-21PM.zip'
 ```
 - Run the container image created above with cloning option to clone the data files of the on-premise database. The sample command is as follows:
 ```bash

--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -133,7 +133,7 @@ The Oracle Database inside the container also has Oracle Enterprise Manager Expr
 `Podman secret` is supported if the user uses the podman runtime and needs to specify the password to the container securely. The user needs to create a secret first with the name **oracle_pwd**, and then run the container image after specifying the secret in the `run` command. The example commands are as follows:
 ```bash
     # Creating podman secret
-    echo "<Your Password>" | podman create secret oracle_pwd -
+    echo "<Your Password>" | podman secret create oracle_pwd -
 
     # Running the Oracle Database 21c XE image with the secret
     podman run -d --name=<container_name> --secret=oracle_pwd oracle/database:21.3.0-xe
@@ -264,22 +264,22 @@ Once the container has been started you can connect to it just like to any other
     sqlplus system/<your password>@//localhost:1521/XE
 
 ### Containerizing an on-premise database (Supported from version 19.3.0 release)
-If the user wants to containerize his/her on-premise database, we support cloning the on-premise databases. The user should use the following steps for successful on-premise database containerization:
+To containerize an on-premise database, please follow the steps mentioned below: 
 
-- The user needs to create the gold image from his on-premise database. The sample command is as follows:
+- Create the gold image from the on-premise database. The required command is as follows:
 ```bash
-cd $ORACLE_HOME && ./runInstaller -silent -createGoldImage -destinationLocation '<location for storing the gold image>'
+cd $ORACLE_HOME && ./runInstaller -silent -createGoldImage -destinationLocation '<location to store the gold image>'
 ``` 
-- The gold image created in the step above will have the name like `db_home_2022-03-25_12-43-21PM.zip`. The user needs to transfer it to the `OracleDatabase/SingleInstance/dockerfiles/<version>` directory. The **version** would be the base version of the gold image, e.g. 19.3.0.
-- Further, the user needs to create the container image using this gold image by the following command:
+- The gold image created in the step above will have the name like `db_home_2022-03-25_12-43-21PM.zip`. Copy this gold image to the `OracleDatabase/SingleInstance/dockerfiles/<version>` directory. The **version** would be the base version of the gold image, e.g. 19.3.0.
+- Create the container image using this gold image by the following sample command:
 ```bash
-./buildContainerImage.sh -e -v <base-version> -t oracle/database:19-onprem -o '--build-arg INSTALL_FILE_1=db_home_2022-03-25_12-43-21PM.zip'
+./buildContainerImage.sh -e -v 19.3.0 -t oracle/database:19-onprem -o '--build-arg INSTALL_FILE_1=db_home_2022-03-25_12-43-21PM.zip'
 ```
-- Finally, the user can spin-up a container using the container image created above by cloning the on-premise database and using the following command:
+- Run the container image created above with cloning option to clone the data files of the on-premise database. The sample command is as follows:
 ```bash
 docker run --name <container-name> -e CLONE_DB=true \
--e ORACLE_PWD=<sys password of the on-prem database> \
--e PRIMARY_DB_CONN_STR '<the on-prem database connection string in <HOST>:<PORT>/<SERVICE_NAME> format>' \
+-e ORACLE_PWD='<sys password of the on-prem database>' \
+-e PRIMARY_DB_CONN_STR='<the on-prem database connection string in <HOST>:<PORT>/<SERVICE_NAME> format>' \
 oracle/database:19-onprem
 ```
 

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
@@ -36,13 +36,14 @@ LABEL "provider"="Oracle"                                               \
 
 # Argument to control removal of components not needed after db software installation
 ARG SLIMMING=true
+ARG INSTALL_FILE_1="LINUX.X64_193000_db_home.zip"
 
 # Environment variables required for this build (do NOT change)
 # -------------------------------------------------------------
 ENV ORACLE_BASE=/opt/oracle \
     ORACLE_HOME=/opt/oracle/product/19c/dbhome_1 \
     INSTALL_DIR=/opt/install \
-    INSTALL_FILE_1="LINUX.X64_193000_db_home.zip" \
+    INSTALL_FILE_1=$INSTALL_FILE_1 \
     INSTALL_RSP="db_inst.rsp" \
     CONFIG_RSP="dbca.rsp.tmpl" \
     PWD_FILE="setPassword.sh" \

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/Dockerfile
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/Dockerfile
@@ -36,6 +36,7 @@ LABEL "provider"="Oracle"                                               \
 
 # Argument to control removal of components not needed after db software installation
 ARG SLIMMING=true
+ARG INSTALL_FILE_1="LINUX.X64_213000_db_home.zip"
 
 # Environment variables required for this build (do NOT change)
 # -------------------------------------------------------------
@@ -43,7 +44,7 @@ ENV ORACLE_BASE=/opt/oracle \
     ORACLE_HOME=/opt/oracle/product/21c/dbhome_1 \
     ORACLE_BASE_HOME=/opt/oracle/homes/OraDB21Home1 \
     INSTALL_DIR=/opt/install \
-    INSTALL_FILE_1="LINUX.X64_213000_db_home.zip" \
+    INSTALL_FILE_1=$INSTALL_FILE_1 \
     INSTALL_RSP="db_inst.rsp" \
     CONFIG_RSP="dbca.rsp.tmpl" \
     PWD_FILE="setPassword.sh" \


### PR DESCRIPTION
Support for containerizing  on-premise databases by using CLONE_DB option along with README changes.
+ Fixing podman secret create command in the README.


