### PR TITLE
April cpu patch

### DIFF
--- a/OracleJava/11/Dockerfile
+++ b/OracleJava/11/Dockerfile
@@ -23,7 +23,7 @@
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
-FROM  oraclelinux:7-slim as builder
+FROM oraclelinux:7-slim as builder
 
 MAINTAINER Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>
 
@@ -36,7 +36,7 @@ RUN set -eux; \
 ENV LANG en_US.UTF-8
 
 
-# Environment variables for the builder image.  
+# Environment variables for the builder image.
 # Required to validate that you are using the correct file
 
 ENV JAVA_HOME=/usr/java/jdk-11

--- a/OracleJava/11/Dockerfile
+++ b/OracleJava/11/Dockerfile
@@ -9,7 +9,7 @@
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
 #
-# (1) jdk-11.XX_linux-x64_bin.tar.gz
+# (1) jdk-11.XX_linux-x64_bin.tar.gz or jdk-11.XX_linux-aarch64_bin.tar.gz
 #     Download from https://www.oracle.com/java/technologies/javase-jdk11-downloads.html
 #
 # HOW TO BUILD THIS IMAGE
@@ -23,7 +23,7 @@
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
-FROM --platform=linux/amd64 oraclelinux:7-slim as builder
+FROM  oraclelinux:7-slim as builder
 
 MAINTAINER Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>
 
@@ -39,19 +39,26 @@ ENV LANG en_US.UTF-8
 # Environment variables for the builder image.  
 # Required to validate that you are using the correct file
 
-ENV JAVA_PKG=jdk-11.0.15.1_linux-x64_bin.tar.gz \
-	JAVA_SHA256=a40ad9342646ec14196deaf28c64f697fef4c698296f0e7d39b638f360780d27 \
-	JAVA_HOME=/usr/java/jdk-11
+ENV JAVA_HOME=/usr/java/jdk-11
 
 ##
-COPY $JAVA_PKG /tmp/jdk.tgz
+COPY *.tar.gz /tmp/
 RUN set -eux; \
-	echo "$JAVA_SHA256 */tmp/jdk.tgz" | sha256sum -c -; \
+	ARCH=$(uname -m) && \
+    if [ "$ARCH" == "x86_64" ]; \
+    then \
+		mv $(ls /tmp/jdk-11*_linux-x64_bin.tar.gz) /tmp/jdk.tar.gz ; \
+        JAVA_SHA256=a40ad9342646ec14196deaf28c64f697fef4c698296f0e7d39b638f360780d27 ; \
+    else \
+	    mv $(ls /tmp/jdk-11*_linux-aarch64_bin.tar.gz) /tmp/jdk.tar.gz ; \
+    	JAVA_SHA256=fbb191c2dfc976e61691b1c4805c6ac94cf39f72464779f421d207db1571540a ; \    	
+    fi && \
+	echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
 	mkdir -p "$JAVA_HOME"; \
-	tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1
+	tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
 	
 ## Get a fresh version of SLIM for the final image	
-FROM --platform=linux/amd64 oraclelinux:7-slim
+FROM oraclelinux:7-slim
 
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8

--- a/OracleJava/11/Dockerfile
+++ b/OracleJava/11/Dockerfile
@@ -23,7 +23,7 @@
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
-FROM oraclelinux:7-slim as builder
+FROM --platform=linux/amd64 oraclelinux:7-slim as builder
 
 MAINTAINER Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>
 
@@ -39,8 +39,8 @@ ENV LANG en_US.UTF-8
 # Environment variables for the builder image.  
 # Required to validate that you are using the correct file
 
-ENV JAVA_PKG=jdk-11.0.15_linux-x64_bin.tar.gz \
-	JAVA_SHA256=d69e577d6ea80bea71d01db1d17c1e764ad65982942991f4641bc63202a495ba \
+ENV JAVA_PKG=jdk-11.0.15.1_linux-x64_bin.tar.gz \
+	JAVA_SHA256=a40ad9342646ec14196deaf28c64f697fef4c698296f0e7d39b638f360780d27 \
 	JAVA_HOME=/usr/java/jdk-11
 
 ##
@@ -51,12 +51,12 @@ RUN set -eux; \
 	tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1
 	
 ## Get a fresh version of SLIM for the final image	
-FROM oraclelinux:7-slim
+FROM --platform=linux/amd64 oraclelinux:7-slim
 
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
-ENV JAVA_VERSION=11.0.15 \
+ENV JAVA_VERSION=11.0.15.1 \
 	JAVA_HOME=/usr/java/jdk-11
 
 ENV	PATH $JAVA_HOME/bin:$PATH	

