### PR TITLE
add specific digest function

### DIFF
--- a/OracleDatabase/RAC/OracleRealApplicationClusters/README.md
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/README.md
@@ -187,7 +187,7 @@ If you are planing to deploy Oracle RAC container image on Docker, skip to the s
    - Edit the `/opt/.secrets/common_os_pwdfile` and seed the password for the  grid, oracle and database users. For this deployment scenario, it will be a common password for the grid, oracle, and database users. Run the command:
 
       ```bash
-      # openssl enc -aes-256-cbc -salt -in /opt/.secrets/common_os_pwdfile -out /opt/.secrets/common_os_pwdfile.enc -pass file:/opt/.secrets/pwd.key
+      # openssl enc -aes-256-cbc -salt -md md5 -in /opt/.secrets/common_os_pwdfile -out /opt/.secrets/common_os_pwdfile.enc -pass file:/opt/.secrets/pwd.key
       # rm -f /opt/.secrets/common_os_pwdfile
       ```
 


### PR DESCRIPTION
on openssl >=1.02 uses sha256 instead of sha256 which OL8 will use

ref: https://superuser.com/questions/1451101/openssl-encrypted-file-cannot-be-decrypted-by-others#comment2714265_1504252