### PR TITLE
Changes required to build Oracle Database container images using Podman

### DIFF
--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -59,6 +59,18 @@ The character set for the database is set during creating of the database. 11gR2
 
     ./buildContainerImage.sh -e -v 21.3.0 -o '--build-arg SLIMMING=false'
 
+##### Building the container images using Podman
+Building Oracle Database container images using Podman is similar to Docker. Some additional environment variables are required to be set for proper functioning. The description is as follows:
+
+- `export BUILDAH_FORMAT=docker` (Required to support `HEALTHCHECK` specified in the Dockerfile)
+- `export BUILDAH_ISOLATION=chroot` (Required while building the container image in rootless mode)
+
+After setting these environment variables, the container image can be built using `buildContainerImage.sh` script as follows:
+
+```bash
+./buildContainerImage.sh -e -v <version-to-build>
+```
+
 ### Running Oracle Database in a container
 
 #### Running Oracle Database Enterprise and Standard Edition 2 in a container

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
@@ -130,7 +130,7 @@ RUN $ORACLE_BASE/oraInventory/orainstRoot.sh && \
 USER oracle
 WORKDIR /home/oracle
 
-HEALTHCHECK --interval=1m --start-period=5m \
+HEALTHCHECK --interval=1m --start-period=5m --timeout=30s \
    CMD "$ORACLE_BASE/$CHECK_DB_FILE" >/dev/null || exit 1
 
 # Define default command to start Oracle Database. 

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/Dockerfile
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/Dockerfile
@@ -131,7 +131,7 @@ RUN $ORACLE_BASE/oraInventory/orainstRoot.sh && \
 USER oracle
 WORKDIR /home/oracle
 
-HEALTHCHECK --interval=1m --start-period=5m \
+HEALTHCHECK --interval=1m --start-period=5m --timeout=30s \
    CMD "$ORACLE_BASE/$CHECK_DB_FILE" >/dev/null || exit 1
 
 # Define default command to start Oracle Database. 

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/Dockerfile.xe
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/Dockerfile.xe
@@ -81,7 +81,7 @@ RUN chmod ug+x $INSTALL_DIR/*.sh && \
 USER oracle
 WORKDIR /home/oracle
 
-HEALTHCHECK --interval=1m --start-period=5m \
+HEALTHCHECK --interval=1m --start-period=5m --timeout=30s \
    CMD "$ORACLE_BASE/$CHECK_DB_FILE" >/dev/null || exit 1
 
 CMD exec $ORACLE_BASE/$RUN_FILE


### PR DESCRIPTION
- Added a Readme section to specify the environment variables required to build the container images using Podman.
- Added `--timeout` option in the` HEALTHCHECK` instruction in the Dockerfiles (19c onwards). If not set, it takes the default value of 0 while using podman and always shows status `unhealthy` while running the container image in Podman. Value of the timeout kept as 30s which is default in Docker environment.

Signed-off-by: abhisbyk <abhishek.by.kumar@oracle.com>