### PR TITLE
use default expansions for run as agent user variable

### DIFF
--- a/OracleManagementAgent/dockerfiles/latest/container-scripts/watchdog.sh
+++ b/OracleManagementAgent/dockerfiles/latest/container-scripts/watchdog.sh
@@ -31,10 +31,7 @@ trap "log 'Stopping container ...'; stop_agent; exit" SIGINT SIGTERM
 
 ###########################################################
 # Init environment
-if [[ -z "$RUN_AGENT_AS_USER" ]]; then
-  export RUN_AGENT_AS_USER="mgmt_agent"
-fi
-
+export RUN_AGENT_AS_USER=${RUN_AGENT_AS_USER:-mgmt_agent}
 
 ###########################################################
 # Check if agent upgrade is available


### PR DESCRIPTION
set -u in a script causes the script to abort if the variable being referenced is not set, using default expansions for the RUN_AGENT_AS_USER variable