### PR TITLE
fix isOGGRunning to avoid conflict with tailReport ../ServiceManager.log

### DIFF
--- a/OracleGoldenGate/12c-19c/runOracleGoldenGate.sh
+++ b/OracleGoldenGate/12c-19c/runOracleGoldenGate.sh
@@ -29,7 +29,7 @@ function getCommand {
 
 getCommand runuser
 runAsUser="${RUNUSER} -u oracle --"
-OGGProcesses="(adminclient|adminsrvr|distsrvr|extract|ggsci|pmsrvr|recvsrvr|replicat|server|ServiceManager)"
+OGGProcesses="(adminclient|adminsrvr|distsrvr|extract|ggsci|pmsrvr|recvsrvr|replicat|server|/bin/ServiceManager)"
 
 ##
 ## Set some reasonable defaults


### PR DESCRIPTION
In exec_microservices function I commented startReverseProxy line and tailReport command is executed in parallel with isOGGRunning.
Because tailReport is listening to ServiceManager.log isOGGRunning thinks that ServiceManager is already running and doesn't start it.

function exec_microservices {
    export OGG_ETC_HOME="${OGG_DEPLOY_BASE}/ServiceManager/etc"
    export OGG_VAR_HOME="${OGG_DEPLOY_BASE}/ServiceManager/var"
    isOGGRunning || ${runAsUser} ${OGG_HOME}/bin/ServiceManager &
    # startReverseProxy
    tailReport "${OGG_VAR_HOME}/log/ServiceManager.log"
}