### PR TITLE
Adjust the HEALTHCHECK for prebuiltdb extension

### DIFF
--- a/OracleDatabase/SingleInstance/extensions/prebuiltdb/Dockerfile
+++ b/OracleDatabase/SingleInstance/extensions/prebuiltdb/Dockerfile
@@ -35,3 +35,7 @@ ENV AUTO_MEM_CALCULATION=${AUTO_MEM_CALCULATION:-false}
 
 # Creating the database
 RUN $ORACLE_BASE/$RUN_FILE --nowait
+
+# Adjust the healthcheck since the database won't be created
+HEALTHCHECK --interval=30s --start-period=1m --timeout=30s \
+   CMD "$ORACLE_BASE/$CHECK_DB_FILE" >/dev/null || exit 1


### PR DESCRIPTION
This turns down the startup time of the container from 1m to 30s, which in most cases is sufficient for the prebuiltdb ones to be ready.