### PR TITLE
Java oct2023 cpu

### DIFF
--- a/OracleJava/11/Dockerfile
+++ b/OracleJava/11/Dockerfile
@@ -47,10 +47,10 @@ RUN set -eux; \
     if [ "$ARCH" = "x86_64" ]; \
     then \
 		mv "$(ls /tmp/jdk-11*_linux-x64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
-        JAVA_SHA256=b4eb49c123e2cf2ed7cb068a37b84eb75fcf1e76c3620d3378f5735e11a8508b ; \
+        JAVA_SHA256=612b6687c185b2b0f0651d5ca2cfd1dfd5936418e9bf0b169b516e83d18d178d ; \
     else \
 	    mv "$(ls /tmp/jdk-11*_linux-aarch64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
-    	JAVA_SHA256=d6b26336a467768d0ec1474dbfdc68df0aa0745e8e46871f0aa46a07851097df ; \    	
+    	JAVA_SHA256=5036569e689c5385a31d55d5f66332768e1ee552624cbd097fcab17c6b583f22 ; \    	
     fi && \
 	echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
 	mkdir -p "$JAVA_HOME"; \

--- a/OracleJava/11/Dockerfile.8
+++ b/OracleJava/11/Dockerfile.8
@@ -46,10 +46,10 @@ RUN set -eux; \
     if [ "$ARCH" = "x86_64" ]; \
     then \
 		mv "$(ls /tmp/jdk-11*_linux-x64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
-        JAVA_SHA256=b4eb49c123e2cf2ed7cb068a37b84eb75fcf1e76c3620d3378f5735e11a8508b ; \
+        JAVA_SHA256=612b6687c185b2b0f0651d5ca2cfd1dfd5936418e9bf0b169b516e83d18d178d ; \
     else \
 	    mv "$(ls /tmp/jdk-11*_linux-aarch64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
-    	JAVA_SHA256=d6b26336a467768d0ec1474dbfdc68df0aa0745e8e46871f0aa46a07851097df ; \
+    	JAVA_SHA256=5036569e689c5385a31d55d5f66332768e1ee552624cbd097fcab17c6b583f22 ; \
     fi && \
 	echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
 	mkdir -p "$JAVA_HOME"; \

--- a/OracleJava/8/jdk/Dockerfile
+++ b/OracleJava/8/jdk/Dockerfile
@@ -45,10 +45,10 @@ RUN set -eux; \
     if [ "$ARCH" = "x86_64" ]; \
     then \
 		mv "$(ls /tmp/jdk-8*-linux-x64.tar.gz)" /tmp/jdk.tar.gz ; \
-        JAVA_SHA256=036aeb193d4262e27c74d9ade316dc50a026fba0255467d12fc73db49d20ce8c ; \
+        JAVA_SHA256=c2f9513727fa7a06d6cf9a10a4c1712a984baa33a69373c0b909785b1f805108 ; \
     else \
 	    mv "$(ls /tmp/jdk-8*-linux-aarch64.tar.gz)" /tmp/jdk.tar.gz ; \
-    	JAVA_SHA256=7db2e4893da151cb15787421100d76ffd3e88801166431de80ea02dd84109333 ; \    	
+    	JAVA_SHA256=c4aa317651de863dc1164aa270a1f9e8045245f3c77a1863d01c3dfc55c04780 ; \    	
     fi && \
 	echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
 	mkdir -p "$JAVA_HOME"; \

--- a/OracleJava/8/jdk/Dockerfile.8
+++ b/OracleJava/8/jdk/Dockerfile.8
@@ -45,10 +45,10 @@ RUN set -eux; \
     if [ "$ARCH" = "x86_64" ]; \
     then \
 		mv "$(ls /tmp/jdk-8*-linux-x64.tar.gz)" /tmp/jdk.tar.gz ; \
