### PR TITLE
Resolved docker version 23.0 issue

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/buildContainerImage.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/buildContainerImage.sh
@@ -87,7 +87,7 @@ checkPodmanVersion() {
 checkDockerVersion() {
   # Get Docker Server version
   echo "Checking Docker version."
-  DOCKER_VERSION=$("${CONTAINER_RUNTIME}" version --format '{{.Server.Version | printf "%.5s" }}'|| exit 0)
+  DOCKER_VERSION=$("${CONTAINER_RUNTIME}" version --format '{{.Server.Version }}'|| exit 0)
   # Remove dot in Docker version
   DOCKER_VERSION=${DOCKER_VERSION//./}
 


### PR DESCRIPTION
Previous Line 90 of buildContainerImage.sh will work for all docker versions before 23.0. Min version of docker as per code is 17.09, which is converted to 1709 by the code before comparison. For versions before 23.0, taking 5 letters works. But from docker version 23.0 onwards, 23.0.0, 23.0.1, etc. are converted to 23.0. (when 1st 5 letters are taken) and it becomes 230 after removing the decimal point as per code logic. So, the comparison of 230 > 1709 fails. Removing printf "%.5s" will resolve this.