--- a/OracleJava/11/Dockerfile.8
+++ b/OracleJava/11/Dockerfile.8
@@ -34,7 +34,7 @@ RUN set -eux; \
 ENV LANG en_US.UTF-8
 
 
-# Environment variables for the builder image.  
+# Environment variables for the builder image.
 # Required to validate that you are using the correct file
 
 ENV JAVA_HOME=/usr/java/jdk-11
@@ -49,7 +49,7 @@ RUN set -eux; \
         JAVA_SHA256=a40ad9342646ec14196deaf28c64f697fef4c698296f0e7d39b638f360780d27 ; \
     else \
 	    mv $(ls /tmp/jdk-11*_linux-aarch64_bin.tar.gz) /tmp/jdk.tar.gz ; \
-    	JAVA_SHA256=fbb191c2dfc976e61691b1c4805c6ac94cf39f72464779f421d207db1571540a ; \    	
+    	JAVA_SHA256=fbb191c2dfc976e61691b1c4805c6ac94cf39f72464779f421d207db1571540a ; \	
     fi && \
 	echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
 	mkdir -p "$JAVA_HOME"; \

--- a/OracleJava/11/Dockerfile.8
+++ b/OracleJava/11/Dockerfile.8
@@ -23,7 +23,7 @@
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
-FROM ghcr.io/oracle/oraclelinux8-compat:8-slim as builder
+FROM --platform=linux/amd64 ghcr.io/oracle/oraclelinux8-compat:8-slim as builder
 
 MAINTAINER Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>
 
@@ -37,8 +37,8 @@ ENV LANG en_US.UTF-8
 # Environment variables for the builder image.  
 # Required to validate that you are using the correct file
 
-ENV JAVA_PKG=jdk-11.0.15_linux-x64_bin.tar.gz \
-	JAVA_SHA256=d69e577d6ea80bea71d01db1d17c1e764ad65982942991f4641bc63202a495ba \
+ENV JAVA_PKG=jdk-11.0.15.1_linux-x64_bin.tar.gz \
+	JAVA_SHA256=a40ad9342646ec14196deaf28c64f697fef4c698296f0e7d39b638f360780d27 \
 	JAVA_HOME=/usr/java/jdk-11
 
 ##
@@ -49,12 +49,12 @@ RUN set -eux; \
 	tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1
 	
 ## Get a fresh version of OL8 for the final image	
-FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
+FROM --platform=linux/amd64 ghcr.io/oracle/oraclelinux8-compat:8-slim
 
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
-ENV JAVA_VERSION=11.0.15 \
+ENV JAVA_VERSION=11.0.15.1 \
 	JAVA_HOME=/usr/java/jdk-11
 
 ENV	PATH $JAVA_HOME/bin:$PATH	

--- a/OracleJava/11/Dockerfile.8
+++ b/OracleJava/11/Dockerfile.8
@@ -9,7 +9,7 @@
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
 #
-# (1) jdk-11.XX_linux-x64_bin.tar.gz
+# (1) jdk-11.XX_linux-x64_bin.tar.gz or jdk-11.XX_linux-aarch64_bin.tar.gz
 #     Download from https://www.oracle.com/java/technologies/javase-jdk11-downloads.html
 #
 # HOW TO BUILD THIS IMAGE
@@ -23,7 +23,7 @@
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
-FROM --platform=linux/amd64 ghcr.io/oracle/oraclelinux8-compat:8-slim as builder
+FROM ghcr.io/oracle/oraclelinux8-compat:8-slim as builder
 
 MAINTAINER Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>
 
@@ -37,19 +37,26 @@ ENV LANG en_US.UTF-8
 # Environment variables for the builder image.  
 # Required to validate that you are using the correct file
 
-ENV JAVA_PKG=jdk-11.0.15.1_linux-x64_bin.tar.gz \
-	JAVA_SHA256=a40ad9342646ec14196deaf28c64f697fef4c698296f0e7d39b638f360780d27 \
-	JAVA_HOME=/usr/java/jdk-11
+ENV JAVA_HOME=/usr/java/jdk-11
 
 ##
-COPY $JAVA_PKG /tmp/jdk.tgz
+COPY *.tar.gz /tmp/
 RUN set -eux; \
