### PR TITLE
updated to April 2024 Critical Patch Update versions

### DIFF
--- a/OracleJava/11/Dockerfile
+++ b/OracleJava/11/Dockerfile
@@ -47,10 +47,10 @@ RUN set -eux; \
     if [ "$ARCH" = "x86_64" ]; \
     then \
 		mv "$(ls /tmp/jdk-11*_linux-x64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
-        JAVA_SHA256=f9eaf0f224fac4ff26f146089181a155d547ebcf2e033cf4cc850efa228086ba ; \
+        JAVA_SHA256=e73531c1b09cb6e618d4d3617f622acfb05bd9afea2f1539aa4cf452a24eb3bc ; \
     else \
 	    mv "$(ls /tmp/jdk-11*_linux-aarch64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
-    	JAVA_SHA256=97ee39f2a39ab9612a06b0d56882571f701cad082b7cf169b5cfdee174aec7eb ; \    	
+    	JAVA_SHA256=34c22df9bb58a97f92e4fffdd6961e56b9b4387a5055f8f4a98b361168e881cc ; \    	
     fi && \
 	echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
 	mkdir -p "$JAVA_HOME"; \

--- a/OracleJava/11/Dockerfile.8
+++ b/OracleJava/11/Dockerfile.8
@@ -46,10 +46,10 @@ RUN set -eux; \
     if [ "$ARCH" = "x86_64" ]; \
     then \
 		mv "$(ls /tmp/jdk-11*_linux-x64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
-        JAVA_SHA256=f9eaf0f224fac4ff26f146089181a155d547ebcf2e033cf4cc850efa228086ba ; \
+        JAVA_SHA256=e73531c1b09cb6e618d4d3617f622acfb05bd9afea2f1539aa4cf452a24eb3bc ; \
     else \
 	    mv "$(ls /tmp/jdk-11*_linux-aarch64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
-    	JAVA_SHA256=97ee39f2a39ab9612a06b0d56882571f701cad082b7cf169b5cfdee174aec7eb ; \
+    	JAVA_SHA256=34c22df9bb58a97f92e4fffdd6961e56b9b4387a5055f8f4a98b361168e881cc ; \
     fi && \
 	echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
 	mkdir -p "$JAVA_HOME"; \

--- a/OracleJava/8/jdk/Dockerfile
+++ b/OracleJava/8/jdk/Dockerfile
@@ -45,10 +45,10 @@ RUN set -eux; \
     if [ "$ARCH" = "x86_64" ]; \
     then \
 		mv "$(ls /tmp/jdk-8*-linux-x64.tar.gz)" /tmp/jdk.tar.gz ; \
-        JAVA_SHA256=19684fccd7ff32a8400e952a643f0049449a772ef63b8037d5b917cbd137d173 ; \
+        JAVA_SHA256=6210799322de9316e16ec884e6904eab14017bc98725a85a5b66071be1dc1596 ; \
     else \
 	    mv "$(ls /tmp/jdk-8*-linux-aarch64.tar.gz)" /tmp/jdk.tar.gz ; \
-    	JAVA_SHA256=daa226b47bc57b03dbd6f7398eadd89d5fca5e98353e9e66017de362ecb7e7f8 ; \    	
+    	JAVA_SHA256=29c0543af33986667122cdcc0cc70b17dc4b3e53a9115149b531c8e3270d301d ; \    	
     fi && \
 	echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
 	mkdir -p "$JAVA_HOME"; \

--- a/OracleJava/8/jdk/Dockerfile.8
+++ b/OracleJava/8/jdk/Dockerfile.8
@@ -45,10 +45,10 @@ RUN set -eux; \
     if [ "$ARCH" = "x86_64" ]; \
     then \
 		mv "$(ls /tmp/jdk-8*-linux-x64.tar.gz)" /tmp/jdk.tar.gz ; \
-        JAVA_SHA256=19684fccd7ff32a8400e952a643f0049449a772ef63b8037d5b917cbd137d173 ; \
+        JAVA_SHA256=6210799322de9316e16ec884e6904eab14017bc98725a85a5b66071be1dc1596 ; \
     else \
 	    mv "$(ls /tmp/jdk-8*-linux-aarch64.tar.gz)" /tmp/jdk.tar.gz ; \
-    	JAVA_SHA256=daa226b47bc57b03dbd6f7398eadd89d5fca5e98353e9e66017de362ecb7e7f8 ; \    	
+    	JAVA_SHA256=29c0543af33986667122cdcc0cc70b17dc4b3e53a9115149b531c8e3270d301d ; \    	
     fi && \
 	echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
 	mkdir -p "$JAVA_HOME"; \

--- a/OracleJava/8/serverjre/Dockerfile
+++ b/OracleJava/8/serverjre/Dockerfile
@@ -42,7 +42,7 @@ ENV JAVA_HOME=/usr/java/jdk-8
 COPY server-jre-8u*-linux-x64.tar.gz /tmp/jdk.tgz
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux; \
-	JAVA_SHA256=cf22b1e332da4eb70bc0e37b2968f60e051496df026c0a8b57138d8e646b7119 ; \
+	JAVA_SHA256=fc46938f1186ee72a372410bcce4750047b0781ad94e592be38149d648144da6 ; \
 	echo "$JAVA_SHA256 */tmp/jdk.tgz" | sha256sum -c -; \
 	mkdir -p "$JAVA_HOME"; \
 	tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1; 

--- a/OracleJava/8/serverjre/Dockerfile.8
+++ b/OracleJava/8/serverjre/Dockerfile.8
@@ -41,7 +41,7 @@ ENV JAVA_HOME=/usr/java/jdk-8
 COPY server-jre-8u*-linux-x64.tar.gz /tmp/jdk.tgz
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux; \
-	JAVA_SHA256=cf22b1e332da4eb70bc0e37b2968f60e051496df026c0a8b57138d8e646b7119 ; \
+	JAVA_SHA256=fc46938f1186ee72a372410bcce4750047b0781ad94e592be38149d648144da6 ; \
 	echo "$JAVA_SHA256 */tmp/jdk.tgz" | sha256sum -c -; \
 	mkdir -p "$JAVA_HOME"; \
 	tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1;

--- a/OracleOpenJDK/22/Dockerfile
+++ b/OracleOpenJDK/22/Dockerfile
@@ -25,7 +25,7 @@ FROM oraclelinux:8
 
 LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
-ENV JAVA_URL=https://download.java.net/java/GA/jdk22/830ec9fcccef480bb3e73fb7ecafe059/36/GPL \
+ENV JAVA_URL=https://download.java.net/java/GA/jdk22.0.1/c7ec1332f7bb44aeba2eb341ae18aca4/8/GPL \
 	JAVA_HOME=/usr/java/jdk-22 \
 	LANG=en_US.UTF-8
 	
@@ -50,7 +50,7 @@ RUN set -eux; \
     if [ "$ARCH" = "x86_64" ]; \
         then ARCH="x64"; \
     fi && \
-    JAVA_PKG="$JAVA_URL"/openjdk-22_linux-"${ARCH}"_bin.tar.gz ; \
+    JAVA_PKG="$JAVA_URL"/openjdk-22.0.1_linux-"${ARCH}"_bin.tar.gz ; \
 	JAVA_SHA256="$(curl "$JAVA_PKG".sha256)" ; \ 
 	curl --output /tmp/jdk.tgz "$JAVA_PKG" && \
 	echo "$JAVA_SHA256" */tmp/jdk.tgz | sha256sum -c -; \


### PR DESCRIPTION
Update the versions and checksums to match the April Critical Patch Update releases. 