### PR TITLE
Fix version check for docker 23+

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/buildContainerImage.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/buildContainerImage.sh
@@ -105,14 +105,15 @@ checkDockerVersion() {
 ##############
 
 # Go into dockerfiles directory
-cd $(dirname $0)
+cd "$(dirname "$0")"
 
 # Parameters
 ENTERPRISE=0
 STANDARD=0
 EXPRESS=0
 # Obtaining the latest version to build
-VERSION="$(ls -1rd *.*.* | sed -n 1p)"
+# shellcheck disable=SC2012
+VERSION="$(ls -1rd ./*.*.* | sed -n 1p)"
 SKIPMD5=0
 declare -a BUILD_OPTS
 MIN_DOCKER_VERSION="17.09"
@@ -250,7 +251,7 @@ echo "Building image '${IMAGE_NAME}' ..."
 # BUILD THE IMAGE (replace all environment variables)
 BUILD_START=$(date '+%s')
 "${CONTAINER_RUNTIME}" build --force-rm=true --no-cache=true \
-       "${BUILD_OPTS[@]}" "${PROXY_SETTINGS[@]}" --build-arg DB_EDITION=${EDITION} \
+       "${BUILD_OPTS[@]}" "${PROXY_SETTINGS[@]}" --build-arg DB_EDITION="${EDITION}" \
        -t "${IMAGE_NAME}" -f "${DOCKERFILE}" . || {
   echo ""
   echo "ERROR: Oracle Database container image was NOT successfully created."

--- a/OracleDatabase/SingleInstance/dockerfiles/buildContainerImage.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/buildContainerImage.sh
@@ -87,7 +87,9 @@ checkPodmanVersion() {
 checkDockerVersion() {
   # Get Docker Server version
   echo "Checking Docker version."
-  DOCKER_VERSION=$("${CONTAINER_RUNTIME}" version --format '{{.Server.Version | printf "%.5s" }}'|| exit 0)
+  DOCKER_VERSION=$("${CONTAINER_RUNTIME}" version --format '{{.Server.Version}}' | grep -oE '^[0-9]+\.[0-9]+')
+  # Ensure 23.0 becomes 23.00
+  DOCKER_VERSION=$(printf "%.2f" "${DOCKER_VERSION}")
   # Remove dot in Docker version
   DOCKER_VERSION=${DOCKER_VERSION//./}
 


### PR DESCRIPTION
Since version 23 of Docker, they switched away from CalVer to SemVer, which means their versions no longer looks like `23.01` but instead `23.1`.

The buildContainer script fails with docker v23 with:

```console
$ ./buildContainerImage.sh -v 21.3.0 -x -t oracle:xe-21.3.0
WARNING: No swap limit support
Checking Docker version.
Docker version is below the minimum required version 17.09
Please upgrade your Docker installation to proceed.
```

This changes the logic on how the version of docker was being checked so that it works for both the older and the new format.
