### PR TITLE
tcps db conn fix : disabled oob in sqlnet.ora of DB wallet

### DIFF
--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -236,16 +236,26 @@ To configure  wallet password, please use the following command:
 * The container port at which TCPS listener is listening (i.e. 2484) should be exposed and mapped to some host port using `-p <host-port>:2484` option in the `docker run` command. It is required to connect to the database from the outside world using TCPS.
 * When TCPS is enabled, a self-signed certificate will be created. For users' convenience, a client-side wallet is prepared and stored at the location `/opt/oracle/oradata/clientWallet/$ORACLE_SID`. You can use this client wallet along with SQL\*Plus to connect to the database. The sample command to download the client wallet is as follows:
 
-        # ORACLE_SID default value is ORCLCDB
-        docker cp <container name>:/opt/oracle/oradata/clientWallet/<ORACLE_SID> <destination directory>
+    # ORACLE_SID default value is ORCLCDB
+    docker cp <container name>:/opt/oracle/oradata/clientWallet/<ORACLE_SID> <destination wallet directory>
 
 * The client wallet directory above will include wallet files, along with sample `sqlnet.ora` and `tnsnames.ora` files.
-* To connect to the database via TCPS use EZCONNECT (easy connect naming method) as shown:
+* To connect to the database via TCPS you can use SQL*Plus as shown:
 
-        sqlplus sys@tcps://<host>:<port>/<service_name>?wallet_location=<wallet_directory> as sysdba
-        # service_name could be ORACLE_SID or ORACLE_PDB
+        sqlplus sys@tcps://<host>:<port>/<service_name>?wallet_location=<destination wallet directory> as sysdba
         # port is mapped port of host where container is running
-        # wallet_directory is where client wallet is copied to.
+        # destination wallet directory is where client wallet is copied to.
+
+    OR
+
+* Edit the `HOST` and `PORT` fields in the tnsnames.ora accordingly.
+* After tnsnames.ora is modified, go inside the downloaded client wallet directory and set TNS_ADMIN for SQL*Plus by using the `export TNS_ADMIN=$(pwd)` command. Then users can connect via TCPS with, for example, the following commands:
+
+        # Connecting Enterprise Edition
+        sqlplus sys@ORCLCDB as sysdba
+        # Connecting Express Edition
+        sqlplus sys@XE as sysdba
+
 
 * The certificate used with TCPS has validity for 1 year. After the certificate is expired, you can renew it using the following command:
 

--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -240,12 +240,12 @@ To configure  wallet password, please use the following command:
         docker cp <container name>:/opt/oracle/oradata/clientWallet/<ORACLE_SID> <destination directory>
 
 * The client wallet directory above will include wallet files, along with sample `sqlnet.ora` and `tnsnames.ora` files.
-* To easily connect with the database via TCPS users can use EZCONNECT (easy connect naming method) as shown:
+* To connect to the database via TCPS use EZCONNECT (easy connect naming method) as shown:
 
         sqlplus sys@tcps://<host>:<port>/<service_name>?wallet_location=<wallet_directory> as sysdba
         # service_name could be ORACLE_SID or ORACLE_PDB
         # port is mapped port of host where container is running
-        # wallet_directory is where client walllet is copied to.
+        # wallet_directory is where client wallet is copied to.
 
 * The certificate used with TCPS has validity for 1 year. After the certificate is expired, you can renew it using the following command:
 

--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -236,8 +236,8 @@ To configure  wallet password, please use the following command:
 * The container port at which TCPS listener is listening (i.e. 2484) should be exposed and mapped to some host port using `-p <host-port>:2484` option in the `docker run` command. It is required to connect to the database from the outside world using TCPS.
 * When TCPS is enabled, a self-signed certificate will be created. For users' convenience, a client-side wallet is prepared and stored at the location `/opt/oracle/oradata/clientWallet/$ORACLE_SID`. You can use this client wallet along with SQL\*Plus to connect to the database. The sample command to download the client wallet is as follows:
 
-    # ORACLE_SID default value is ORCLCDB
-    docker cp <container name>:/opt/oracle/oradata/clientWallet/<ORACLE_SID> <destination wallet directory>
+        # ORACLE_SID default value is ORCLCDB
+        docker cp <container name>:/opt/oracle/oradata/clientWallet/<ORACLE_SID> <destination wallet directory>
 
 * The client wallet directory above will include wallet files, along with sample `sqlnet.ora` and `tnsnames.ora` files.
 * To connect to the database via TCPS you can use SQL*Plus as shown:
