### PR TITLE
k8s extension fix for NFS

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -264,8 +264,8 @@ else
   # Check whether database is successfully created
   if "$ORACLE_BASE"/"$CHECK_DB_FILE"; then
     # Create a checkpoint file if database is successfully created
-    touch "$ORACLE_BASE"/oradata/.${ORACLE_SID}"${CHECKPOINT_FILE_EXTN}"
-    sync
+    # Populate the checkpoint file with the current date to avoid timing issue when using NFS persistence in multi-replica mode
+    date -Iseconds > "$ORACLE_BASE"/oradata/.${ORACLE_SID}"${CHECKPOINT_FILE_EXTN}"
   fi
 
   # Move database operational files to oradata
@@ -305,7 +305,6 @@ fi;
 if [ "$1" = "--nowait" ]; then
    # Creating state-file for identifyig container of the prebuiltdb extended image
    touch "${ORACLE_BASE}/oradata/${ORACLE_SID}/.prebuiltdb"
-   sync
    exit $status;
 fi
 

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -265,6 +265,7 @@ else
   if "$ORACLE_BASE"/"$CHECK_DB_FILE"; then
     # Create a checkpoint file if database is successfully created
     touch "$ORACLE_BASE"/oradata/.${ORACLE_SID}"${CHECKPOINT_FILE_EXTN}"
+    sync
   fi
 
   # Move database operational files to oradata
@@ -304,6 +305,7 @@ fi;
 if [ "$1" = "--nowait" ]; then
    # Creating state-file for identifyig container of the prebuiltdb extended image
    touch "${ORACLE_BASE}/oradata/${ORACLE_SID}/.prebuiltdb"
+   sync
    exit $status;
 fi
 

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -265,7 +265,7 @@ else
   if "$ORACLE_BASE"/"$CHECK_DB_FILE"; then
     # Create a checkpoint file if database is successfully created
     # Populate the checkpoint file with the current date to avoid timing issue when using NFS persistence in multi-replica mode
-    date -Iseconds > "$ORACLE_BASE"/oradata/.${ORACLE_SID}"${CHECKPOINT_FILE_EXTN}"
+    echo "$(date -Iseconds)" > "$ORACLE_BASE"/oradata/.${ORACLE_SID}"${CHECKPOINT_FILE_EXTN}"
   fi
 
   # Move database operational files to oradata

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/runOracle.sh
@@ -281,9 +281,9 @@ else
 
   # Check whether database is successfully created
   if "$ORACLE_BASE"/"$CHECK_DB_FILE"; then
-    # Create a checkpoint file if database is successfully created
-    touch "$ORACLE_BASE"/oradata/.${ORACLE_SID}"${CHECKPOINT_FILE_EXTN}"
-    sync
+    # Create a checkpoint file if database is successfully 
+    # Populate the checkpoint file with the current date to avoid timing issue when using NFS persistence in multi-replica mode
+    date -Iseconds > "$ORACLE_BASE"/oradata/.${ORACLE_SID}"${CHECKPOINT_FILE_EXTN}"
   fi
 
   # Move database operational files to oradata
@@ -325,7 +325,6 @@ fi;
 if [ "$1" = "--nowait" ]; then
    # Creating state-file for identifyig container of the prebuiltdb extended image
    touch "${ORACLE_BASE}/oradata/${ORACLE_SID}/.prebuiltdb"
-   sync
    exit $status;
 fi
 

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/runOracle.sh
@@ -283,7 +283,7 @@ else
   if "$ORACLE_BASE"/"$CHECK_DB_FILE"; then
     # Create a checkpoint file if database is successfully 
     # Populate the checkpoint file with the current date to avoid timing issue when using NFS persistence in multi-replica mode
-    date -Iseconds > "$ORACLE_BASE"/oradata/.${ORACLE_SID}"${CHECKPOINT_FILE_EXTN}"
+    echo "$(date -Iseconds)" > "$ORACLE_BASE"/oradata/.${ORACLE_SID}"${CHECKPOINT_FILE_EXTN}"
   fi
 
   # Move database operational files to oradata

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/runOracle.sh
@@ -281,7 +281,7 @@ else
 
   # Check whether database is successfully created
   if "$ORACLE_BASE"/"$CHECK_DB_FILE"; then
-    # Create a checkpoint file if database is successfully 
+    # Create a checkpoint file if database is successfully created
     # Populate the checkpoint file with the current date to avoid timing issue when using NFS persistence in multi-replica mode
     echo "$(date -Iseconds)" > "$ORACLE_BASE"/oradata/.${ORACLE_SID}"${CHECKPOINT_FILE_EXTN}"
   fi

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/runOracle.sh
@@ -283,6 +283,7 @@ else
   if "$ORACLE_BASE"/"$CHECK_DB_FILE"; then
     # Create a checkpoint file if database is successfully created
     touch "$ORACLE_BASE"/oradata/.${ORACLE_SID}"${CHECKPOINT_FILE_EXTN}"
+    sync
   fi
 
   # Move database operational files to oradata
@@ -324,6 +325,7 @@ fi;
 if [ "$1" = "--nowait" ]; then
    # Creating state-file for identifyig container of the prebuiltdb extended image
    touch "${ORACLE_BASE}/oradata/${ORACLE_SID}/.prebuiltdb"
+   sync
    exit $status;
 fi
 

--- a/OracleDatabase/SingleInstance/extensions/k8s/swapLocks.sh
+++ b/OracleDatabase/SingleInstance/extensions/k8s/swapLocks.sh
@@ -11,11 +11,6 @@
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
 
-# Sleep if the database checkpoint file is not created
-if [ ! -f "$ORACLE_BASE/oradata/.${ORACLE_SID}${CHECKPOINT_FILE_EXTN}" ]; then
-  sleep 2
-fi
-
 "$ORACLE_BASE/$LOCKING_SCRIPT" --release --file "$ORACLE_BASE/oradata/.${ORACLE_SID}.create_lck"
 if ! pgrep -f "$LOCKING_SCRIPT.*--acquire.*exist_lck" > /dev/null; then
   # Acquire exist lock if not already acquired or trying. This is a blocking call

--- a/OracleDatabase/SingleInstance/extensions/k8s/swapLocks.sh
+++ b/OracleDatabase/SingleInstance/extensions/k8s/swapLocks.sh
@@ -11,6 +11,11 @@
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
 
+# Sleep if the database checkpoint file is not created
+if [ ! -f "$ORACLE_BASE/oradata/.${ORACLE_SID}${CHECKPOINT_FILE_EXTN}" ]; then
+  sleep 2
+fi
+
 "$ORACLE_BASE/$LOCKING_SCRIPT" --release --file "$ORACLE_BASE/oradata/.${ORACLE_SID}.create_lck"
 if ! pgrep -f "$LOCKING_SCRIPT.*--acquire.*exist_lck" > /dev/null; then
   # Acquire exist lock if not already acquired or trying. This is a blocking call


### PR DESCRIPTION
Database checkpoint file (empty file) creation is facing some latency issues when NFS is used as a persistent storage in multi-replica mode (kubernetes deployment). To resolve this, populating the checkpoint file with the current date. By doing it, it is not buffered and directly written to the NFS storage.