### PR TITLE
NoSQL Database Proxy waits for kvstore to start.

### DIFF
--- a/NoSQL/ce/start-kvlite.sh
+++ b/NoSQL/ce/start-kvlite.sh
@@ -6,4 +6,8 @@
 set -e
 
 java -jar lib/kvstore.jar kvlite -secure-config disable -root /kvroot -host "$HOSTNAME" -port "$KV_PORT" -admin-web-port "$KV_ADMIN_PORT" -harange "${KV_HARANGE/\-/\,}" -servicerange "${KV_SERVICERANGE/\-/\,}" &
+while java -jar lib/kvstore.jar ping -host $HOSTNAME -port 5000  >/dev/null 2>&1 ; [ $? -ne 0 ];do
+    echo "Waiting for kvstore to start..."
+    sleep 1
+done
 java -jar lib/httpproxy.jar -helperHosts "$HOSTNAME:$KV_PORT" -storeName kvstore -httpPort "$KV_PROXY_PORT" -verbose true

--- a/NoSQL/ce/start-kvlite.sh
+++ b/NoSQL/ce/start-kvlite.sh
@@ -6,7 +6,7 @@
 set -e
 
 java -jar lib/kvstore.jar kvlite -secure-config disable -root /kvroot -host "$HOSTNAME" -port "$KV_PORT" -admin-web-port "$KV_ADMIN_PORT" -harange "${KV_HARANGE/\-/\,}" -servicerange "${KV_SERVICERANGE/\-/\,}" &
-while java -jar lib/kvstore.jar ping -host $HOSTNAME -port 5000  >/dev/null 2>&1 ; [ $? -ne 0 ];do
+while java -jar lib/kvstore.jar ping -host $HOSTNAME -port $KV_PORT  >/dev/null 2>&1 ; [ $? -ne 0 ];do
     echo "Waiting for kvstore to start..."
     sleep 1
 done


### PR DESCRIPTION
This PR updates with some improvements to the Oracle NoSQL CE image.
HTTP proxy waits for kvstore to start. Adding a while, so that the Oracle NoSQL Database Proxy didn't exit and wait for the kvstore to start

Signed-off-by: Dario Vega [dario.vega@oracle.com](mailto:dario.vega@oracle.com)