### PR TITLE
Update Instant Client dockerfile comments

### DIFF
--- a/OracleInstantClient/oraclelinux7/21/Dockerfile
+++ b/OracleInstantClient/oraclelinux7/21/Dockerfile
@@ -1,15 +1,18 @@
 # LICENSE UPL 1.0
 #
-# Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
 #
-# Container image template for Oracle Instant Client
+# Container image template for Oracle Instant Client 21
+#
+# This file is found at:
+# https://github.com/oracle/docker-images/blob/main/OracleInstantClient/oraclelinux7/21/Dockerfile
 #
 # HOW TO BUILD THIS IMAGE AND RUN A CONTAINER
 # --------------------------------------------
 #
 # Execute:
-#      $ docker build --pull -t oraclelinux7-instantclient:21 .
-#      $ docker run -ti --rm oraclelinux7-instantclient:21 sqlplus /nolog
+#      $ podman build --pull -t oraclelinux7-instantclient:21 .
+#      $ podman run -ti --rm oraclelinux7-instantclient:21 sqlplus /nolog
 #
 # NOTES
 # -----
@@ -30,7 +33,7 @@
 # cwallet.sso.  You can use a Docker volume to mount the directory containing
 # the files at runtime, for example:
 #
-#   docker run -v /my/host/wallet_dir:/usr/lib/oracle/21/client64/lib/network/admin:Z,ro . . .
+#   podman run -v /my/host/wallet_dir:/usr/lib/oracle/21/client64/lib/network/admin:Z,ro . . .
 #
 # This avoids embedding private information such as wallets in images.  If you
 # do choose to include network configuration files in images, you can use a
@@ -67,7 +70,7 @@
 # A prebuilt container from this Dockerfile is available from
 #   https://github.com/orgs/oracle/packages/container/package/oraclelinux7-instantclient
 # and can be pulled with:
-#   docker pull ghcr.io/oracle/oraclelinux7-instantclient:21
+#   podman pull ghcr.io/oracle/oraclelinux7-instantclient:21
 
 FROM oraclelinux:7-slim
 

--- a/OracleInstantClient/oraclelinux8/21/Dockerfile
+++ b/OracleInstantClient/oraclelinux8/21/Dockerfile
@@ -1,15 +1,18 @@
 # LICENSE UPL 1.0
 #
-# Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
 #
-# Container image template for Oracle Instant Client
+# Container image template for Oracle Instant Client 21
+#
+# This file is found at:
+# https://github.com/oracle/docker-images/blob/main/OracleInstantClient/oraclelinux8/21/Dockerfile
 #
 # HOW TO BUILD THIS IMAGE AND RUN A CONTAINER
 # --------------------------------------------
 #
 # Execute:
-#      $ docker build --pull -t oraclelinux8-instantclient:21 .
-#      $ docker run -ti --rm oraclelinux8-instantclient:21 sqlplus /nolog
+#      $ podman build --pull -t oraclelinux8-instantclient:21 .
+#      $ podman run -ti --rm oraclelinux8-instantclient:21 sqlplus /nolog
 #
 # NOTES
 # -----
@@ -30,7 +33,7 @@
 # cwallet.sso.  You can use a Docker volume to mount the directory containing
 # the files at runtime, for example:
 #
-#   docker run -v /my/host/wallet_dir:/usr/lib/oracle/21/client64/lib/network/admin:Z,ro . . .
+#   podman run -v /my/host/wallet_dir:/usr/lib/oracle/21/client64/lib/network/admin:Z,ro . . .
 #
 # This avoids embedding private information such as wallets in images.  If you
 # do choose to include network configuration files in images, you can use a
@@ -67,7 +70,7 @@
 # A prebuilt container from this Dockerfile is available from
 #   https://github.com/orgs/oracle/packages/container/package/oraclelinux8-instantclient
 # and can be pulled with:
-#   docker pull ghcr.io/oracle/oraclelinux8-instantclient:21
+#   podman pull ghcr.io/oracle/oraclelinux8-instantclient:21
 
 FROM oraclelinux:8
 

--- a/OracleInstantClient/oraclelinux8/23/Dockerfile
+++ b/OracleInstantClient/oraclelinux8/23/Dockerfile
@@ -2,7 +2,10 @@
 #
 # Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
 #
-# Container image template for Oracle Instant Client
+# Container image template for Oracle Instant Client 23
+#
+# This file is found at:
+# https://github.com/oracle/docker-images/blob/main/OracleInstantClient/oraclelinux8/23/Dockerfile
 #
 # HOW TO BUILD THIS IMAGE AND RUN A CONTAINER
 # --------------------------------------------

--- a/OracleInstantClient/oraclelinux9/19/Dockerfile
+++ b/OracleInstantClient/oraclelinux9/19/Dockerfile
@@ -2,7 +2,10 @@
 #
 # Copyright (c) 2014, 2024, Oracle and/or its affiliates.
 #
-# Container image template for Oracle Instant Client
+# Container image template for Oracle Instant Client 19
+#
+# This file is found at:
+# https://github.com/oracle/docker-images/blob/main/OracleInstantClient/oraclelinux9/19/Dockerfile
 #
 # HOW TO BUILD THIS IMAGE AND RUN A CONTAINER
 # --------------------------------------------

--- a/OracleInstantClient/oraclelinux9/23/Dockerfile
+++ b/OracleInstantClient/oraclelinux9/23/Dockerfile
@@ -2,7 +2,10 @@
 #
 # Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
 #
-# Container image template for Oracle Instant Client
+# Container image template for Oracle Instant Client 23
+#
+# This file is found at:
+# https://github.com/oracle/docker-images/blob/main/OracleInstantClient/oraclelinux9/23/Dockerfile
 #
 # HOW TO BUILD THIS IMAGE AND RUN A CONTAINER
 # --------------------------------------------


### PR DESCRIPTION
Change a few usages of 'docker' to podman.

Add links the the base files so users who take/share copies know where to find the originals.  Similar changes were made to 19c files in https://github.com/oracle/docker-images/pull/2862