### PR TITLE
Update deployment-init.py

### DIFF
--- a/OracleGoldenGate/21c/bin/deployment-init.py
+++ b/OracleGoldenGate/21c/bin/deployment-init.py
@@ -133,17 +133,11 @@ def get_digest_authentication():
     userName, credential = get_admin_credentials()
     return requests.auth.HTTPDigestAuth(userName, credential)
 
-def get_basic_auth_authentication():
-    """Retrieve a basic authentication method for making a request"""
-    userName, credential = get_admin_credentials()
-    return requests.auth.HTTPBasicAuth(userName, credential)
 
 def get_service_config(serviceName):
     """Retrieve the configuration of a service from Service Manager"""
     url = 'http://' + service_address + ':' + str(service_ports['ServiceManager']) + '/services/v2/deployments/' + os.environ['OGG_DEPLOYMENT'] + '/services/' + serviceName
-    response = get_requests_session().get(url, headers=rest_call_headers, auth=get_basic_auth_authentication())
-    if response.status_code == 401:
-        response = get_requests_session().get(url, headers=rest_call_headers, auth=get_digest_authentication())
+    response = get_requests_session().get(url, headers=rest_call_headers, auth=get_digest_authentication())
     if response.status_code == 200:
         response_json = response.json()
         if 'response' in response_json and \
@@ -159,9 +153,7 @@ def set_service_config(serviceName, config):
         'config': config,
         'status': 'restart'
     }
-    response = get_requests_session().patch(url, headers=rest_call_headers, auth=get_basic_auth_authentication(), json=body)
-    if response.status_code == 401:
-        response = get_requests_session().patch(url, headers=rest_call_headers, auth=get_digest_authentication(), json=body)
+    response = get_requests_session().patch(url, headers=rest_call_headers, auth=get_digest_authentication(), json=body)
     if response.status_code == 200:
         response_json = response.json()
         if 'response' in response_json:
@@ -206,7 +198,7 @@ def establish_service_manager(hasServiceManager):
             option('oggDeployHome',              deployment_directory) + \
             option('deploymentName',            'ServiceManager') + \
             option('authUser',                   userName) + \
-            option('authModes',                 'Digest,Basic') + \
+            option('authModes',                 'Digest-SHA-256,Digest,Basic') + \
             option('silent') + \
             option('nonsecure')
         subprocess.call(shell_command, shell=True, env=deployment_env)
@@ -243,13 +235,13 @@ def create_ogg_deployment():
         option('authUser',                   userName) + \
         option('enablePmSrvr',              'Yes') + \
         option('criticalPmSrvr',            'Yes') + \
-        option('pmSrvrDataStoreType',       'LMDB') + \
+        option('pmSrvrDataStoreType',       'LMDB') +f \
         option('portAdminSrvr',              service_ports['adminsrvr']) + \
         option('portDistSrvr',               service_ports['distsrvr' ]) + \
         option('portRcvrSrvr',               service_ports['recvsrvr' ]) + \
         option('portPmSrvr',                 service_ports['pmsrvr'   ]) + \
         option('portPmSrvrUdp',              service_ports['pmsrvr'   ]) + \
-        option('authModes',                 'Digest,Basic') + \
+        option('authModes',                 'Digest-SHA-256,Digest,Basic') + \
         option('silent') + \
         option('nonsecure')
     subprocess.call(shell_command, shell=True, env=deployment_env)

--- a/OracleGoldenGate/21c/bin/deployment-init.py
+++ b/OracleGoldenGate/21c/bin/deployment-init.py
@@ -133,11 +133,17 @@ def get_digest_authentication():
     userName, credential = get_admin_credentials()
     return requests.auth.HTTPDigestAuth(userName, credential)
 
+def get_basic_auth_authentication():
+    """Retrieve a basic authentication method for making a request"""
+    userName, credential = get_admin_credentials()
+    return requests.auth.HTTPBasicAuth(userName, credential)
 
 def get_service_config(serviceName):
     """Retrieve the configuration of a service from Service Manager"""
     url = 'http://' + service_address + ':' + str(service_ports['ServiceManager']) + '/services/v2/deployments/' + os.environ['OGG_DEPLOYMENT'] + '/services/' + serviceName
-    response = get_requests_session().get(url, headers=rest_call_headers, auth=get_digest_authentication())
+    response = get_requests_session().get(url, headers=rest_call_headers, auth=get_basic_auth_authentication())
+    if response.status_code == 401:
+        response = get_requests_session().get(url, headers=rest_call_headers, auth=get_digest_authentication())
     if response.status_code == 200:
         response_json = response.json()
         if 'response' in response_json and \
@@ -153,7 +159,9 @@ def set_service_config(serviceName, config):
         'config': config,
         'status': 'restart'
     }
-    response = get_requests_session().patch(url, headers=rest_call_headers, auth=get_digest_authentication(), json=body)
+    response = get_requests_session().patch(url, headers=rest_call_headers, auth=get_basic_auth_authentication(), json=body)
+    if response.status_code == 401:
+        response = get_requests_session().patch(url, headers=rest_call_headers, auth=get_digest_authentication(), json=body)
     if response.status_code == 200:
         response_json = response.json()
         if 'response' in response_json:


### PR DESCRIPTION
- API supports basic auth and as a fallback digest auth implemented. 
- This also potentially addresses a Linux issue seen for the fresh OGG deployment and start-up of the container 
- Error stacktrace for reference from container start up for a fresh OGG 21c deployment as below 

`2022-06-01T13:20:23.070Z | INFO    | ALL DONE (0 errors).
Traceback (most recent call last):
  File "/usr/local/bin/deployment-init.py", line 265, in <module>
    sys.exit(main())
  File "/usr/local/bin/deployment-init.py", line 260, in main
    create_ogg_deployment()
  File "/usr/local/bin/deployment-init.py", line 251, in create_ogg_deployment
    reset_service_configuration(serviceName)
  File "/usr/local/bin/deployment-init.py", line 166, in reset_service_configuration
    config = get_service_config(serviceName)
  File "/usr/local/bin/deployment-init.py", line 140, in get_service_config
    response = get_requests_session().get(url, headers=rest_call_headers, auth=get_digest_authentication())
  File "/usr/lib/python3.9/site-packages/requests/sessions.py", line 555, in get
    return self.request('GET', url, **kwargs)
  File "/usr/lib/python3.9/site-packages/requests/sessions.py", line 542, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python3.9/site-packages/requests/sessions.py", line 662, in send
    r = dispatch_hook('response', hooks, r, **kwargs)
  File "/usr/lib/python3.9/site-packages/requests/hooks.py", line 31, in dispatch_hook
    _hook_data = hook(hook_data, **kwargs)
  File "/usr/lib/python3.9/site-packages/requests/auth.py", line 267, in handle_401
    prep.headers['Authorization'] = self.build_digest_header(
  File "/usr/lib/python3.9/site-packages/requests/auth.py", line 185, in build_digest_header
    HA1 = hash_utf8(A1)
  File "/usr/lib/python3.9/site-packages/requests/auth.py", line 148, in md5_utf8
    return hashlib.md5(x).hexdigest()
ValueError: [digital envelope routines: EVP_DigestInit_ex] disabled for FIPS `