### PR TITLE
Some fixes in configTcps.sh

### DIFF
--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -20,7 +20,9 @@ The `buildContainerImage.sh` script is just a utility shell script that performs
 
 ### Building Oracle Database container images
 
-**IMPORTANT:** You will have to provide the installation binaries of Oracle Database (except for Oracle Database 18c XE and 21c XE) and put them into the `dockerfiles/<version>` folder. You only need to provide the binaries for the edition you are going to install. The binaries can be downloaded from the [Oracle Technology Network](http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html), make sure you use the linux link: *Linux x86-64*. The needed file is named *linuxx64_\<version\>_database.zip*. You also have to make sure to have internet connectivity for yum. Note that you must not uncompress the binaries. The script will handle that for you and fail if you uncompress them manually!
+**IMPORTANT:** You will have to provide the installation binaries of Oracle Database (except for Oracle Database 18c XE and 21c XE) and put them into the `dockerfiles/<version>` folder. 
+You only need to provide the binaries for the edition you are going to install. The binaries can be downloaded from the [Oracle Technology Network](http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html), make sure you use the linux link: *Linux x86-64*. The needed file is named *linuxx64_\<version\>_database.zip*. 
+You also have to make sure to have internet connectivity for yum. Note that you must not uncompress the binaries. The script will handle that for you and fail if you uncompress them manually!
 
 Before you build the image make sure that you have provided the installation binaries and put them into the right folder. Once you have chosen which edition and version you want to build an image of, go into the **dockerfiles** folder and run the **buildContainerImage.sh** script:
 
@@ -53,13 +55,14 @@ Before you build the image make sure that you have provided the installation bin
 
 You may extend the image with your own Dockerfile and create the users and tablespaces that you may need.
 
-The character set for the database is set during creating of the database. 11gR2 Express Edition supports only UTF-8. You can set the character set for the Standard Edition 2 and Enterprise Edition during the first run of your container and may keep separate folders containing different tablespaces with different character sets.
+The character set for the database is set during creating of the database. 11gR2 Express Edition supports only UTF-8. 
+You can set the character set for the Standard Edition 2 and Enterprise Edition during the first run of your container and may keep separate folders containing different tablespaces with different character sets.
 
 **NOTE**: This section is intended for container images 19c or higher which has patching extension support. By default, SLIMMING is **true** to remove some components from the image with the intention of making the image slimmer. These removed components cause problems while patching after building patching extension. So, to use patching extension one should use additional build argument `-o '--build-arg SLIMMING=false'` while building the container image. Example command for building the container image is as follows:
 
     ./buildContainerImage.sh -e -v 21.3.0 -o '--build-arg SLIMMING=false'
 
-##### Building the container images using Podman
+#### Building the container images using Podman
 Building Oracle Database container images using Podman is similar to Docker. Some additional environment variables are required to be set for proper functioning. The description is as follows:
 
 - `export BUILDAH_FORMAT=docker` (Required to support `HEALTHCHECK` specified in the Dockerfile)
@@ -67,9 +70,8 @@ Building Oracle Database container images using Podman is similar to Docker. Som
 
 After setting these environment variables, the container image can be built using `buildContainerImage.sh` script as follows:
 
-```bash
-./buildContainerImage.sh -e -v <version-to-build>
-```
+    ./buildContainerImage.sh -e -v <version-to-build>
+
 
 ### Running Oracle Database in a container
 
@@ -155,13 +157,13 @@ The Oracle Database inside the container also has Oracle Enterprise Manager Expr
 
 #### Securely specifying the password when using Podman (Supported from 19.3.0 onwards)
 `Podman secret` is supported if the user uses the podman runtime and needs to specify the password to the container securely. The user needs to create a secret first with the name **oracle_pwd**, and then run the container image after specifying the secret in the `run` command. The example commands are as follows:
-```bash
+
     # Creating podman secret
     echo "<Your Password>" | podman secret create oracle_pwd -
 
     # Running the Oracle Database 21c XE image with the secret
     podman run -d --name=<container_name> --secret=oracle_pwd oracle/database:21.3.0-xe
-```
+
 
 #### Selecting the Edition (Supported from 19.3.0 release)
 
