### PR TITLE
Fix error - orainstRoot.sh No such file or directory

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/buildContainerImage.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/buildContainerImage.sh
@@ -316,7 +316,7 @@ echo "Building image '${IMAGE_NAME}' ..."
 
 # BUILD THE IMAGE (replace all environment variables)
 BUILD_START=$(date '+%s')
-"${CONTAINER_RUNTIME}" build --force-rm=true --no-cache=true \
+"${CONTAINER_RUNTIME}" build --ulimit nofile=65536:65536 --force-rm=true --no-cache=true \
       "${BUILD_OPTS[@]}" "${PROXY_SETTINGS[@]}" --build-arg DB_EDITION="${EDITION}" \
       -t "${IMAGE_NAME}" -f "${DOCKERFILE}" . || {
   echo ""


### PR DESCRIPTION
According to https://github.com/oracle/docker-images/issues/2472 Changed line in script according to comment https://github.com/oracle/docker-images/issues/2472#issuecomment-1867219864

It fixed building image in my case