### PR TITLE
Make GoldenGate wait for Service Manager to launch

### DIFF
--- a/OracleGoldenGate/21c/bin/deployment-init.py
+++ b/OracleGoldenGate/21c/bin/deployment-init.py
@@ -202,6 +202,7 @@ def establish_service_manager(hasServiceManager):
             option('silent') + \
             option('nonsecure')
         subprocess.call(shell_command, shell=True, env=deployment_env)
+        wait_for_service(service_ports['ServiceManager'])
         terminate_process('ServiceManager')
         reset_servicemanager_configuration()
 


### PR DESCRIPTION
 - On slower systems, the Service Manager application is not detected
   correctly. This change makes the OGG initialization logic to wait
   for Service Manager to launch before updating its configuration.

Signed-off-by: Stephen Balousek <stephen.balousek@oracle.com>