### PR TITLE
 NOSQL - Update to version 23.3.32

### DIFF
--- a/NoSQL/README-sec.md
+++ b/NoSQL/README-sec.md
@@ -86,7 +86,7 @@ For example, to check the version of KVLite, use the `version` command:
 
 ```shell
 $ docker run --rm -ti --link kvlite:store oracle/nosql:ce-sec  java -Xmx64m -Xms64m -jar lib/kvstore.jar version
-23.3.30 2023-12-01 19:37:33 UTC  Build id: c5db6593507b Edition: Community
+23.3.32 2024-03-06 18:21:38 UTC  Build id: 69f48431fc69 Edition: Community
 ```
 
 To check the size of the storage shard:
@@ -113,13 +113,13 @@ $ docker run --rm -ti -v secfiles:/shared_conf:ro --link kvlite:store oracle/nos
 
 Pinging components of store kvstore based upon topology sequence #14
 10 partitions and 1 storage nodes
-Time: 2024-02-28 08:20:36 UTC   Version: 23.3.30
+Time: 2024-04-25 08:13:14 UTC   Version: 23.3.32
 Shard Status: healthy: 1 writable-degraded: 0 read-only: 0 offline: 0 total: 1
 Admin Status: healthy
 Zone [name=KVLite id=zn1 type=PRIMARY allowArbiters=false masterAffinity=false]   RN Status: online: 1 read-only: 0 offline: 0
-Storage Node [sn1] on kvlite: 5000    Zone: [name=KVLite id=zn1 type=PRIMARY allowArbiters=false masterAffinity=false]    Status: RUNNING   Ver: 23.3.30 2023-12-01 19:37:33 UTC  Build id: c5db6593507b Edition: Community    isMasterBalanced: true        serviceStartTime: 2024-02-28 08:11:20 UTC
-        Admin [admin1]          Status: RUNNING,MASTER  serviceStartTime: 2024-02-28 08:11:23 UTC       stateChangeTime: 2024-02-28 08:11:23 UTC        availableStorageSize: 2 GB
-        Rep Node [rg1-rn1]      Status: RUNNING,MASTER sequenceNumber: 508 haPort: 5011 availableStorageSize: 6 GB storageType: HD      serviceStartTime: 2024-02-28 08:11:25 UTC       stateChangeTime: 2024-02-28 08:11:25 UTC
+Storage Node [sn1] on kvlite: 5000    Zone: [name=KVLite id=zn1 type=PRIMARY allowArbiters=false masterAffinity=false]    Status: RUNNING   Ver: 23.3.32 2024-03-06 18:21:38 UTC  Build id: 69f48431fc69 Edition: Community    isMasterBalanced: true        serviceStartTime: 2024-04-25 08:10:10 UTC
+        Admin [admin1]          Status: RUNNING,MASTER  serviceStartTime: 2024-04-25 08:10:13 UTC       stateChangeTime: 2024-04-25 08:10:13 UTC        availableStorageSize: 2 GB
+        Rep Node [rg1-rn1]      Status: RUNNING,MASTER sequenceNumber: 86 haPort: 5011 availableStorageSize: 9 GB storageType: HD       serviceStartTime: 2024-04-25 08:10:14 UTC       stateChangeTime: 2024-04-25 08:10:15 UTC
 
 
   kv-> put kv -key /SomeKey -value SomeValue
@@ -217,10 +217,10 @@ be made via the Oracle NoSQL Database Proxy on the `KV_PROXY_PORT`.
 First, install the latest version of Oracle NoSQL on your remote host:
 
 ```shell
-KV_VERSION=23.3.30
+KV_VERSION=23.3.32
 rm -rf kv-$KV_VERSION
 DOWNLOAD_ROOT=http://download.oracle.com/otn-pub/otn_software/nosql-database
-DOWNLOAD_FILE="kv-ce-${KV_VERSION}.zip"
+DOWNLOAD_FILE="community-edition-${KV_VERSION}.zip"
 DOWNLOAD_LINK="${DOWNLOAD_ROOT}/${DOWNLOAD_FILE}"
 curl -OLs $DOWNLOAD_LINK
 jar tf $DOWNLOAD_FILE | grep "kv-$KV_VERSION/lib" > extract.libs
@@ -400,7 +400,7 @@ number used for the image tag:
 
 
 ```shell