@@ -206,37 +208,37 @@ There are two ways to enable TCPS connections for the database:
 To enable TCPS connections while creating the database, use the `-e ENABLE_TCPS=true` option with the `docker run` command. A listener endpoint will be created at the container port 2484 for TCPS.
 
 To enable TCPS connections after the database is created, please use the following sample command:
-```bash
+
     # Creates Listener for TCPS at container port 2484
     docker exec -it <container name> /opt/oracle/configTcps.sh
-```
+
 
 Similarly, to disable TCPS connections for the database, please use the following command:
-```bash
+
     # Disable TCPS in the database
     docker exec -it <container name> /opt/oracle/configTcps.sh disable
-```
+
 
 **NOTE**:
 - Only database server authentication is supported (no mTLS).
 - The container port at which TCPS listener is listening (i.e. 2484) should be exposed and mapped to some host port using `-p <host-port>:2484` option in the `docker run` command. It is required to connect to the database from the outside world using TCPS.
 - When TCPS is enabled, a self-signed certificate will be created. For users' convenience, a client-side wallet is prepared and stored at the location `/opt/oracle/oradata/clientWallet/$ORACLE_SID`. You can use this client wallet along with SQL\*Plus to connect to the database. The sample command to download the client wallet is as follows:
-    ```bash
+    
         # ORACLE_SID default value is ORCLCDB
         docker cp <container name>:/opt/oracle/oradata/clientWallet/<ORACLE_SID> <destination directory>
-    ```
+   
 - The client wallet directory above will include wallet files, along with sample `sqlnet.ora` and `tnsnames.ora` files. You should edit the `HOST` and `PORT` fields accordingly in the `tnsnames.ora` before connecting using TCPS.
 - After `tnsnames.ora` is modified, go inside the downloaded client wallet directory and set TNS_ADMIN for SQL\*Plus by using the `export TNS_ADMIN=$(pwd)` command. Then users can connect via TCPS with, for example, the following commands:
-    ```bash
-    # Connecting Enterprise Edition
-    sqlplus sys@ORCLCDB as sysdba
-    # Connecting Express Edition
-    sqlplus sys@XE as sysdba
-    ```
+    
+        # Connecting Enterprise Edition
+        sqlplus sys@ORCLCDB as sysdba
+        # Connecting Express Edition
+        sqlplus sys@XE as sysdba
+    
 - The certificate used with TCPS has validity for 1 year. After the certificate is expired, you can renew it using the following command:
-    ```bash
+    
         docker exec -it <container name> /opt/oracle/configTcps.sh
-    ```
+    
     After certificate renewal, the client wallet should be updated by downloading it again.
 - Supports Oracle Database XE version 21.3.0 onwards.
 
@@ -284,7 +286,7 @@ On the first startup of the container a random password will be generated for th
 
     docker exec <container name> /opt/oracle/setPassword.sh <your password>
 
-**Important Note:** 
+**Important Note:**
 The ORACLE_SID for Express Edition is always `XE` and cannot be changed, hence there is no ORACLE_SID parameter provided for the XE build.
 
 #### Running Oracle Database 11gR2 Express Edition in a container
@@ -337,24 +339,24 @@ Once the container has been started you can connect to it just like to any other
     sqlplus system/<your password>@//localhost:1521/XE
 
 ### Containerizing an on-premise database (Supported from version 19.3.0 release)
-To containerize an on-premise database, please follow the steps mentioned below: 
+To containerize an on-premise database, please follow the steps mentioned below:
 
 - Create the gold image from the on-premise database. The required command is as follows:
-```bash
-cd $ORACLE_HOME && ./runInstaller -silent -createGoldImage -destinationLocation '<location to store the gold image>'
-``` 
+    
+        cd $ORACLE_HOME && ./runInstaller -silent -createGoldImage -destinationLocation '<location to store the gold image>'
+    
 - The gold image created in the step above will have the name like `db_home_2022-03-25_12-43-21PM.zip`. Copy this gold image to the `OracleDatabase/SingleInstance/dockerfiles/<version>` directory. The **version** would be the base version of the gold image, e.g. 19.3.0.
 - Create the container image using this gold image by the following sample command:
-```bash
-./buildContainerImage.sh -i -e -v 19.3.0 -t oracle/database:19-onprem -o '--build-arg INSTALL_FILE_1=db_home_2022-03-25_12-43-21PM.zip'
-```
+   
+        ./buildContainerImage.sh -i -e -v 19.3.0 -t oracle/database:19-onprem -o '--build-arg INSTALL_FILE_1=db_home_2022-03-25_12-43-21PM.zip'
+    
 - Run the container image created above with cloning option to clone the data files of the on-premise database. The sample command is as follows:
-```bash
-docker run --name <container-name> -e CLONE_DB=true \
--e ORACLE_PWD='<sys password of the on-prem database>' \
--e PRIMARY_DB_CONN_STR='<the on-prem database connection string in <HOST>:<PORT>/<SERVICE_NAME> format>' \
-oracle/database:19-onprem
-```
+    
+        docker run --name <container-name> -e CLONE_DB=true \
+        -e ORACLE_PWD='<sys password of the on-prem database>' \
+        -e PRIMARY_DB_CONN_STR='<the on-prem database connection string in <HOST>:<PORT>/<SERVICE_NAME> format>' \
+        oracle/database:19-onprem
+    
 **NOTE:**
 Make sure that the directory structure of the on-premise database matches with the directory structure used in the container image.
 

