### PR TITLE
Updated to resolve bashrc file creation in wrong location in 23.2 free

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/23.2.0/Containerfile.free
+++ b/OracleDatabase/SingleInstance/dockerfiles/23.2.0/Containerfile.free
@@ -23,13 +23,13 @@ FROM oraclelinux:8
 # Labels
 # ------
 LABEL "provider"="Oracle"                                               \
-      "issues"="https://github.com/oracle/docker-images/issues"         \
-      "volume.data"="/opt/oracle/oradata"                               \
-      "volume.setup.location1"="/opt/oracle/scripts/setup"              \
-      "volume.setup.location2"="/docker-entrypoint-initdb.d/setup"      \
-      "volume.startup.location1"="/opt/oracle/scripts/startup"          \
-      "volume.startup.location2"="/docker-entrypoint-initdb.d/startup"  \
-      "port.listener"="1521"                                            
+    "issues"="https://github.com/oracle/docker-images/issues"         \
+    "volume.data"="/opt/oracle/oradata"                               \
+    "volume.setup.location1"="/opt/oracle/scripts/setup"              \
+    "volume.setup.location2"="/docker-entrypoint-initdb.d/setup"      \
+    "volume.startup.location1"="/opt/oracle/scripts/startup"          \
+    "volume.startup.location2"="/docker-entrypoint-initdb.d/startup"  \
+    "port.listener"="1521"                                            
 
 ARG INSTALL_FILE_1="https://download.oracle.com/otn-pub/otn_software/db-free/oracle-database-free-23c-1.0-1.el8.x86_64.rpm"
 
@@ -80,13 +80,14 @@ RUN mkdir -p "$ORACLE_BASE" && \
     rm -rf "$INSTALL_DIR" && \
     "$ORACLE_BASE"/oraInventory/orainstRoot.sh && \
     "$ORACLE_HOME"/root.sh && \
-    echo 'export ORACLE_SID=FREE' > .bashrc
+    echo 'export ORACLE_SID=FREE' >> /home/oracle/.bashrc && \
+    chown oracle.oinstall /home/oracle/.bashrc
 
 USER oracle
 WORKDIR /home/oracle
 
 HEALTHCHECK --interval=1m --start-period=5m --timeout=30s \
-   CMD "$ORACLE_BASE/$CHECK_DB_FILE" >/dev/null || exit 1
+    CMD "$ORACLE_BASE/$CHECK_DB_FILE" >/dev/null || exit 1
 
 EXPOSE 1521/tcp
 


### PR DESCRIPTION
Resolved bashrc creation in wrong location issue in 23.2 free database. It is supposed to be created inside /home/oracle/ and not inside /root.