### PR TITLE
Fixed condition check for edition in runOracle.sh for arm64 platforms

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -113,7 +113,7 @@ EOF
 
 # Only EE is supported for 19c on ARM64 platform
 if [ "$(arch)" == "aarch64" ] || [ "$(arch)" == "arm64" ]; then
-  if [ "${ORACLE_EDITION^^}" != "ENTERPRISE" ]; then
+  if { [ "${ORACLE_EDITION^^}" != "" ] && [ "${ORACLE_EDITION^^}" != "ENTERPRISE" ]; }; then
     echo "${ORACLE_EDITION} edition is not supported on ARM64 platform.";
     exit 1;
   fi;


### PR DESCRIPTION
Fixed condition check for edition in runOracle.sh on arm64 platforms. ORACLE_EDITION is optional parameter for podman run. So if we don't pass it then also podman run command should not fail/exit.