-        JAVA_SHA256=036aeb193d4262e27c74d9ade316dc50a026fba0255467d12fc73db49d20ce8c ; \
+        JAVA_SHA256=c2f9513727fa7a06d6cf9a10a4c1712a984baa33a69373c0b909785b1f805108 ; \
     else \
 	    mv "$(ls /tmp/jdk-8*-linux-aarch64.tar.gz)" /tmp/jdk.tar.gz ; \
-    	JAVA_SHA256=7db2e4893da151cb15787421100d76ffd3e88801166431de80ea02dd84109333 ; \    	
+    	JAVA_SHA256=c4aa317651de863dc1164aa270a1f9e8045245f3c77a1863d01c3dfc55c04780 ; \    	
     fi && \
 	echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
 	mkdir -p "$JAVA_HOME"; \

--- a/OracleJava/8/serverjre/Dockerfile
+++ b/OracleJava/8/serverjre/Dockerfile
@@ -42,7 +42,7 @@ ENV JAVA_HOME=/usr/java/jdk-8
 COPY server-jre-8u*-linux-x64.tar.gz /tmp/jdk.tgz
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux; \
-	JAVA_SHA256=03bdb10d5e1aaf09e5ff9e99a18966ca2609e4cc4b4d1916432b09f39aeeaf2e ; \
+	JAVA_SHA256=03454fe3a293ad3179bcc00f09dc4ced38dea77ad4f952d0d4154d9cc1f87160 ; \
 	echo "$JAVA_SHA256 */tmp/jdk.tgz" | sha256sum -c -; \
 	mkdir -p "$JAVA_HOME"; \
 	tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1; 

--- a/OracleJava/8/serverjre/Dockerfile.8
+++ b/OracleJava/8/serverjre/Dockerfile.8
@@ -41,7 +41,7 @@ ENV JAVA_HOME=/usr/java/jdk-8
 COPY server-jre-8u*-linux-x64.tar.gz /tmp/jdk.tgz
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux; \
-	JAVA_SHA256=03bdb10d5e1aaf09e5ff9e99a18966ca2609e4cc4b4d1916432b09f39aeeaf2e ; \
+	JAVA_SHA256=03454fe3a293ad3179bcc00f09dc4ced38dea77ad4f952d0d4154d9cc1f87160 ; \
 	echo "$JAVA_SHA256 */tmp/jdk.tgz" | sha256sum -c -; \
 	mkdir -p "$JAVA_HOME"; \
 	tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1;

--- a/OracleOpenJDK/21/Dockerfile
+++ b/OracleOpenJDK/21/Dockerfile
@@ -50,7 +50,7 @@ RUN set -eux; \
     if [ "$ARCH" = "x86_64" ]; \
         then ARCH="x64"; \
     fi && \
-    JAVA_PKG="$JAVA_URL"/openjdk-21_linux-"${ARCH}"_bin.tar.gz ; \
+    JAVA_PKG="$JAVA_URL"/openjdk-21.0.1_linux-"${ARCH}"_bin.tar.gz ; \
 	JAVA_SHA256="$(curl "$JAVA_PKG".sha256)" ; \ 
 	curl --output /tmp/jdk.tgz "$JAVA_PKG" && \
 	echo "$JAVA_SHA256" */tmp/jdk.tgz | sha256sum -c -; \

--- a/OracleOpenJDK/21/Dockerfile
+++ b/OracleOpenJDK/21/Dockerfile
@@ -25,7 +25,7 @@ FROM oraclelinux:8
 
 LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
-ENV JAVA_URL=https://download.java.net/java/GA/jdk21/fd2272bbf8e04c3dbaee13770090416c/35/GPL \
+ENV JAVA_URL=https://download.java.net/java/GA/jdk21.0.1/415e3f918a1f4062a0074a2794853d0d/12/GPL \
 	JAVA_HOME=/usr/java/jdk-21 \
 	LANG=en_US.UTF-8
 	


### PR DESCRIPTION
Change the files and checksums for JDK 11, 8, serverJRE, and OpenJDK to match the Oct 2023 CPU