### PR TITLE
Podman secret support for Oracle Database 19c

### DIFF
--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -141,7 +141,7 @@ The Oracle Database inside the container also has Oracle Enterprise Manager Expr
 
 **NOTE**: Oracle Database bypasses file system level caching for some of the files by using the `O_DIRECT` flag. It is not advised to run the container on a file system that does not support the `O_DIRECT` flag.
 
-#### Securely specifying the password when using Podman (Supported from 21.3.0 onwards)
+#### Securely specifying the password when using Podman (Supported from 19.3.0 onwards)
 `Podman secret` is supported if the user uses the podman runtime and needs to specify the password to the container securely. The user needs to create a secret first with the name **oracle_pwd**, and then run the container image after specifying the secret in the `run` command. The example commands are as follows:
 ```bash
     # Creating podman secret

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/checkDBStatus.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/checkDBStatus.sh
@@ -73,6 +73,11 @@ EOF
 ################ MAIN #######################
 #############################################
 
+# Setting up ORACLE_PWD if podman secret is passed on
+ if [ -e '/run/secrets/oracle_pwd' ]; then
+    export ORACLE_PWD="$(cat '/run/secrets/oracle_pwd')"
+ fi
+
 if [ "$DG_OBSERVER_ONLY" = "true" ]; then
    checkObserver
 else

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -142,6 +142,11 @@ trap _int SIGINT
 # Set SIGTERM handler
 trap _term SIGTERM
 
+# Setting up ORACLE_PWD if podman secret is passed on
+ if [ -e '/run/secrets/oracle_pwd' ]; then
+    export ORACLE_PWD="$(cat '/run/secrets/oracle_pwd')"
+ fi
+
 # Creation of Observer only section
 if [ "${DG_OBSERVER_ONLY}" = "true" ]; then
    if [ -z "${DG_OBSERVER_NAME}" ]; then

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/setPassword.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/setPassword.sh
@@ -10,6 +10,11 @@
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 # 
 
+if [ -e "${ORACLE_BASE}/oradata/${ORACLE_SID}/.prebuiltdb" ] && [ -n "${ORACLE_PWD}" ] && [ "${ORACLE_PWD}" != "$1" ]; then
+      echo "WARNING: The database password can not be changed for this container having a prebuilt database. The original password exists in the container environment. Your new password has been ignored!"
+      exit 1
+fi
+
 ORACLE_PWD=$1
 ORACLE_SID="$(grep "$ORACLE_HOME" /etc/oratab | cut -d: -f1)"
 ORACLE_PDB="$(ls -dl "$ORACLE_BASE"/oradata/"$ORACLE_SID"/*/ | grep -v -e pdbseed -e "$ARCHIVELOG_DIR_NAME" | awk '{print $9}' | cut -d/ -f6)"


### PR DESCRIPTION
- Podman secret support for Oracle Database 19.3.0
- Added condition in `setPassword.sh` script, for preventing user to change the password if it is in environment for a prebuiltdb extended 19c image container.

Signed-off-by: abhisbyk <abhishek.by.kumar@oracle.com>