### PR TITLE
Update oracle-db helm chart to re-use existing secret

### DIFF
--- a/OracleDatabase/SingleInstance/helm-charts/oracle-db/templates/secrets.yaml
+++ b/OracleDatabase/SingleInstance/helm-charts/oracle-db/templates/secrets.yaml
@@ -4,12 +4,16 @@
 #
 
 ---
+{{- $secretName := (include "fullname" .) -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ $secretName }}
 {{- include "oracle-db-labels" . | indent 2 }}
 stringData:
-  oracle_pwd: {{ default (randAlphaNum 10) .Values.oracle_pwd | quote }}
+{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace $secretName) | default dict }}
+{{- $secretData := (get $secretObj "data") | default dict }}
+{{- $pwdSecret := (get $secretData "oracle_pwd") | b64dec | default .Values.oracle_pwd | default (randAlphaNum 10)  }}
+  oracle_pwd: {{ $pwdSecret | quote }}
 ---
 


### PR DESCRIPTION
This fixes issue #2676 

The helm chart will now randomly generate a value for the oracle_pwd secret only if the secret does not already exist. If the secret does exist, it will look it up and use the existing value.