### PR TITLE
Fixed extentions readme file

### DIFF
--- a/OracleDatabase/SingleInstance/extensions/README.md
+++ b/OracleDatabase/SingleInstance/extensions/README.md
@@ -1,6 +1,6 @@
 # Build Extensions
 
-After creating the base image using buildDockerImage.sh, use buildExtensions.sh to build an extended image that will include all features present under the extensions folder.
+After creating the base image using buildContainerImage.sh, use buildExtensions.sh to build an extended image that will include all features present under the extensions folder.
 
 Once you have created the base image, go into the **extensions** folder and run the **buildExtensions.sh** script:
 


### PR DESCRIPTION
The readme file inside the extensions folder has an incorrect file name (buildDockerImage.sh instead of buildContainerImage.sh)