-	echo "$JAVA_SHA256 */tmp/jdk.tgz" | sha256sum -c -; \
+	ARCH=$(uname -m) && \
+    if [ "$ARCH" == "x86_64" ]; \
+    then \
+		mv $(ls /tmp/jdk-11*_linux-x64_bin.tar.gz) /tmp/jdk.tar.gz ; \
+        JAVA_SHA256=a40ad9342646ec14196deaf28c64f697fef4c698296f0e7d39b638f360780d27 ; \
+    else \
+	    mv $(ls /tmp/jdk-11*_linux-aarch64_bin.tar.gz) /tmp/jdk.tar.gz ; \
+    	JAVA_SHA256=fbb191c2dfc976e61691b1c4805c6ac94cf39f72464779f421d207db1571540a ; \    	
+    fi && \
+	echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
 	mkdir -p "$JAVA_HOME"; \
-	tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1
+	tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
 	
 ## Get a fresh version of OL8 for the final image	
-FROM --platform=linux/amd64 ghcr.io/oracle/oraclelinux8-compat:8-slim
+FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8

--- a/OracleJava/17/Dockerfile
+++ b/OracleJava/17/Dockerfile
@@ -21,7 +21,7 @@
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
-FROM oraclelinux:8 as builder
+FROM --platform=linux/amd64 oraclelinux:8 as builder
 
 MAINTAINER Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>
 
@@ -47,7 +47,7 @@ RUN set -eux; \
 	tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1
 	
 ## Get a fresh version of OL8 for the final image	
-FROM oraclelinux:8
+FROM --platform=linux/amd64 oraclelinux:8
 
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8

--- a/OracleJava/17/Dockerfile
+++ b/OracleJava/17/Dockerfile
@@ -8,7 +8,7 @@
 #
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
-# This dockerfile will download a copy of JDK 18 from
+# This dockerfile will download a copy of JDK 17 from
 #	https://download.oracle.com/java/17/latest/jdk-17_linux-<ARCH>_bin.tar.gz
 # 
 # It will use either x64 or aarch64 depending on the target platform
@@ -34,7 +34,7 @@ RUN set -eux; \
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
-# Environment variables for the builder image.  
+# Environment variables for the builder image.
 # Required to validate that you are using the correct file
 
 ENV JAVA_URL=https://download.oracle.com/java/17/latest \

--- a/OracleJava/17/Dockerfile
+++ b/OracleJava/17/Dockerfile
@@ -8,8 +8,10 @@
 #
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
-# This dockerfile will download a copy of JDK 17 from 
-#   https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.tar.gz
+# This dockerfile will download a copy of JDK 18 from
+#	https://download.oracle.com/java/17/latest/jdk-17_linux-<ARCH>_bin.tar.gz
+# 
+# It will use either x64 or aarch64 depending on the target platform
 #
 # HOW TO BUILD THIS IMAGE
 # -----------------------
@@ -21,7 +23,7 @@
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
-FROM --platform=linux/amd64 oraclelinux:8 as builder
+FROM oraclelinux:8 as builder
 
 MAINTAINER Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>
 
@@ -35,11 +37,17 @@ ENV LANG en_US.UTF-8
 # Environment variables for the builder image.  
 # Required to validate that you are using the correct file
 
-ENV JAVA_PKG=https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.tar.gz \
+ENV JAVA_URL=https://download.oracle.com/java/17/latest \
 	JAVA_HOME=/usr/java/jdk-17
 
 ##
 RUN set -eux; \
+	ARCH=$(uname -m) && \
+	# Java uses just x64 in the name of the tarball
+    if [ "$ARCH" == "x86_64" ]; \
+        then ARCH="x64"; \
+    fi && \
+    JAVA_PKG="$JAVA_URL/jdk-17_linux-${ARCH}_bin.tar.gz" ; \
 	JAVA_SHA256=$(curl "$JAVA_PKG".sha256) ; \ 
 	curl --output /tmp/jdk.tgz "$JAVA_PKG" && \
 	echo "$JAVA_SHA256 */tmp/jdk.tgz" | sha256sum -c; \
@@ -47,7 +55,7 @@ RUN set -eux; \
 	tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1
 	
 ## Get a fresh version of OL8 for the final image	
-FROM --platform=linux/amd64 oraclelinux:8
+FROM oraclelinux:8
 
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8

--- a/OracleJava/17/build.sh
+++ b/OracleJava/17/build.sh
@@ -5,4 +5,4 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 echo "Building Oracle JDK 17 on Oracle Linux 8"
-docker build --file Dockerfile --tag oracle/jdk:17  --tag oracle/jdk:17-oraclelinux8 .
+docker build --file Dockerfile --tag oracle/jdk:17 --tag oracle/jdk:17-oraclelinux8 .

