### PR TITLE
ORACLE_PDB fix in configTcps.sh script

### DIFF
--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -78,7 +78,7 @@ After setting these environment variables, the container image can be built usin
 To run your Oracle Database image use the `docker run` command as follows:
 
     docker run --name <container name> \
-    -p <host port>:1521 -p <host port>:5500 -p <host port>:1522\
+    -p <host port>:1521 -p <host port>:5500 -p <host port>:2484\
     -e ORACLE_SID=<your SID> \
     -e ORACLE_PDB=<your PDB name> \
     -e ORACLE_PWD=<your database passwords> \
@@ -96,7 +96,7 @@ To run your Oracle Database image use the `docker run` command as follows:
     Parameters:
        --name:        The name of the container (default: auto generated).
        -p:            The port mapping of the host port to the container port.
-                      The following ports are exposed: 1521 (Oracle Listener), 5500 (OEM Express), 1522 (TCPS Listener Port if TCPS is enabled).
+                      The following ports are exposed: 1521 (Oracle Listener), 5500 (OEM Express), 2484 (TCPS Listener Port if TCPS is enabled).
        -e ORACLE_SID: The Oracle Database SID that should be used (default: ORCLCDB).
        -e ORACLE_PDB: The Oracle Database PDB name that should be used (default: ORCLPDB1).
        -e ORACLE_PWD: The Oracle Database SYS, SYSTEM and PDB_ADMIN password (default: auto generated).
@@ -203,11 +203,11 @@ There are two ways to enable TCPS connections for the database:
 1. Enable TCPS while creating the database.
 2. Enable TCPS after the database is created.
 
-To enable TCPS connections while creating the database, use the `-e ENABLE_TCPS=true` option with the `docker run` command. A listener endpoint will be created at the container port 1522 for TCPS.
+To enable TCPS connections while creating the database, use the `-e ENABLE_TCPS=true` option with the `docker run` command. A listener endpoint will be created at the container port 2484 for TCPS.
 
 To enable TCPS connections after the database is created, please use the following sample command:
 ```bash
-    # Creates Listener for TCPS at container port 1522
+    # Creates Listener for TCPS at container port 2484
     docker exec -it <container name> /opt/oracle/configTcps.sh
 ```
 
@@ -219,7 +219,7 @@ Similarly, to disable TCPS connections for the database, please use the followin
 
 **NOTE**:
 - Only database server authentication is supported (no mTLS).
