### PR TITLE
Fixed issue 2660 (arm64 container fails to start)

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
@@ -141,4 +141,4 @@ HEALTHCHECK --interval=1m --start-period=5m --timeout=30s \
    CMD "$ORACLE_BASE/$CHECK_DB_FILE" >/dev/null || exit 1
 
 # Define default command to start Oracle Database. 
-CMD [ "exec", "$ORACLE_BASE/$RUN_FILE" ]
+CMD [ "/bin/bash", "-c", "exec $ORACLE_BASE/$RUN_FILE" ]


### PR DESCRIPTION
This issue 2660 was caused while trying to fix a lint issue. Fixed by updating Dockerfile. 