--- a/OracleJava/18/Dockerfile
+++ b/OracleJava/18/Dockerfile
@@ -21,7 +21,7 @@
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
-FROM oraclelinux:8 as builder
+FROM --platform=linux/amd64 oraclelinux:8 as builder
 
 MAINTAINER Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>
 
@@ -47,7 +47,7 @@ RUN set -eux; \
 	tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1
 	
 ## Get a fresh version of OL8 for the final image	
-FROM oraclelinux:8
+FROM --platform=linux/amd64 oraclelinux:8
 
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8

--- a/OracleJava/18/Dockerfile
+++ b/OracleJava/18/Dockerfile
@@ -8,8 +8,10 @@
 #
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
-# This dockerfile will download a copy of JDK 18 from 
-#	https://download.oracle.com/java/18/latest/jdk-18_linux-x64_bin.tar.gz
+# This dockerfile will download a copy of JDK 18 from
+#	https://download.oracle.com/java/18/latest/jdk-18_linux-<ARCH>_bin.tar.gz if 
+# 
+# It will use either x64 or aarch64 depending on the target platform
 #
 # HOW TO BUILD THIS IMAGE
 # -----------------------
@@ -21,7 +23,7 @@
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
-FROM --platform=linux/amd64 oraclelinux:8 as builder
+FROM oraclelinux:8 as builder
 
 MAINTAINER Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>
 
@@ -34,12 +36,18 @@ ENV LANG en_US.UTF-8
 
 # Environment variables for the builder image.  
 # Required to validate that you are using the correct file
-
-ENV JAVA_PKG=https://download.oracle.com/java/18/latest/jdk-18_linux-x64_bin.tar.gz \
+	
+ENV JAVA_URL=https://download.oracle.com/java/18/latest \
 	JAVA_HOME=/usr/java/jdk-18
 
 ##
 RUN set -eux; \
+	ARCH=$(uname -m) && \
+	# Java uses just x64 in the name of the tarball
+    if [ "$ARCH" == "x86_64" ]; \
+        then ARCH="x64"; \
+    fi && \
+    JAVA_PKG="$JAVA_URL/jdk-18_linux-${ARCH}_bin.tar.gz" ; \
 	JAVA_SHA256=$(curl "$JAVA_PKG".sha256) ; \ 
 	curl --output /tmp/jdk.tgz "$JAVA_PKG" && \
 	echo "$JAVA_SHA256 */tmp/jdk.tgz" | sha256sum -c; \
@@ -47,7 +55,7 @@ RUN set -eux; \
 	tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1
 	
 ## Get a fresh version of OL8 for the final image	
-FROM --platform=linux/amd64 oraclelinux:8
+FROM oraclelinux:8
 
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8

--- a/OracleJava/18/Dockerfile
+++ b/OracleJava/18/Dockerfile
@@ -34,7 +34,7 @@ RUN set -eux; \
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
-# Environment variables for the builder image.  
+# Environment variables for the builder image.
 # Required to validate that you are using the correct file
 	
 ENV JAVA_URL=https://download.oracle.com/java/18/latest \

--- a/OracleJava/18/build.sh
+++ b/OracleJava/18/build.sh
@@ -5,4 +5,4 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 echo "Building Oracle JDK 18 on Oracle Linux 8"
-docker build --platform amd64 --file Dockerfile --tag oracle/jdk:18  --tag oracle/jdk:18-oraclelinux8 .
+docker build  --file Dockerfile --tag oracle/jdk:18  --tag oracle/jdk:18-oraclelinux8 .

--- a/OracleJava/18/build.sh
+++ b/OracleJava/18/build.sh
@@ -5,4 +5,4 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 echo "Building Oracle JDK 18 on Oracle Linux 8"
-docker build --file Dockerfile --tag oracle/jdk:18  --tag oracle/jdk:18-oraclelinux8 .
+docker build --platform amd64 --file Dockerfile --tag oracle/jdk:18  --tag oracle/jdk:18-oraclelinux8 .

--- a/OracleJava/18/build.sh
+++ b/OracleJava/18/build.sh
@@ -5,4 +5,4 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 echo "Building Oracle JDK 18 on Oracle Linux 8"
-docker build  --file Dockerfile --tag oracle/jdk:18  --tag oracle/jdk:18-oraclelinux8 .
+docker build --file Dockerfile --tag oracle/jdk:18 --tag oracle/jdk:18-oraclelinux8 .

