### PR TITLE
Pass wallet password as an optional positional argument

### DIFF
--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -223,8 +223,8 @@ Similarly, to disable TCPS connections for the database, please use the followin
 
 To configure  wallet password, please use the following command:
 
-   # Setup TCPS for port 16002 and pass wallet password as argument
-   docker exec -it <container name> /opt/oracle/configTcps.sh 16002 localhost <WALLET_PWD>
+    # Setup TCPS for port 16002 and pass wallet password as argument
+    docker exec -it <container name> /opt/oracle/configTcps.sh 16002 localhost <WALLET_PWD>
 
 **NOTE**:
 

--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -221,6 +221,11 @@ Similarly, to disable TCPS connections for the database, please use the followin
     # Disable TCPS in the database
     docker exec -it <container name> /opt/oracle/configTcps.sh disable
 
+To configure  wallet password, please use the following command:
+
+   # Setup TCPS for port 16002 and pass wallet password as argument
+   docker exec -it <container name> /opt/oracle/configTcps.sh 16002 localhost <WALLET_PWD>
+
 **NOTE**:
 
 * Only database server authentication is supported (no mTLS).

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/configTcps.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/configTcps.sh
@@ -138,8 +138,16 @@ elif [[ "$1" =~ ^[0-9]+$ ]]; then
   # If TCPS_PORT is not set in the environment, honor the TCPS_PORT passed as the positional argument
   TCPS_PORT=${TCPS_PORT:-"$1"}
   HOSTNAME="$2"
+  # Optional wallet password
+  if [[ ! -z "$3" ]]; then
+      WALLET_PWD="$3"
+  fi
 else
   HOSTNAME="$1"
+  # Optional wallet password
+  if [[ ! -z "$2" ]]; then
+      WALLET_PWD="$2"
+  fi
 fi
 
 # Default TCPS_PORT value

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/configTcps.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/configTcps.sh
@@ -139,13 +139,13 @@ elif [[ "$1" =~ ^[0-9]+$ ]]; then
   TCPS_PORT=${TCPS_PORT:-"$1"}
   HOSTNAME="$2"
   # Optional wallet password
-  if [[ ! -z "$3" ]]; then
+  if [[ -n "$3" ]]; then
       WALLET_PWD="$3"
   fi
 else
   HOSTNAME="$1"
   # Optional wallet password
-  if [[ ! -z "$2" ]]; then
+  if [[ -n "$2" ]]; then
       WALLET_PWD="$2"
   fi
 fi

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/configTcps.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/configTcps.sh
@@ -141,8 +141,16 @@ elif [[ "$1" =~ ^[0-9]+$ ]]; then
   # If TCPS_PORT is not set in the environment, honor the TCPS_PORT passed as the positional argument
   TCPS_PORT=${TCPS_PORT:-"$1"}
   HOSTNAME="$2"
+   # Optional wallet password
+  if [[ ! -z "$3" ]]; then
+      WALLET_PWD="$3"
+  fi
 else
   HOSTNAME="$1"
+  # Optional wallet password
+  if [[ ! -z "$2" ]]; then
+      WALLET_PWD="$2"
+  fi
 fi
 
 # Default TCPS_PORT value

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/configTcps.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/configTcps.sh
@@ -142,13 +142,13 @@ elif [[ "$1" =~ ^[0-9]+$ ]]; then
   TCPS_PORT=${TCPS_PORT:-"$1"}
   HOSTNAME="$2"
    # Optional wallet password
-  if [[ ! -z "$3" ]]; then
+  if [[ -n "$3" ]]; then
       WALLET_PWD="$3"
   fi
 else
   HOSTNAME="$1"
   # Optional wallet password
-  if [[ ! -z "$2" ]]; then
+  if [[ -n "$2" ]]; then
       WALLET_PWD="$2"
   fi
 fi


### PR DESCRIPTION
Fixes https://github.com/oracle/docker-images/issues/2596

This PR adds changes to pass wallet password as an optional argument to `configTcps.sh`

I have tested the changes in the docker container:

1. Create a Database server and client wallet using a custom password

```bash
 ./configTcps.sh 16002 `hostname` <wallet_pwd>
```

2. Export server's certificate using the same wallet password

```bash
orapki wallet export -wallet "/opt/oracle/oradata/dbconfig/.tls-wallet" \
                     -pwd <wallet_pwd> \
                     -dn "CN=localhost" \
                     -cert `hostname`-certificate.crt
```

3. Successfully exported server's certificate 

```
Oracle PKI Tool Release 19.0.0.0.0 - Production
Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.

Operation is successfully completed.
```