-KV_VERSION=23.3.30 docker build --build-arg "$KV_VERSION" --tag "oracle/nosql-ce-sec:$KV_VERSION" .
+KV_VERSION=23.3.32 docker build --build-arg "$KV_VERSION" --tag "oracle/nosql-ce-sec:$KV_VERSION" .
 ```
 
 ## More information

--- a/NoSQL/README.md
+++ b/NoSQL/README.md
@@ -73,7 +73,7 @@ For example, to check the version of KVLite, use the `version` command:
 
 ```shell
 $ docker run --rm -ti --link kvlite:store oracle/nosql:ce  java -Xmx64m -Xms64m -jar lib/kvstore.jar version
-23.3.30 2023-12-01 19:37:33 UTC  Build id: c5db6593507b Edition: Community
+23.3.32 2024-03-06 18:21:38 UTC  Build id: 69f48431fc69 Edition: Community
 ```
 
 To check the size of the storage shard:
@@ -98,14 +98,13 @@ $ docker run --rm -ti --link kvlite:store oracle/nosql:ce \
   
 Pinging components of store kvstore based upon topology sequence #14
 10 partitions and 1 storage nodes
-Time: 2024-02-28 08:20:36 UTC   Version: 23.3.30
+Time: 2024-04-25 08:13:14 UTC   Version: 23.3.32
 Shard Status: healthy: 1 writable-degraded: 0 read-only: 0 offline: 0 total: 1
 Admin Status: healthy
 Zone [name=KVLite id=zn1 type=PRIMARY allowArbiters=false masterAffinity=false]   RN Status: online: 1 read-only: 0 offline: 0
-Storage Node [sn1] on kvlite: 5000    Zone: [name=KVLite id=zn1 type=PRIMARY allowArbiters=false masterAffinity=false]    Status: RUNNING   Ver: 23.3.30 2023-12-01 19:37:33 UTC  Build id: c5db6593507b Edition: Community    isMasterBalanced: true        serviceStartTime: 2024-02-28 08:11:20 UTC
-        Admin [admin1]          Status: RUNNING,MASTER  serviceStartTime: 2024-02-28 08:11:23 UTC       stateChangeTime: 2024-02-28 08:11:23 UTC        availableStorageSize: 2 GB
-        Rep Node [rg1-rn1]      Status: RUNNING,MASTER sequenceNumber: 508 haPort: 5011 availableStorageSize: 6 GB storageType: HD      serviceStartTime: 2024-02-28 08:11:25 UTC       stateChangeTime: 2024-02-28 08:11:25 UTC
-
+Storage Node [sn1] on kvlite: 5000    Zone: [name=KVLite id=zn1 type=PRIMARY allowArbiters=false masterAffinity=false]    Status: RUNNING   Ver: 23.3.32 2024-03-06 18:21:38 UTC  Build id: 69f48431fc69 Edition: Community    isMasterBalanced: true        serviceStartTime: 2024-04-25 08:10:10 UTC
+        Admin [admin1]          Status: RUNNING,MASTER  serviceStartTime: 2024-04-25 08:10:13 UTC       stateChangeTime: 2024-04-25 08:10:13 UTC        availableStorageSize: 2 GB
+        Rep Node [rg1-rn1]      Status: RUNNING,MASTER sequenceNumber: 86 haPort: 5011 availableStorageSize: 9 GB storageType: HD       serviceStartTime: 2024-04-25 08:10:14 UTC       stateChangeTime: 2024-04-25 08:10:15 UTC
   
   kv-> put kv -key /SomeKey -value SomeValue
   Operation successful, record inserted.
@@ -173,10 +172,10 @@ be made via the Oracle NoSQL Database Proxy on the `KV_PROXY_PORT`.
 First, install the latest version of Oracle NoSQL on your remote host:
 
 ```shell