--- a/OracleJava/8/Dockerfile
+++ b/OracleJava/8/Dockerfile
@@ -38,7 +38,7 @@ RUN set -eux; \
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
-# Environment variables for the builder image.  
+# Environment variables for the builder image.
 # Required to validate that you are using the correct file
 
 ENV JAVA_PKG=server-jre-8u333-linux-x64.tar.gz \

--- a/OracleJava/8/Dockerfile
+++ b/OracleJava/8/Dockerfile
@@ -23,7 +23,7 @@
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
-FROM --platform=linux/amd64 oraclelinux:7-slim as builder
+FROM oraclelinux:7-slim as builder
 
 MAINTAINER Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>
 
@@ -53,7 +53,7 @@ RUN set -eux; \
 
 ## Get a fresh version of SLIM for the final image
 
-FROM --platform=linux/amd64 oraclelinux:7-slim
+FROM oraclelinux:7-slim
 
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8

--- a/OracleJava/8/Dockerfile
+++ b/OracleJava/8/Dockerfile
@@ -23,7 +23,7 @@
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
-FROM oraclelinux:7-slim as builder
+FROM --platform=linux/amd64 oraclelinux:7-slim as builder
 
 MAINTAINER Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>
 
@@ -41,8 +41,8 @@ ENV LANG en_US.UTF-8
 # Environment variables for the builder image.  
 # Required to validate that you are using the correct file
 
-ENV JAVA_PKG=server-jre-8u331-linux-x64.tar.gz \
-	JAVA_SHA256=023bbb827168baa489638eeba6e96af53ebfdf6640c41015663646b238e3c4f0 \
+ENV JAVA_PKG=server-jre-8u333-linux-x64.tar.gz \
+	JAVA_SHA256=e6383f75665f5674deeb7e5c366fc7c6fc93e990c638c224dc68c5ec2863b763 \
 	JAVA_HOME=/usr/java/jdk-8
 
 COPY $JAVA_PKG /tmp/jdk.tgz
@@ -53,12 +53,12 @@ RUN set -eux; \
 
 ## Get a fresh version of SLIM for the final image
 
-FROM oraclelinux:7-slim
+FROM --platform=linux/amd64 oraclelinux:7-slim
 
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
-ENV JAVA_VERSION=1.8.0_331 \
+ENV JAVA_VERSION=1.8.0_333 \
 	JAVA_HOME=/usr/java/jdk-8 
 	
 ENV	PATH $JAVA_HOME/bin:$PATH

--- a/OracleJava/8/Dockerfile.8
+++ b/OracleJava/8/Dockerfile.8
@@ -23,7 +23,7 @@
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
-FROM ghcr.io/oracle/oraclelinux8-compat:8-slim as builder
+FROM --platform=linux/amd64 ghcr.io/oracle/oraclelinux8-compat:8-slim as builder
 
 MAINTAINER Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>
 
@@ -37,8 +37,8 @@ ENV LANG en_US.UTF-8
 # Environment variables for the builder image.  
 # Required to validate that you are using the correct file
 
-ENV JAVA_PKG=server-jre-8u331-linux-x64.tar.gz \
-	JAVA_SHA256=023bbb827168baa489638eeba6e96af53ebfdf6640c41015663646b238e3c4f0 \
+ENV JAVA_PKG=server-jre-8u333-linux-x64.tar.gz \
+	JAVA_SHA256=e6383f75665f5674deeb7e5c366fc7c6fc93e990c638c224dc68c5ec2863b763 \
 	JAVA_HOME=/usr/java/jdk-8
 
 COPY $JAVA_PKG /tmp/jdk.tgz
@@ -49,12 +49,12 @@ RUN set -eux; \
 
 ## Get a fresh version of SLIM for the final image
 
-FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
+FROM --platform=linux/amd64 ghcr.io/oracle/oraclelinux8-compat:8-slim
 
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
-ENV JAVA_VERSION=1.8.0_331 \
+ENV JAVA_VERSION=1.8.0_333 \
 	JAVA_HOME=/usr/java/jdk-8 
 	
 ENV	PATH $JAVA_HOME/bin:$PATH

--- a/OracleJava/8/Dockerfile.8
+++ b/OracleJava/8/Dockerfile.8
@@ -23,7 +23,7 @@
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
-FROM --platform=linux/amd64 ghcr.io/oracle/oraclelinux8-compat:8-slim as builder
+FROM ghcr.io/oracle/oraclelinux8-compat:8-slim as builder
 
 MAINTAINER Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>
 
