### PR TITLE
Oracle Management Agent in a Container - support user script execution

### DIFF
--- a/OracleManagementAgent/README.md
+++ b/OracleManagementAgent/README.md
@@ -101,6 +101,20 @@ Oracle Management Agent image uses the official `oraclelinux:7-slim` container i
     $ rm  /var/lib/docker/volumes/mgmtagent-volume/_data/mgmtagent_secret/input.rsp
     ```
 
+#### Steps to execute custom user operations
+
+Users can provide custom shell script commands to execute before starting Management Agent as described in the following steps
+
+1. Refer to [init-agent.sh](dockerfiles/latest/user-scripts/init-agent.sh) in the user-scripts directory
+
+    Modify the script `init-agent.sh` to add custom commands that execute each time before Management Agent starts
+
+1. Follow the steps to build and run a container and validate the output of `init-agent.sh` script is visible in the logs by running the following command
+
+    ```shell
+    $ docker logs mgmtagent-container
+    ```
+
 #### Helpful administration commands
 
 1. Starting a stopped Management Agent Container

--- a/OracleManagementAgent/dockerfiles/latest/Dockerfile
+++ b/OracleManagementAgent/dockerfiles/latest/Dockerfile
@@ -48,6 +48,10 @@ ENV LC_ALL=en_US.UTF-8
 COPY ./container-scripts/*.sh /opt/oracle-mgmtagent-bootstrap/scripts/
 RUN chmod 0544 /opt/oracle-mgmtagent-bootstrap/scripts/*.sh
 
+# Copy user provided scripts
+COPY ./user-scripts/init-agent.sh /opt/oracle-mgmtagent-bootstrap/scripts/
+RUN chmod 0544 /opt/oracle-mgmtagent-bootstrap/scripts/init-agent.sh
+
 # Copy Management Agent Installer Zip bundle
 COPY ./oracle.mgmt_agent.zip /opt/oracle-mgmtagent-bootstrap/packages/
 

--- a/OracleManagementAgent/dockerfiles/latest/container-scripts/watchdog.sh
+++ b/OracleManagementAgent/dockerfiles/latest/container-scripts/watchdog.sh
@@ -228,6 +228,10 @@ function start_agent()
       return 0
   fi
 
+  if [ -e "${SCRIPTS}/init-agent.sh" ]; then
+    execute_cmd "${SCRIPTS}/init-agent.sh" "initialize agent"
+  fi
+
   log "Starting $APPNAME ..."
   su -c '/opt/oracle/mgmt_agent/agent_inst/bin/polaris_start.sh' -s /bin/sh $RUN_AGENT_AS_USER &
 

--- a/OracleManagementAgent/dockerfiles/latest/user-scripts/init-agent.sh
+++ b/OracleManagementAgent/dockerfiles/latest/user-scripts/init-agent.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+# ORACLE MANAGEMENT AGENT INITIALIZE SCRIPT
+# -----------------------------------------
+# This script will be executed each time before agent starts therefore it is
+# the user responsibility to ensure the operations remain idempotent.
+#
+echo "Initializing Management Agent before agent startup"
+#
+###########################################################
+# Add custom initialization commands below
+#
+


### PR DESCRIPTION
With this change users can provide custom commands to execute each time before Management Agent starts inside the container.

Signed-off-by: Drupad Panchal <drupad.panchal@oracle.com>