### PR TITLE
how to fix a connection issue from oracle container

### DIFF
--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -135,6 +135,8 @@ Once the container has been started and the database created you can connect to 
     sqlplus system/<your password>@//localhost:1521/<your SID>
     sqlplus pdbadmin/<your password>@//localhost:1521/<Your PDB name>
 
+If you having connections error like "Got minus one from read call" from SQLDeveloper try to use the internal IP from Docker0 instead of localhost.
+
 The Oracle Database inside the container also has Oracle Enterprise Manager Express configured. To access OEM Express, start your browser and follow the URL:
 
     https://localhost:5500/em/


### PR DESCRIPTION
Added a line to explain how to fix a common issue of connection to oracle container as it's reported on Stackoverflow (https://stackoverflow.com/questions/19660336/how-to-approach-a-got-minus-one-from-a-read-call-error-when-connecting-to-an-a)

Third answer.