### PR TITLE
fix: value for formatting the version number

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/buildContainerImage.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/buildContainerImage.sh
@@ -87,7 +87,7 @@ checkPodmanVersion() {
 checkDockerVersion() {
   # Get Docker Server version
   echo "Checking Docker version."
-  DOCKER_VERSION=$("${CONTAINER_RUNTIME}" version --format '{{.Server.Version | printf "%.5s" }}'|| exit 0)
+  DOCKER_VERSION=$("${CONTAINER_RUNTIME}" version --format '{{.Server.Version | printf "%.8s" }}'|| exit 0)
   # Remove dot in Docker version
   DOCKER_VERSION=${DOCKER_VERSION//./}
 


### PR DESCRIPTION
According to issue #2556, the value `"%.5s"` in line 90,for formatting the version number given, doesn't verify all numbers needed and cuts the last value of given string, like number version of `23.0.0`.  Executing the line 
`/usr/bin/docker version --format '{{.Server.Version | printf "%.5s" }}'`  corresponding to the original line 90 in the script, we have: `23.0.`
Which make the condition fails.
Using `"%.8s"` the condition works properly. Any number like 23.45.01 will be verified.