-- The container port at which TCPS listener is listening (i.e. 1522) should be exposed and mapped to some host port using `-p <host-port>:1522` option in the `docker run` command. It is required to connect to the database from the outside world using TCPS.
+- The container port at which TCPS listener is listening (i.e. 2484) should be exposed and mapped to some host port using `-p <host-port>:2484` option in the `docker run` command. It is required to connect to the database from the outside world using TCPS.
 - When TCPS is enabled, a self-signed certificate will be created. For users' convenience, a client-side wallet is prepared and stored at the location `/opt/oracle/oradata/clientWallet/$ORACLE_SID`. You can use this client wallet along with SQL\*Plus to connect to the database. The sample command to download the client wallet is as follows:
     ```bash
         # ORACLE_SID default value is ORCLCDB

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/configTcps.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/configTcps.sh
@@ -110,7 +110,9 @@ function disable_tcps() {
 ###########################################
 
 ORACLE_SID="$(grep "$ORACLE_HOME" /etc/oratab | cut -d: -f1)"
-ORACLE_PDB="$(ls -dl "$ORACLE_BASE"/oradata/"$ORACLE_SID"/*/ | grep -v -e pdbseed -e "${ARCHIVELOG_DIR_NAME:-archive_logs}"| awk '{print $9}' | cut -d/ -f6)"
+# Export ORACLE_PDB value
+export ORACLE_PDB=${ORACLE_PDB:-ORCLPDB1}
+ORACLE_PDB=${ORACLE_PDB^^}
 
 # Oracle wallet location which stores the certificate
 WALLET_LOC="${ORACLE_BASE}/oradata/dbconfig/${ORACLE_SID}/.tls-wallet"
@@ -150,7 +152,7 @@ orapki wallet create -wallet "${WALLET_LOC}" -pwd "${WALLET_PWD}" -auto_login
 echo -e "\nOracle Wallet location: ${WALLET_LOC}\n"
 
 # Create a self-signed certificate using orapki utility; VALIDITY: 1095 days
-orapki wallet add -wallet "${WALLET_LOC}" -pwd "${WALLET_PWD}" -dn "CN=localhost" -keysize 1024 -self_signed -validity 1095
+orapki wallet add -wallet "${WALLET_LOC}" -pwd "${WALLET_PWD}" -dn "CN=localhost" -keysize 2048 -self_signed -validity 1095
 
 
 # Reconfigure listener to enable TCPS (Reload wouldn't work here)

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/configTcps.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/configTcps.sh
@@ -136,7 +136,7 @@ else
 fi
 
 # Default TCPS_PORT value
-TCPS_PORT=${TCPS_PORT:-1522}
+TCPS_PORT=${TCPS_PORT:-2484}
 
 # Creating the wallet
 echo -e "\n\nCreating Oracle Wallet for the database server side certificate...\n"

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/configTcps.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/configTcps.sh
@@ -139,7 +139,7 @@ else
 fi
 
 # Default TCPS_PORT value
-TCPS_PORT=${TCPS_PORT:-1522}
+TCPS_PORT=${TCPS_PORT:-2484}
 
 # Creating the wallet
 echo -e "\n\nCreating Oracle Wallet for the database server side certificate...\n"

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/configTcps.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/configTcps.sh
@@ -109,7 +109,13 @@ function disable_tcps() {
 ###########################################
 
 ORACLE_SID="$(grep "$ORACLE_HOME" /etc/oratab | cut -d: -f1)"
-ORACLE_PDB="$(ls -dl "$ORACLE_BASE"/oradata/"$ORACLE_SID"/*/ | grep -v -e pdbseed -e "${ARCHIVELOG_DIR_NAME:-archive_logs}"| awk '{print $9}' | cut -d/ -f6)"
+# Export ORACLE_PDB value
+if [ "$ORACLE_SID" == "XE" ]; then
+  export ORACLE_PDB="XEPDB1"
+else
+  export ORACLE_PDB=${ORACLE_PDB:-ORCLPDB1}
+fi
+ORACLE_PDB=${ORACLE_PDB^^}
 
 # Oracle wallet location which stores the certificate
 WALLET_LOC="${ORACLE_BASE}/oradata/dbconfig/${ORACLE_SID}/.tls-wallet"
@@ -149,7 +155,7 @@ orapki wallet create -wallet "${WALLET_LOC}" -pwd "${WALLET_PWD}" -auto_login
 echo -e "\nOracle Wallet location: ${WALLET_LOC}\n"
 
 # Create a self-signed certificate using orapki utility; VALIDITY: 1095 days
-orapki wallet add -wallet "${WALLET_LOC}" -pwd "${WALLET_PWD}" -dn "CN=localhost" -keysize 1024 -self_signed -validity 1095
+orapki wallet add -wallet "${WALLET_LOC}" -pwd "${WALLET_PWD}" -dn "CN=localhost" -keysize 2048 -self_signed -validity 1095
 
 
 # Reconfigure listener to enable TCPS (Reload wouldn't work here)


### PR DESCRIPTION
- Taking ORACLE_PDB from the env or default it accordingly (XEPDB1 or ORCLPDB). Because the existing method does not work with clone database functionality.
- Increasing the key size to 2048 bytes.

EDIT:
Changing the default tcps port to 2484. Ref: [https://docs.oracle.com/en/database/oracle/oracle-database/12.2/netrf/protocol-address-configuration.html#GUID-71A0702F-A5C6-4122-907D-5E9BFA1DCE45](https://docs.oracle.com/en/database/oracle/oracle-database/12.2/netrf/protocol-address-configuration.html#GUID-71A0702F-A5C6-4122-907D-5E9BFA1DCE45)

Signed-off-by: abhisbyk <abhishek.by.kumar@oracle.com>