-KV_VERSION=23.3.30
+KV_VERSION=23.3.32
 rm -rf kv-$KV_VERSION
 DOWNLOAD_ROOT=http://download.oracle.com/otn-pub/otn_software/nosql-database
-DOWNLOAD_FILE="kv-ce-${KV_VERSION}.zip"
+DOWNLOAD_FILE="community-edition-${KV_VERSION}.zip"
 DOWNLOAD_LINK="${DOWNLOAD_ROOT}/${DOWNLOAD_FILE}"
 curl -OLs $DOWNLOAD_LINK
 jar tf $DOWNLOAD_FILE | grep "kv-$KV_VERSION/lib" > extract.libs
@@ -333,7 +332,7 @@ number used for the image tag:
 
 
 ```shell
-KV_VERSION=23.3.30 docker build --build-arg "$KV_VERSION" --tag "oracle/nosql-ce:$KV_VERSION" .
+KV_VERSION=23.3.32 docker build --build-arg "$KV_VERSION" --tag "oracle/nosql-ce:$KV_VERSION" .
 ```
 
 ## More information

--- a/NoSQL/ce-sec/Dockerfile
+++ b/NoSQL/ce-sec/Dockerfile
@@ -5,7 +5,7 @@ FROM ghcr.io/graalvm/jdk:ol8-java17
 
 LABEL org.opencontainers.image.source = "https://github.com/oracle/docker-images"
 
-ARG KV_VERSION=23.3.30
+ARG KV_VERSION=23.3.32
 ARG DOWNLOAD_ROOT=http://download.oracle.com/otn-pub/otn_software/nosql-database
 ARG DOWNLOAD_FILE="community-edition-${KV_VERSION}.zip"
 ARG DOWNLOAD_LINK="${DOWNLOAD_ROOT}/${DOWNLOAD_FILE}"

--- a/NoSQL/ce-sec/Dockerfile
+++ b/NoSQL/ce-sec/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.source = "https://github.com/oracle/docker-images
 
 ARG KV_VERSION=23.3.30
 ARG DOWNLOAD_ROOT=http://download.oracle.com/otn-pub/otn_software/nosql-database
-ARG DOWNLOAD_FILE="kv-ce-${KV_VERSION}.zip"
+ARG DOWNLOAD_FILE="community-edition-${KV_VERSION}.zip"
 ARG DOWNLOAD_LINK="${DOWNLOAD_ROOT}/${DOWNLOAD_FILE}"
 
 ENV KV_PROXY_PORT 8080

--- a/NoSQL/ce/Dockerfile
+++ b/NoSQL/ce/Dockerfile
@@ -5,9 +5,9 @@ FROM ghcr.io/graalvm/jdk:ol8-java17
 
 LABEL org.opencontainers.image.source = "https://github.com/oracle/docker-images"
 
-ARG KV_VERSION=23.3.30
+ARG KV_VERSION=23.3.32
 ARG DOWNLOAD_ROOT=http://download.oracle.com/otn-pub/otn_software/nosql-database
-ARG DOWNLOAD_FILE="kv-ce-${KV_VERSION}.zip"
+ARG DOWNLOAD_FILE="community-edition-${KV_VERSION}.zip"
 ARG DOWNLOAD_LINK="${DOWNLOAD_ROOT}/${DOWNLOAD_FILE}"
 
 ENV KV_PROXY_PORT 8080


### PR DESCRIPTION
This PR updates the Oracle NoSQL Dockerfile to align with the latest version and bundles.

-  Our last bundle for this version is `kv-ce-23.3.32`
- It uses the new `DOWNLOAD_FILE` in OTN `community-edition-${KV_VERSION}.zip` instead of `kv-ce-${KV_VERSION}.zip`

Signed-off-by: Dario Vega [dario.vega@oracle.com](mailto:dario.vega@oracle.com)