### PR TITLE
Some fixes for Oracle SIDB 19.3 and 21.3

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
@@ -130,6 +130,9 @@ RUN $ORACLE_BASE/oraInventory/orainstRoot.sh && \
 USER oracle
 WORKDIR /home/oracle
 
+# Add a bashrc file to capitalize ORACLE_SID in the environment also
+RUN echo 'export ORACLE_SID=${ORACLE_SID^^}' > .bashrc
+
 HEALTHCHECK --interval=1m --start-period=5m --timeout=30s \
    CMD "$ORACLE_BASE/$CHECK_DB_FILE" >/dev/null || exit 1
 

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -118,7 +118,8 @@ else
    memory=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 fi
 
-export ALLOCATED_MEMORY=$((memory/1024/1024))
+# Default memory to 2GB, if not able to fetch memory restrictions from cgroups
+export ALLOCATED_MEMORY=$((${memory:=2147483648}/1024/1024))
 
 # Github issue #219: Prevent integer overflow,
 # only check if memory digits are less than 11 (single GB range and below)
@@ -248,7 +249,7 @@ else
   # Clean up incomplete database
   rm -rf "$ORACLE_BASE"/oradata/$ORACLE_SID
   cp /etc/oratab oratab.bkp
-  sed "/$ORACLE_SID/d" oratab.bkp > /etc/oratab
+  sed "/^#/!d" oratab.bkp > /etc/oratab
   rm -f oratab.bkp
   rm -rf "$ORACLE_BASE"/cfgtoollogs/dbca/$ORACLE_SID
   rm -rf "$ORACLE_BASE"/admin/$ORACLE_SID

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/Dockerfile
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/Dockerfile
@@ -131,6 +131,9 @@ RUN $ORACLE_BASE/oraInventory/orainstRoot.sh && \
 USER oracle
 WORKDIR /home/oracle
 
+# Add a bashrc file to capitalize ORACLE_SID in the environment also
+RUN echo 'export ORACLE_SID=${ORACLE_SID^^}' > .bashrc
+
 HEALTHCHECK --interval=1m --start-period=5m --timeout=30s \
    CMD "$ORACLE_BASE/$CHECK_DB_FILE" >/dev/null || exit 1
 

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/Dockerfile.xe
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/Dockerfile.xe
@@ -81,6 +81,9 @@ RUN chmod ug+x $INSTALL_DIR/*.sh && \
 USER oracle
 WORKDIR /home/oracle
 
+# Add a bashrc file to capitalize ORACLE_SID in the environment also
+RUN echo 'export ORACLE_SID=${ORACLE_SID^^}' > .bashrc
+
 HEALTHCHECK --interval=1m --start-period=5m --timeout=30s \
    CMD "$ORACLE_BASE/$CHECK_DB_FILE" >/dev/null || exit 1
 


### PR DESCRIPTION
Following changes are proposed:

- Create a .bashrc file in /home/oracle directory (for version 19.3 and 21.3) which has command to capitalize ORACLE_SID in the environment. If ORACLE_SID has lower case alphabets then it cause problems while connecting to SQLPlus from inside the container. Please refer issue #2233.
- If memory restrictions are not obtained from cgroups, then default the memory to 2GB instead of failing. Please refer issue #2334.
- Cleaning `/etc/oratab` properly (useful in the case when **prebuiltdb** extended image is started with different `ORACLE_SID`) .

close #2233 

Signed-off-by: abhisbyk <abhishek.by.kumar@oracle.com>