### PR TITLE
Update from cx_Oracle to python-oracledb

### DIFF
--- a/OracleLinuxDevelopers/oraclelinux7/python/3.6-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/python/3.6-oracledb/Dockerfile
@@ -8,11 +8,10 @@ RUN yum -y install oraclelinux-developer-release-el7 && \
                    python3-pip \
                    python3-setuptools \
                    python3-oracledb && \
+    # Optionally install Oracle Instant Client if you want to use python-oracledb Thick mode
+    # yum -y install oracle-instantclient-release-el7 && \
+    # yum -y install oracle-instantclient-basic && \
     rm -rf /var/cache/yum/*
 
-# Optionally install Oracle Instant Client to use python-oracledb Thick mode
-#RUN yum -y install oracle-instantclient-release-el7 && \
-#    yum -y install oracle-instantclient-basic && \
-#    rm -rf /var/cache/yum/*
 
-CMD ["/bin/python3","--version"]
+CMD ["/bin/python3", "--version"]

--- a/OracleLinuxDevelopers/oraclelinux7/python/3.6-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/python/3.6-oracledb/Dockerfile
@@ -1,13 +1,18 @@
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 FROM oraclelinux:7-slim
 
-RUN yum -y install oraclelinux-developer-release-el7 oracle-instantclient-release-el7 && \
+RUN yum -y install oraclelinux-developer-release-el7 && \
     yum -y install python3 \
                    python3-libs \
                    python3-pip \
                    python3-setuptools \
-                   python36-cx_Oracle && \
+                   python3-oracledb && \
     rm -rf /var/cache/yum/*
+
+# Optionally install Oracle Instant Client to use python-oracledb Thick mode
+#RUN yum -y install oracle-instantclient-release-el7 && \
+#    yum -y install oracle-instantclient-basic && \
+#    rm -rf /var/cache/yum/*
 
 CMD ["/bin/python3","--version"]

--- a/OracleLinuxDevelopers/oraclelinux8/python/3.6-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/python/3.6-oracledb/Dockerfile
@@ -1,12 +1,16 @@
-# Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 FROM ghcr.io/oracle/oraclelinux:8
 
-RUN dnf -y install oracle-instantclient-release-el8 oraclelinux-developer-release-el8 && \
+RUN dnf -y install oraclelinux-developer-release-el8 && \
     dnf -y module enable python36 && \
-    dnf -y install oracle-instantclient-basic \
-                   python36 python3-pip python3-setuptools python36-cx_Oracle && \
+    dnf -y install python36 python3-pip python3-setuptools python3-oracledb && \
     rm -rf /var/cache/dnf
 
-CMD ["/bin/python3", "-V"]
+# Optionally install Oracle Instant Client to use python-oracledb Thick mode
+#RUN dnf -y install oracle-instantclient-release-el8 && \
+#    dnf -y install oracle-instantclient-basic && \
+#    rm -rf /var/cache/dnf
+
+CMD ["/bin/python3", "--version"]

--- a/OracleLinuxDevelopers/oraclelinux8/python/3.6-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/python/3.6-oracledb/Dockerfile
@@ -6,11 +6,10 @@ FROM ghcr.io/oracle/oraclelinux:8
 RUN dnf -y install oraclelinux-developer-release-el8 && \
     dnf -y module enable python36 && \
     dnf -y install python36 python3-pip python3-setuptools python3-oracledb && \
+    # Optionally install Oracle Instant Client to use python-oracledb Thick mode
+    # dnf -y install oracle-instantclient-release-el8 && \
+    # dnf -y install oracle-instantclient-basic && \
     rm -rf /var/cache/dnf
 
-# Optionally install Oracle Instant Client to use python-oracledb Thick mode
-#RUN dnf -y install oracle-instantclient-release-el8 && \
-#    dnf -y install oracle-instantclient-basic && \
-#    rm -rf /var/cache/dnf
 
 CMD ["/bin/python3", "--version"]


### PR DESCRIPTION
Update Linux Python / Oracle Database images to use python-oracledb in preference to its predecessor cx_Oracle.