### PR TITLE
Allow word splitting proxy variable in Tuxedo build script

### DIFF
--- a/OracleTuxedo/core/dockerfiles/buildContainerImage.sh
+++ b/OracleTuxedo/core/dockerfiles/buildContainerImage.sh
@@ -116,7 +116,7 @@ fi
 
 echo "====================="
 
-docker build  ${PROXY_SETTINGS:+"$PROXY_SETTINGS"} -t oracle/tuxedo:latest -t oracle/tuxedo:"${VERSION}" "${VERSION}"/
+docker build  $PROXY_SETTINGS -t oracle/tuxedo:latest -t oracle/tuxedo:"${VERSION}" "${VERSION}"/
 ret=$?
 if [ "$ret" = "0" ]
     then

--- a/OracleTuxedo/core/dockerfiles/buildContainerImage.sh
+++ b/OracleTuxedo/core/dockerfiles/buildContainerImage.sh
@@ -116,7 +116,7 @@ fi
 
 echo "====================="
 
-docker build  $PROXY_SETTINGS -t oracle/tuxedo:latest -t oracle/tuxedo:"${VERSION}" "${VERSION}"/
+docker build $PROXY_SETTINGS -t oracle/tuxedo:latest -t oracle/tuxedo:"${VERSION}" "${VERSION}"/
 ret=$?
 if [ "$ret" = "0" ]
     then


### PR DESCRIPTION
Fixes #2837.

## Changes

This changes allows the `PROXY_SETTINGS` variable to be word split (as is done in [other build scripts](https://github.com/oracle/docker-images/blob/fa24c6d56a6df05a54dd5c75e6f17ce025f2bde6/OracleWebLogic/dockerfiles/buildDockerImage.sh#L179)) rather than treated as a single argument to the `docker` command. This ensures that the `docker` command is constructed correctly to enable the use of the `https_proxy` environment variable.