--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -233,7 +233,7 @@ Similarly, to disable TCPS connections for the database, please use the followin
     # Connecting Express Edition
     sqlplus sys@XE as sysdba
     ```
-- The certificate used with TCPS has validity for 3 years. After the certificate is expired, you can renew it using the following command:
+- The certificate used with TCPS has validity for 1 year. After the certificate is expired, you can renew it using the following command:
     ```bash
         docker exec -it <container name> /opt/oracle/configTcps.sh
     ```

--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -20,8 +20,8 @@ The `buildContainerImage.sh` script is just a utility shell script that performs
 
 ### Building Oracle Database container images
 
-**IMPORTANT:** You will have to provide the installation binaries of Oracle Database (except for Oracle Database 18c XE and 21c XE) and put them into the `dockerfiles/<version>` folder. 
-You only need to provide the binaries for the edition you are going to install. The binaries can be downloaded from the [Oracle Technology Network](http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html), make sure you use the linux link: *Linux x86-64*. The needed file is named *linuxx64_\<version\>_database.zip*. 
+**IMPORTANT:** You will have to provide the installation binaries of Oracle Database (except for Oracle Database 18c XE and 21c XE) and put them into the `dockerfiles/<version>` folder.
+You only need to provide the binaries for the edition you are going to install. The binaries can be downloaded from the [Oracle Technology Network](http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html), make sure you use the linux link: *Linux x86-64*. The needed file is named *linuxx64_\<version\>_database.zip*.
 You also have to make sure to have internet connectivity for yum. Note that you must not uncompress the binaries. The script will handle that for you and fail if you uncompress them manually!
 
 Before you build the image make sure that you have provided the installation binaries and put them into the right folder. Once you have chosen which edition and version you want to build an image of, go into the **dockerfiles** folder and run the **buildContainerImage.sh** script:
@@ -55,23 +55,24 @@ Before you build the image make sure that you have provided the installation bin
 
 You may extend the image with your own Dockerfile and create the users and tablespaces that you may need.
 
-The character set for the database is set during creating of the database. 11gR2 Express Edition supports only UTF-8. 
+The character set for the database is set during creating of the database. 11gR2 Express Edition supports only UTF-8.
 You can set the character set for the Standard Edition 2 and Enterprise Edition during the first run of your container and may keep separate folders containing different tablespaces with different character sets.
 
-**NOTE**: This section is intended for container images 19c or higher which has patching extension support. By default, SLIMMING is **true** to remove some components from the image with the intention of making the image slimmer. These removed components cause problems while patching after building patching extension. So, to use patching extension one should use additional build argument `-o '--build-arg SLIMMING=false'` while building the container image. Example command for building the container image is as follows:
+**NOTE**: This section is intended for container images 19c or higher which has patching extension support. By default, SLIMMING is **true** to remove some components from the image with the intention of making the image slimmer. These removed components cause problems while patching after building patching extension.
+So, to use patching extension one should use additional build argument `-o '--build-arg SLIMMING=false'` while building the container image. Example command for building the container image is as follows:
 
     ./buildContainerImage.sh -e -v 21.3.0 -o '--build-arg SLIMMING=false'
 
 #### Building the container images using Podman
+
 Building Oracle Database container images using Podman is similar to Docker. Some additional environment variables are required to be set for proper functioning. The description is as follows:
 
-- `export BUILDAH_FORMAT=docker` (Required to support `HEALTHCHECK` specified in the Dockerfile)
-- `export BUILDAH_ISOLATION=chroot` (Required while building the container image in rootless mode)
+* `export BUILDAH_FORMAT=docker` (Required to support `HEALTHCHECK` specified in the Dockerfile)
+* `export BUILDAH_ISOLATION=chroot` (Required while building the container image in rootless mode)
 
 After setting these environment variables, the container image can be built using `buildContainerImage.sh` script as follows:
 
     ./buildContainerImage.sh -e -v <version-to-build>
-
 
 ### Running Oracle Database in a container
 
@@ -156,6 +157,7 @@ The Oracle Database inside the container also has Oracle Enterprise Manager Expr
 **NOTE**: Oracle Database bypasses file system level caching for some of the files by using the `O_DIRECT` flag. It is not advised to run the container on a file system that does not support the `O_DIRECT` flag.
 
 #### Securely specifying the password when using Podman (Supported from 19.3.0 onwards)
+
 `Podman secret` is supported if the user uses the podman runtime and needs to specify the password to the container securely. The user needs to create a secret first with the name **oracle_pwd**, and then run the container image after specifying the secret in the `run` command. The example commands are as follows:
 
     # Creating podman secret
@@ -163,7 +165,6 @@ The Oracle Database inside the container also has Oracle Enterprise Manager Expr
 
     # Running the Oracle Database 21c XE image with the secret
     podman run -d --name=<container_name> --secret=oracle_pwd oracle/database:21.3.0-xe
-
 
 #### Selecting the Edition (Supported from 19.3.0 release)
 
@@ -194,6 +195,7 @@ The password for those accounts can be changed via the `docker exec` command. **
     docker exec <container name> ./setPassword.sh <your password>
 
 This new password will be used afterwards.
+
 #### Enabling archive log mode while creating the database
 
 Archive mode can be enabled during the first time when database is created by setting ENABLE_ARCHIVELOG to `true` and passing it to `docker run` command. Archive logs are stored at the directory location: `/opt/oracle/oradata/$ORACLE_SID/archive_logs` inside the container.
@@ -201,7 +203,9 @@ Archive mode can be enabled during the first time when database is created by se
 In case this parameter is set `true` and passed to `docker run` command while reusing existing datafiles, even though this parameter would be visible as set to `true` in the container environment, this would not be set inside the database. The value used at the time of database creation will be used.
 
 #### Configuring TCPS connections for Oracle Database (Supported from version 19.3.0 onwards)
+
 There are two ways to enable TCPS connections for the database:
+
 1. Enable TCPS while creating the database.
 2. Enable TCPS after the database is created.
 
@@ -212,36 +216,34 @@ To enable TCPS connections after the database is created, please use the followi
     # Creates Listener for TCPS at container port 2484
     docker exec -it <container name> /opt/oracle/configTcps.sh
 
-
 Similarly, to disable TCPS connections for the database, please use the following command:
 
     # Disable TCPS in the database
     docker exec -it <container name> /opt/oracle/configTcps.sh disable
 
-
 **NOTE**:
-- Only database server authentication is supported (no mTLS).
-- The container port at which TCPS listener is listening (i.e. 2484) should be exposed and mapped to some host port using `-p <host-port>:2484` option in the `docker run` command. It is required to connect to the database from the outside world using TCPS.
-- When TCPS is enabled, a self-signed certificate will be created. For users' convenience, a client-side wallet is prepared and stored at the location `/opt/oracle/oradata/clientWallet/$ORACLE_SID`. You can use this client wallet along with SQL\*Plus to connect to the database. The sample command to download the client wallet is as follows:
-    
+
+* Only database server authentication is supported (no mTLS).
+* The container port at which TCPS listener is listening (i.e. 2484) should be exposed and mapped to some host port using `-p <host-port>:2484` option in the `docker run` command. It is required to connect to the database from the outside world using TCPS.
+* When TCPS is enabled, a self-signed certificate will be created. For users' convenience, a client-side wallet is prepared and stored at the location `/opt/oracle/oradata/clientWallet/$ORACLE_SID`. You can use this client wallet along with SQL\*Plus to connect to the database. The sample command to download the client wallet is as follows:
+
         # ORACLE_SID default value is ORCLCDB
         docker cp <container name>:/opt/oracle/oradata/clientWallet/<ORACLE_SID> <destination directory>
-   
-- The client wallet directory above will include wallet files, along with sample `sqlnet.ora` and `tnsnames.ora` files. You should edit the `HOST` and `PORT` fields accordingly in the `tnsnames.ora` before connecting using TCPS.
-- After `tnsnames.ora` is modified, go inside the downloaded client wallet directory and set TNS_ADMIN for SQL\*Plus by using the `export TNS_ADMIN=$(pwd)` command. Then users can connect via TCPS with, for example, the following commands:
-    
+
+* The client wallet directory above will include wallet files, along with sample `sqlnet.ora` and `tnsnames.ora` files. You should edit the `HOST` and `PORT` fields accordingly in the `tnsnames.ora` before connecting using TCPS.
+* After `tnsnames.ora` is modified, go inside the downloaded client wallet directory and set TNS_ADMIN for SQL\*Plus by using the `export TNS_ADMIN=$(pwd)` command. Then users can connect via TCPS with, for example, the following commands:
+
         # Connecting Enterprise Edition
         sqlplus sys@ORCLCDB as sysdba
         # Connecting Express Edition
         sqlplus sys@XE as sysdba
-    
-- The certificate used with TCPS has validity for 1 year. After the certificate is expired, you can renew it using the following command:
-    
-        docker exec -it <container name> /opt/oracle/configTcps.sh
-    
-    After certificate renewal, the client wallet should be updated by downloading it again.
-- Supports Oracle Database XE version 21.3.0 onwards.
 
+* The certificate used with TCPS has validity for 1 year. After the certificate is expired, you can renew it using the following command:
+
+        docker exec -it <container name> /opt/oracle/configTcps.sh
+
+    After certificate renewal, the client wallet should be updated by downloading it again.
+* Supports Oracle Database XE version 21.3.0 onwards.
 
 #### Running Oracle Database 21c/18c Express Edition in a container
 
@@ -339,24 +341,25 @@ Once the container has been started you can connect to it just like to any other
     sqlplus system/<your password>@//localhost:1521/XE
 
 ### Containerizing an on-premise database (Supported from version 19.3.0 release)
+
 To containerize an on-premise database, please follow the steps mentioned below:
 
-- Create the gold image from the on-premise database. The required command is as follows:
-    
+* Create the gold image from the on-premise database. The required command is as follows:
+
         cd $ORACLE_HOME && ./runInstaller -silent -createGoldImage -destinationLocation '<location to store the gold image>'
-    
-- The gold image created in the step above will have the name like `db_home_2022-03-25_12-43-21PM.zip`. Copy this gold image to the `OracleDatabase/SingleInstance/dockerfiles/<version>` directory. The **version** would be the base version of the gold image, e.g. 19.3.0.
-- Create the container image using this gold image by the following sample command:
-   
+
+* The gold image created in the step above will have the name like `db_home_2022-03-25_12-43-21PM.zip`. Copy this gold image to the `OracleDatabase/SingleInstance/dockerfiles/<version>` directory. The **version** would be the base version of the gold image, e.g. 19.3.0.
+* Create the container image using this gold image by the following sample command:
+
         ./buildContainerImage.sh -i -e -v 19.3.0 -t oracle/database:19-onprem -o '--build-arg INSTALL_FILE_1=db_home_2022-03-25_12-43-21PM.zip'
-    
-- Run the container image created above with cloning option to clone the data files of the on-premise database. The sample command is as follows:
-    
+
+* Run the container image created above with cloning option to clone the data files of the on-premise database. The sample command is as follows:
+
         docker run --name <container-name> -e CLONE_DB=true \
         -e ORACLE_PWD='<sys password of the on-prem database>' \
         -e PRIMARY_DB_CONN_STR='<the on-prem database connection string in <HOST>:<PORT>/<SERVICE_NAME> format>' \
         oracle/database:19-onprem
-    
+
 **NOTE:**
 Make sure that the directory structure of the on-premise database matches with the directory structure used in the container image.
 

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/configTcps.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/configTcps.sh
@@ -25,9 +25,16 @@ function setupClientWallet() {
     fi
 
     # Create the client wallet
-    orapki wallet create -wallet "${CLIENT_WALLET_LOC}" -pwd "$WALLET_PWD" -auto_login
+    orapki wallet create -wallet "${CLIENT_WALLET_LOC}" -auto_login <<EOF
+${WALLET_PWD}
+${WALLET_PWD}
+EOF
+
     # Add the certificate
-    orapki wallet add -wallet "${CLIENT_WALLET_LOC}" -pwd "$WALLET_PWD" -trusted_cert -cert /tmp/"$(hostname)"-certificate.crt
+    orapki wallet add -wallet "${CLIENT_WALLET_LOC}" -trusted_cert -cert /tmp/"$(hostname)"-certificate.crt <<EOF
+${WALLET_PWD}
+EOF
+
     # Removing cert from /tmp location
     rm /tmp/"$(hostname)"-certificate.crt
 
@@ -118,7 +125,7 @@ ORACLE_PDB=${ORACLE_PDB^^}
 WALLET_LOC="${ORACLE_BASE}/oradata/dbconfig/${ORACLE_SID}/.tls-wallet"
 
 # Random wallet Password
-WALLET_PWD=$(openssl rand -hex 4)
+WALLET_PWD=$(openssl rand -hex 8)
 
 # Client wallet location
 CLIENT_WALLET_LOC="${ORACLE_BASE}/oradata/clientWallet/${ORACLE_SID}"
@@ -148,18 +155,25 @@ else
     echo -e "\nCleaning up existing wallet..."
     rm -f "${WALLET_LOC}"/*
 fi
-orapki wallet create -wallet "${WALLET_LOC}" -pwd "${WALLET_PWD}" -auto_login
+orapki wallet create -wallet "${WALLET_LOC}" -auto_login <<EOF
+${WALLET_PWD}
+${WALLET_PWD}
+EOF
+
 echo -e "\nOracle Wallet location: ${WALLET_LOC}\n"
 
-# Create a self-signed certificate using orapki utility; VALIDITY: 1095 days
-orapki wallet add -wallet "${WALLET_LOC}" -pwd "${WALLET_PWD}" -dn "CN=localhost" -keysize 2048 -self_signed -validity 1095
-
+# Create a self-signed certificate using orapki utility; VALIDITY: 365 days
+orapki wallet add -wallet "${WALLET_LOC}" -dn "CN=localhost" -keysize 2048 -self_signed -validity 365 <<EOF
+${WALLET_PWD}
+EOF
 
 # Reconfigure listener to enable TCPS (Reload wouldn't work here)
 reconfigure_listener
 
 # Export the cert to be updated in the client wallet
-orapki wallet export -wallet "${WALLET_LOC}" -pwd "${WALLET_PWD}" -dn "CN=localhost" -cert /tmp/"$(hostname)"-certificate.crt
-
+orapki wallet export -wallet "${WALLET_LOC}" -dn "CN=localhost" -cert /tmp/"$(hostname)"-certificate.crt <<EOF
+${WALLET_PWD}
+EOF
+ 
 # Update the client wallet
 setupClientWallet


### PR DESCRIPTION
- Taking password from standard input for wallet
- Using 8 byte long randomly generated password for wallet
- Reducing cert validity for 1yr

Signed-off-by: abhisbyk <abhishek.by.kumar@oracle.com>