@@ -49,7 +49,7 @@ RUN set -eux; \
 
 ## Get a fresh version of SLIM for the final image
 
-FROM --platform=linux/amd64 ghcr.io/oracle/oraclelinux8-compat:8-slim
+FROM ghcr.io/oracle/oraclelinux8-compat:8-slim
 
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8

--- a/OracleJava/8/Dockerfile.8
+++ b/OracleJava/8/Dockerfile.8
@@ -27,14 +27,14 @@ FROM ghcr.io/oracle/oraclelinux8-compat:8-slim as builder
 
 MAINTAINER Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>
 
-# Since the files is compressed as tar.gz first yum install tar.  gzip is already in ghcr.io/oracle/oraclelinux8-compat:8-slim
+# Since the files is compressed as tar.gz first yum install tar. gzip is already in ghcr.io/oracle/oraclelinux8-compat:8-slim
 RUN set -eux; \
 	dnf install -y tar ;
 	
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
-# Environment variables for the builder image.  
+# Environment variables for the builder image.
 # Required to validate that you are using the correct file
 
 ENV JAVA_PKG=server-jre-8u333-linux-x64.tar.gz \

--- a/OracleOpenJDK/18/Dockerfile
+++ b/OracleOpenJDK/18/Dockerfile
@@ -21,11 +21,11 @@
 #		$ bash build.sh
 #
 
-FROM oraclelinux:8
+FROM --platform=linux/amd64 oraclelinux:8 
 
 MAINTAINER Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>
 
-ENV JAVA_PKG=https://download.java.net/java/GA/jdk18.0.1/3f48cabb83014f9fab465e280ccf630b/10/GPL/openjdk-18.0.1_linux-x64_bin.tar.gz \
+ENV JAVA_PKG=https://download.java.net/java/GA/jdk18.0.1.1/65ae32619e2f40f3a9af3af1851d6e19/2/GPL/openjdk-18.0.1.1_linux-x64_bin.tar.gz \
 	JAVA_HOME=/usr/java/jdk-18 \
 	LANG=en_US.UTF-8
 

--- a/OracleOpenJDK/18/Dockerfile
+++ b/OracleOpenJDK/18/Dockerfile
@@ -21,11 +21,11 @@
 #		$ bash build.sh
 #
 
-FROM --platform=linux/amd64 oraclelinux:8 
+FROM oraclelinux:8 
 
 MAINTAINER Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>
 
-ENV JAVA_PKG=https://download.java.net/java/GA/jdk18.0.1.1/65ae32619e2f40f3a9af3af1851d6e19/2/GPL/openjdk-18.0.1.1_linux-x64_bin.tar.gz \
+ENV JAVA_URL=https://download.java.net/java/GA/jdk18.0.1.1/65ae32619e2f40f3a9af3af1851d6e19/2/GPL \
 	JAVA_HOME=/usr/java/jdk-18 \
 	LANG=en_US.UTF-8
 
@@ -34,7 +34,6 @@ ENV JAVA_PKG=https://download.java.net/java/GA/jdk18.0.1.1/65ae32619e2f40f3a9af3
 	
 ENV	PATH $JAVA_HOME/bin:$PATH
 	
-
 # Since the files are compressed as tar.gz first dnf install tar. gzip is already in oraclelinux:8
 RUN set -eux; \
 	dnf -y update; \
@@ -44,6 +43,12 @@ RUN set -eux; \
 		freetype fontconfig \
 	; \
 	rm -rf /var/cache/dnf; \
+	ARCH=$(uname -m) && \
+	# Java uses just x64 in the name of the tarball
+    if [ "$ARCH" == "x86_64" ]; \
+        then ARCH="x64"; \
+    fi && \
+    JAVA_PKG="$JAVA_URL/openjdk-18.0.1.1_linux-${ARCH}_bin.tar.gz" ; \
 	JAVA_SHA256=$(curl "$JAVA_PKG".sha256) ; \ 
 	curl --output /tmp/jdk.tgz "$JAVA_PKG" && \
 	echo "$JAVA_SHA256 */tmp/jdk.tgz" | sha256sum -c -; \


### PR DESCRIPTION
Updated the versions to match the May patch update that replaced the April 2022 CPU.  Also changed the dockerfiles for JDK 11, 17, and 18 to be able to build either x86-64 or aarch64. (serverJRE 8 is only available as x86-64 that version is just an update from 8u331 to 8u33)