### PR TITLE
Making Oracle Database EM Express available remotely for XE 21.3

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
@@ -163,6 +163,11 @@ setupNetworkConfigXE;
 # Setting up database
 dbSetupSQL;
 
+# Making Oracle Database EM Express available remotely for XE
+sqlplus / as sysdba << EOF
+EXEC DBMS_XDB.SETLISTENERLOCALACCESS(FALSE);
+EOF
+
 exit 0
 fi;
 


### PR DESCRIPTION
By default, Oracle EM Express is available only from the local server in 21c XE. This PR has the changes to make it accessible remotely.
Signed-off-by: abhisbyk <abhishek.by.kumar@oracle.com>