### PR TITLE
Oracle Management Agent in a Container - support agent run as root user

### DIFF
--- a/OracleManagementAgent/README.md
+++ b/OracleManagementAgent/README.md
@@ -101,6 +101,27 @@ Oracle Management Agent image uses the official `oraclelinux:7-slim` container i
     $ rm  /var/lib/docker/volumes/mgmtagent-volume/_data/mgmtagent_secret/input.rsp
     ```
 
+#### Steps to run Management Agent as root user
+
+Management Agent can be run as the root user if access to specific locations (example: `/var/log`) within the container environment are restricted to only the root user as described in the following steps. Please also note that the steps given below must be applied prior to container creation. Applying these changes after creating the container is not supported. 
+
+##### Steps to run as root when using Docker Compose
+
+1. Update the .env file to override the agent run-as-user environment variable
+    ```shell
+    $ echo "RUN_AGENT_AS_USER=root" >> .env
+    ```
+    **Note: Modifying this environment variable after container creation is not supported. Refer to volume cleanup in Helpful administration commands section and then startover.**
+
+##### Steps to run as root when using Docker CLI
+
+1. Start a container overriding the agent run-as-user environment variable
+    ```shell
+    $ docker run -d --env RUN_AGENT_AS_USER=root --name mgmtagent-container --hostname mgmtagent1 -v mgmtagent-volume:/opt/oracle:rw --restart unless-stopped oracle/mgmtagent-container:latest
+    ```
+    **Note: Setting this environment variable after container creation is not supported. Refer to volume cleanup in Helpful administration commands section and then startover.**
+
+
 #### Steps to execute custom user operations
 
 Users can provide custom shell script commands to execute before starting Management Agent as described in the following steps
@@ -133,6 +154,18 @@ Users can provide custom shell script commands to execute before starting Manage
 
     ```shell
     $ docker logs mgmtagent-container
+    ```
+
+1. Cleanup volume using Docker Compose
+
+    ```shell
+    $ docker-compose down --volumes
+    ```
+
+1. Cleanup volume using Docker CLI
+
+    ```shell
+    $ docker volume rm mgmtagent-volume
     ```
 
 ## License

--- a/OracleManagementAgent/dockerfiles/latest/container-scripts/watchdog.sh
+++ b/OracleManagementAgent/dockerfiles/latest/container-scripts/watchdog.sh
@@ -14,7 +14,6 @@ BOOTSTRAP_HOME=/opt/oracle-mgmtagent-bootstrap
 SCRIPTS=$BOOTSTRAP_HOME/scripts
 PACKAGES=$BOOTSTRAP_HOME/packages
 UPGRADE_STAGE=$BOOTSTRAP_HOME/upgrade
-RUN_AGENT_AS_USER=mgmt_agent
 CONFIG_FILE=/opt/oracle/mgmtagent_secret/input.rsp
 MGMTAGENT_HOME=/opt/oracle/mgmt_agent
 AUTOUPGRADE_BUNDLE=$MGMTAGENT_HOME/zip/oracle.mgmt_agent-??????.????.linux.zip
@@ -28,6 +27,13 @@ source "$SCRIPTS/install_zip.sh"
 
 echo $$ > /var/run/mgmtagent_watchdog.pid
 trap "log 'Stopping container ...'; stop_agent; exit" SIGINT SIGTERM
+
+
+###########################################################
+# Init environment
+if [[ -z "$RUN_AGENT_AS_USER" ]]; then
+  export RUN_AGENT_AS_USER="mgmt_agent"
+fi
 
 
 ###########################################################

--- a/OracleManagementAgent/dockerfiles/latest/docker-compose.yml
+++ b/OracleManagementAgent/dockerfiles/latest/docker-compose.yml
@@ -26,6 +26,9 @@ services:
     # Image name reported by docker images listing
     image: oracle/mgmtagent-container
 
+    environment:
+      RUN_AGENT_AS_USER: ${RUN_AGENT_AS_USER:-mgmt_agent}
+
     # Internal hostname identifier for the container
     hostname: ${mgmtagent_hostname}
 


### PR DESCRIPTION
This change allows running Management Agent inside a container as root and thus allowing access to root owned locations only within the container.

Signed-off-by: Drupad Panchal <drupad.panchal@oracle.com>