@@ -255,7 +255,6 @@ To configure  wallet password, please use the following command:
         sqlplus sys@ORCLCDB as sysdba
         # Connecting Express Edition
         sqlplus sys@XE as sysdba
-
 
 * The certificate used with TCPS has validity for 1 year. After the certificate is expired, you can renew it using the following command:
 

--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -243,6 +243,7 @@ To configure  wallet password, please use the following command:
 * To connect to the database via TCPS you can use SQL*Plus as shown:
 
         sqlplus sys@tcps://<host>:<port>/<service_name>?wallet_location=<destination wallet directory> as sysdba
+        # Default value for host is localhost unless specified while running configTcps.sh
         # port is mapped port of host where container is running
         # destination wallet directory is where client wallet is copied to.
 

--- a/OracleDatabase/SingleInstance/README.md
+++ b/OracleDatabase/SingleInstance/README.md
@@ -218,17 +218,17 @@ To enable TCPS connections while creating the database, use the `-e ENABLE_TCPS=
 To enable TCPS connections after the database is created, please use the following sample command:
 
     # Creates Listener for TCPS at container port 2484
-    docker exec -it <container name> /opt/oracle/configTcps.sh
+    docker exec <container name> /opt/oracle/configTcps.sh
 
 Similarly, to disable TCPS connections for the database, please use the following command:
 
     # Disable TCPS in the database
-    docker exec -it <container name> /opt/oracle/configTcps.sh disable
+    docker exec <container name> /opt/oracle/configTcps.sh disable
 
 To configure  wallet password, please use the following command:
 
     # Setup TCPS for port 16002 and pass wallet password as argument
-    docker exec -it <container name> /opt/oracle/configTcps.sh 16002 localhost <WALLET_PWD>
+    docker exec <container name> /opt/oracle/configTcps.sh 16002 localhost <WALLET_PWD>
 
 **NOTE**:
 
@@ -239,17 +239,17 @@ To configure  wallet password, please use the following command:
         # ORACLE_SID default value is ORCLCDB
         docker cp <container name>:/opt/oracle/oradata/clientWallet/<ORACLE_SID> <destination directory>
 
-* The client wallet directory above will include wallet files, along with sample `sqlnet.ora` and `tnsnames.ora` files. You should edit the `HOST` and `PORT` fields accordingly in the `tnsnames.ora` before connecting using TCPS.
-* After `tnsnames.ora` is modified, go inside the downloaded client wallet directory and set TNS_ADMIN for SQL\*Plus by using the `export TNS_ADMIN=$(pwd)` command. Then users can connect via TCPS with, for example, the following commands:
+* The client wallet directory above will include wallet files, along with sample `sqlnet.ora` and `tnsnames.ora` files.
+* To easily connect with the database via TCPS users can use EZCONNECT (easy connect naming method) as shown:
 
-        # Connecting Enterprise Edition
-        sqlplus sys@ORCLCDB as sysdba
-        # Connecting Express Edition
-        sqlplus sys@XE as sysdba
+        sqlplus sys@tcps://<host>:<port>/<service_name>?wallet_location=<wallet_directory> as sysdba
+        # service_name could be ORACLE_SID or ORACLE_PDB
+        # port is mapped port of host where container is running
+        # wallet_directory is where client walllet is copied to.
 
 * The certificate used with TCPS has validity for 1 year. After the certificate is expired, you can renew it using the following command:
 
-        docker exec -it <container name> /opt/oracle/configTcps.sh
+        docker exec <container name> /opt/oracle/configTcps.sh
 
     After certificate renewal, the client wallet should be updated by downloading it again.
 * Supports Oracle Database XE version 21.3.0 onwards.

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/configTcps.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/configTcps.sh
@@ -122,13 +122,11 @@ function disable_tcps() {
 ################## MAIN ###################
 ###########################################
 
-ORACLE_SID="$(grep "$ORACLE_HOME" /etc/oratab | cut -d: -f1)"
+export ORACLE_SID="$(grep "$ORACLE_HOME" /etc/oratab | cut -d: -f1)"
 # Export ORACLE_PDB value
 export ORACLE_PDB=${ORACLE_PDB:-ORCLPDB1}
 ORACLE_PDB=${ORACLE_PDB^^}
 
-# Export ORACLE_SID value
-export ORACLE_SID=${ORACLE_SID}
 
 # Oracle wallet location which stores the certificate
 WALLET_LOC="${ORACLE_BASE}/oradata/dbconfig/${ORACLE_SID}/.tls-wallet"

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/configTcps.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/configTcps.sh
@@ -84,6 +84,9 @@ function configure_netservices() {
    echo "WALLET_LOCATION = (SOURCE = (METHOD = FILE)(METHOD_DATA = (DIRECTORY = $WALLET_LOC)))
 SSL_CLIENT_AUTHENTICATION = FALSE" | tee -a "$ORACLE_BASE"/oradata/dbconfig/"$ORACLE_SID"/{sqlnet.ora,listener.ora} > /dev/null
 
+   # Disable OOB in sqlnet.ora of DB wallet
+   echo "DISABLE_OOB=ON" >> "$ORACLE_BASE"/oradata/dbconfig/"$ORACLE_SID"/sqlnet.ora
+   
    # Add listener for TCPS
    sed -i "/TCP/a\
 \ \ \ \ (ADDRESS = (PROTOCOL = TCPS)(HOST = 0.0.0.0)(PORT = ${TCPS_PORT}))

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/configTcps.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/configTcps.sh
@@ -179,12 +179,8 @@ EOF
 
 echo -e "\nOracle Wallet location: ${WALLET_LOC}\n"
 
-if [ -n "${HOSTNAME}" ]; then
-        DN="CN=${HOSTNAME}"
-fi
-
 # Create a self-signed certificate using orapki utility; VALIDITY: 365 days
-orapki wallet add -wallet "${WALLET_LOC}" -dn "${DN}" -keysize 2048 -self_signed -validity 365 <<EOF
+orapki wallet add -wallet "${WALLET_LOC}" -dn "CN=${HOSTNAME:-localhost}" -keysize 2048 -self_signed -validity 365 <<EOF
 ${WALLET_PWD}
 EOF
 
@@ -192,7 +188,7 @@ EOF
 reconfigure_listener
 
 # Export the cert to be updated in the client wallet
-orapki wallet export -wallet "${WALLET_LOC}" -dn "${DN}" -cert /tmp/"$(hostname)"-certificate.crt <<EOF
+orapki wallet export -wallet "${WALLET_LOC}" -dn "CN=${HOSTNAME:-localhost}" -cert /tmp/"$(hostname)"-certificate.crt <<EOF
 ${WALLET_PWD}
 EOF
  

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/configTcps.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/configTcps.sh
@@ -122,7 +122,9 @@ function disable_tcps() {
 ################## MAIN ###################
 ###########################################
 
-export ORACLE_SID="$(grep "$ORACLE_HOME" /etc/oratab | cut -d: -f1)"
+export ORACLE_SID
+ORACLE_SID="$(grep "$ORACLE_HOME" /etc/oratab | cut -d: -f1)"
+
 # Export ORACLE_PDB value
 export ORACLE_PDB=${ORACLE_PDB:-ORCLPDB1}
 ORACLE_PDB=${ORACLE_PDB^^}

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/configTcps.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/configTcps.sh
@@ -86,7 +86,7 @@ SSL_CLIENT_AUTHENTICATION = FALSE" | tee -a "$ORACLE_BASE"/oradata/dbconfig/"$OR
 
    # Disable OOB in sqlnet.ora of DB wallet
    echo "DISABLE_OOB=ON" >> "$ORACLE_BASE"/oradata/dbconfig/"$ORACLE_SID"/sqlnet.ora
-   
+
    # Add listener for TCPS
    sed -i "/TCP/a\
 \ \ \ \ (ADDRESS = (PROTOCOL = TCPS)(HOST = 0.0.0.0)(PORT = ${TCPS_PORT}))
@@ -98,6 +98,9 @@ SSL_CLIENT_AUTHENTICATION = FALSE" | tee -a "$ORACLE_BASE"/oradata/dbconfig/"$OR
 function reconfigure_listener() {
   lsnrctl stop
   lsnrctl start
+
+# To quickly register a service
+  echo 'alter system register;' | sqlplus -s / as sysdba
 }
 
 # Function for disabling the tcps and restore the previous Oracle Net configuration
@@ -126,6 +129,10 @@ else
   export ORACLE_PDB=${ORACLE_PDB:-ORCLPDB1}
 fi
 ORACLE_PDB=${ORACLE_PDB^^}
+
+# Export ORACLE_SID value
+export ORACLE_SID=${ORACLE_SID}
+
 
 # Oracle wallet location which stores the certificate
 WALLET_LOC="${ORACLE_BASE}/oradata/dbconfig/${ORACLE_SID}/.tls-wallet"
@@ -176,8 +183,12 @@ EOF
 
 echo -e "\nOracle Wallet location: ${WALLET_LOC}\n"
 
+if [ -n "${HOSTNAME}" ]; then
+        DN="CN=${HOSTNAME}"
+fi
+
 # Create a self-signed certificate using orapki utility; VALIDITY: 365 days
-orapki wallet add -wallet "${WALLET_LOC}" -dn "CN=localhost" -keysize 2048 -self_signed -validity 365 <<EOF
+orapki wallet add -wallet "${WALLET_LOC}" -dn "${DN}" -keysize 2048 -self_signed -validity 365 <<EOF
 ${WALLET_PWD}
 EOF
 
@@ -185,7 +196,7 @@ EOF
 reconfigure_listener
 
 # Export the cert to be updated in the client wallet
-orapki wallet export -wallet "${WALLET_LOC}" -dn "CN=localhost" -cert /tmp/"$(hostname)"-certificate.crt <<EOF
+orapki wallet export -wallet "${WALLET_LOC}" -dn "${DN}" -cert /tmp/"$(hostname)"-certificate.crt <<EOF
 ${WALLET_PWD}
 EOF
 

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/configTcps.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/configTcps.sh
@@ -84,6 +84,9 @@ function configure_netservices() {
    echo "WALLET_LOCATION = (SOURCE = (METHOD = FILE)(METHOD_DATA = (DIRECTORY = $WALLET_LOC)))
 SSL_CLIENT_AUTHENTICATION = FALSE" | tee -a "$ORACLE_BASE"/oradata/dbconfig/"$ORACLE_SID"/{sqlnet.ora,listener.ora} > /dev/null
 
+   # Disable OOB in sqlnet.ora of DB wallet
+   echo "DISABLE_OOB=ON" >> "$ORACLE_BASE"/oradata/dbconfig/"$ORACLE_SID"/sqlnet.ora
+   
    # Add listener for TCPS
    sed -i "/TCP/a\
 \ \ \ \ (ADDRESS = (PROTOCOL = TCPS)(HOST = 0.0.0.0)(PORT = ${TCPS_PORT}))

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/configTcps.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/configTcps.sh
@@ -121,7 +121,7 @@ function disable_tcps() {
 ################## MAIN ###################
 ###########################################
 
-ORACLE_SID="$(grep "$ORACLE_HOME" /etc/oratab | cut -d: -f1)"
+export ORACLE_SID="$(grep "$ORACLE_HOME" /etc/oratab | cut -d: -f1)"
 # Export ORACLE_PDB value
 if [ "$ORACLE_SID" == "XE" ]; then
   export ORACLE_PDB="XEPDB1"
@@ -130,8 +130,6 @@ else
 fi
 ORACLE_PDB=${ORACLE_PDB^^}
 
-# Export ORACLE_SID value
-export ORACLE_SID=${ORACLE_SID}
 
 
 # Oracle wallet location which stores the certificate

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/configTcps.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/configTcps.sh
@@ -183,12 +183,8 @@ EOF
 
 echo -e "\nOracle Wallet location: ${WALLET_LOC}\n"
 
-if [ -n "${HOSTNAME}" ]; then
-        DN="CN=${HOSTNAME}"
-fi
-
 # Create a self-signed certificate using orapki utility; VALIDITY: 365 days
-orapki wallet add -wallet "${WALLET_LOC}" -dn "${DN}" -keysize 2048 -self_signed -validity 365 <<EOF
+orapki wallet add -wallet "${WALLET_LOC}" -dn "CN=${HOSTNAME:-localhost}" -keysize 2048 -self_signed -validity 365 <<EOF
 ${WALLET_PWD}
 EOF
 
@@ -196,7 +192,7 @@ EOF
 reconfigure_listener
 
 # Export the cert to be updated in the client wallet
-orapki wallet export -wallet "${WALLET_LOC}" -dn "${DN}" -cert /tmp/"$(hostname)"-certificate.crt <<EOF
+orapki wallet export -wallet "${WALLET_LOC}" -dn "CN=${HOSTNAME:-localhost}" -cert /tmp/"$(hostname)"-certificate.crt <<EOF
 ${WALLET_PWD}
 EOF
 

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/configTcps.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/configTcps.sh
@@ -121,7 +121,9 @@ function disable_tcps() {
 ################## MAIN ###################
 ###########################################
 
-export ORACLE_SID="$(grep "$ORACLE_HOME" /etc/oratab | cut -d: -f1)"
+export ORACLE_SID
+ORACLE_SID="$(grep "$ORACLE_HOME" /etc/oratab | cut -d: -f1)"
+
 # Export ORACLE_PDB value
 if [ "$ORACLE_SID" == "XE" ]; then
   export ORACLE_PDB="XEPDB1"

--- a/OracleDatabase/SingleInstance/dockerfiles/23.2.0/configTcps.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/23.2.0/configTcps.sh
@@ -84,6 +84,9 @@ function configure_netservices() {
    echo "WALLET_LOCATION = (SOURCE = (METHOD = FILE)(METHOD_DATA = (DIRECTORY = $WALLET_LOC)))
 SSL_CLIENT_AUTHENTICATION = FALSE" | tee -a "$ORACLE_BASE"/oradata/dbconfig/"$ORACLE_SID"/{sqlnet.ora,listener.ora} > /dev/null
 
+   # Disable OOB in sqlnet.ora of DB wallet
+   echo "DISABLE_OOB=ON" >> "$ORACLE_BASE"/oradata/dbconfig/"$ORACLE_SID"/sqlnet.ora
+
    # Add listener for TCPS
    sed -i "/TCP/a\
 \ \ \ \ (ADDRESS = (PROTOCOL = TCPS)(HOST = 0.0.0.0)(PORT = ${TCPS_PORT}))
@@ -95,6 +98,9 @@ SSL_CLIENT_AUTHENTICATION = FALSE" | tee -a "$ORACLE_BASE"/oradata/dbconfig/"$OR
 function reconfigure_listener() {
   lsnrctl stop
   lsnrctl start
+
+  # To quickly register a service
+  echo 'alter system register;' | sqlplus -s / as sysdba
 }
 
 # Function for disabling the tcps and restore the previous Oracle Net configuration
@@ -115,7 +121,9 @@ function disable_tcps() {
 ################## MAIN ###################
 ###########################################
 
+export ORACLE_SID
 ORACLE_SID="$(grep "$ORACLE_HOME" /etc/oratab | cut -d: -f1)"
+
 # Export ORACLE_PDB value
 if [ "$ORACLE_SID" == "FREE" ]; then
   export ORACLE_PDB="FREEPDB1"
@@ -166,7 +174,7 @@ EOF
 echo -e "\nOracle Wallet location: ${WALLET_LOC}\n"
 
 # Create a self-signed certificate using orapki utility; VALIDITY: 365 days
-orapki wallet add -wallet "${WALLET_LOC}" -dn "CN=localhost" -keysize 2048 -self_signed -validity 365 <<EOF
+orapki wallet add -wallet "${WALLET_LOC}" -dn "CN=${HOSTNAME:-localhost}" -keysize 2048 -self_signed -validity 365 <<EOF
 ${WALLET_PWD}
 EOF
 
@@ -174,7 +182,7 @@ EOF
 reconfigure_listener
 
 # Export the cert to be updated in the client wallet
-orapki wallet export -wallet "${WALLET_LOC}" -dn "CN=localhost" -cert /tmp/"$(hostname)"-certificate.crt <<EOF
+orapki wallet export -wallet "${WALLET_LOC}" -dn "CN=${HOSTNAME:-localhost}" -cert /tmp/"$(hostname)"-certificate.crt <<EOF
 ${WALLET_PWD}
 EOF
 


### PR DESCRIPTION
Added Disable_oob=on in sqlnet.ora of db wallet in configTcps.sh
For version 19 and 21c.

Tested both tcp and tcps connection thereafter.