### PR TITLE
Updated JDK 22 to JDK 23

### DIFF
--- a/OracleJava/23/Dockerfile
+++ b/OracleJava/23/Dockerfile
@@ -4,30 +4,30 @@
 #
 # ORACLE DOCKERFILES PROJECT
 # --------------------------
-# This is the Dockerfile for Oracle JDK 22 on Oracle Linux 8
+# This is the Dockerfile for Oracle JDK 23 on Oracle Linux 9
 #
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
-# This dockerfile will download a copy of JDK 22 from
-#	https://download.oracle.com/java/22/latest/jdk-22_linux-<ARCH>_bin.tar.gz  
+# This dockerfile will download a copy of JDK 23 from
+#	https://download.oracle.com/java/23/latest/jdk-23_linux-<ARCH>_bin.tar.gz  
 # 
 # It will use either x64 or aarch64 depending on the target platform
 #
 # HOW TO BUILD THIS IMAGE
 # -----------------------
 # Run:
-#      $ docker build -t oracle/jdk:22 .
+#      $ docker build -t oracle/jdk:23 .
 #
 # This command is already scripted in build.sh so you can alternatively run
 #		$ bash build.sh
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
-FROM oraclelinux:8 as builder
+FROM oraclelinux:9 as builder
 
 LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
-# Since the files are compressed as tar.gz first dnf install tar. gzip is already in oraclelinux:8
+# Since the files are compressed as tar.gz first dnf install tar. gzip is already in oraclelinux:9
 RUN set -eux; \
 	dnf install -y tar; 
 	
@@ -37,8 +37,8 @@ ENV LANG en_US.UTF-8
 # Environment variables for the builder image.
 # Required to validate that you are using the correct file
 	
-ENV JAVA_URL=https://download.oracle.com/java/22/latest \
-	JAVA_HOME=/usr/java/jdk-22
+ENV JAVA_URL=https://download.oracle.com/java/23/latest \
+	JAVA_HOME=/usr/java/jdk-23
 
 ##
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -48,7 +48,7 @@ RUN set -eux; \
     if [ "$ARCH" = "x86_64" ]; \
         then ARCH="x64"; \
     fi && \
-    JAVA_PKG="$JAVA_URL"/jdk-22_linux-"${ARCH}"_bin.tar.gz ; \
+    JAVA_PKG="$JAVA_URL"/jdk-23_linux-"${ARCH}"_bin.tar.gz ; \
 	JAVA_SHA256=$(curl "$JAVA_PKG".sha256) ; \ 
 	curl --output /tmp/jdk.tgz "$JAVA_PKG" && \
 	echo "$JAVA_SHA256" */tmp/jdk.tgz | sha256sum -c; \
@@ -56,11 +56,11 @@ RUN set -eux; \
 	tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1
 	
 ## Get a fresh version of OL8 for the final image	
-FROM oraclelinux:8
+FROM oraclelinux:9
 
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
-ENV	JAVA_HOME=/usr/java/jdk-22
+ENV	JAVA_HOME=/usr/java/jdk-23
 ENV	PATH $JAVA_HOME/bin:$PATH	
 
 # If you need the Java Version you can read it from the release file with 

--- a/OracleJava/23/build.sh
+++ b/OracleJava/23/build.sh
@@ -4,5 +4,5 @@
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-echo "Building Oracle JDK 22 on Oracle Linux 8"
-docker build --file Dockerfile --tag oracle/jdk:22-ol8 .
+echo "Building Oracle JDK 23 on Oracle Linux 0"
+docker build --file Dockerfile --tag oracle/jdk:23-ol9 .

--- a/OracleJava/README.md
+++ b/OracleJava/README.md
@@ -1,12 +1,12 @@
 # Oracle Java in Containers
 
-This repository contains sample container configurations to facilitate installation and environment setup for DevOps users. This project provides container images based on Oracle Linux for JDK versions 22, 21, 17, 11 and 8 as well as Server JRE 8.
+This repository contains sample container configurations to facilitate installation and environment setup for DevOps users. This project provides container images based on Oracle Linux for JDK versions 23, 21, 17, 11 and 8 as well as Server JRE 8.
 
 Oracle Java Server JRE provides the features from Oracle Java JDK commonly required for server-side applications (i.e. Running a Java EE application server). For more information about Server JRE, visit the [Understanding the Server JRE blog entry](https://blogs.oracle.com/java-platform-group/understanding-the-server-jre) from the Java Product Management team.
 
 ## Building the Oracle Java base image
 
-For JDK 22, 21, and 17 the required JDK binaries will be downloaded from [Oracle](https://www.oracle.com/javadownload) as part of the build using curl.
+For JDK 23, 21, and 17 the required JDK binaries will be downloaded from [Oracle](https://www.oracle.com/javadownload) as part of the build using curl.
 
 For JDK 11 and JDK 8 you must first download the linux x64 or linux aarch64 compressed archive (tar.gz), for Server JRE 8 you must download the linux x64 compressed archive, from [https://oracle.com/javadownload](https://www.oracle.com/javadownload) and place it in the same directory as the corresponding Dockerfile.
 
@@ -14,11 +14,11 @@ e.g. for JDK 11 download jdk-11[X]_linux-x64_bin.tar.gz into OracleJava/11, for 
 
 To build the container image run `docker build`. Tag it with the correct version number.
 
-e.g. For JDK 22 run
+e.g. For JDK 23 run
 
 ```bash
-cd ../OracleJava/22
-docker build --tag oracle/jdk:22 .
+cd ../OracleJava/23
+docker build --tag oracle/jdk:23 .
 ```
 
 for Server JRE 8 run
@@ -36,7 +36,12 @@ bash build.sh
 
 ### Parent image OS version
 
-The Oracle Java images for JDK 22, 21, and 17 use `oraclelinux:8` as the parent image.
+The Oracle Java image for JDK 23 uses `oraclelinux:9` as the parent image.
+
+The Oracle Java image for JDK  21 and 17 use `oraclelinux:8` as the parent image.
+
+JDK 21 allows for optionally building on `oraclelinux:9` by using `Dockerfile.9` rather than `Dockerfile`.
+
 The Oracle Java image for JDK 11, JDK 8, and Server JRE 8 use `oraclelinux:7-slim` as the parent image.
 
 JDK 11, JDK 8, and Server JRE 8 allow for optionally building on `oraclelinux:8` by using `Dockerfile.8` rather than `Dockerfile`.
@@ -60,7 +65,7 @@ The script `build.sh` will tag the images it creates with the JDK version, and w
 
 ## Licenses
 
-JDK 22, 21, and 17 are downloaded, as part of the build process, from the [Oracle Website](https://www.oracle.com/javadownload) under the [Oracle No-Fee Terms and Conditions (NFTC)](https://java.com/freeuselicense).
+JDK 23, 21, and 17 are downloaded, as part of the build process, from the [Oracle Website](https://www.oracle.com/javadownload) under the [Oracle No-Fee Terms and Conditions (NFTC)](https://java.com/freeuselicense).
 
 For building JDK 11, JDK 8, and Server JRE 8 you must first download the corresponding Java Runtime from the [Oracle Website](https://www.oracle.com/javadownload) and accept the license indicated on that page.
 
@@ -68,4 +73,4 @@ All scripts and files hosted in this project and GitHub [`docker/OracleJava`](./
 
 ## Customer Support
 
-Oracle offers support for JDK 22, JDK 21, JDK 17, JDK 11, and JDK 8 (JDK and Server JRE) when running on certified operating systems in a container. For additional details on the JDK Certified System Configurations, please refer to the [Oracle Java SE Certified System Configuration Pages](https://www.oracle.com/technetwork/java/javaseproducts/documentation/index.html#sysconfig).
+Oracle offers support for JDK 23, JDK 21, JDK 17, JDK 11, and JDK 8 (JDK and Server JRE) when running on certified operating systems in a container. For additional details on the JDK Certified System Configurations, please refer to the [Oracle Java SE Certified System Configuration Pages](https://www.oracle.com/technetwork/java/javaseproducts/documentation/index.html#sysconfig).

--- a/OracleOpenJDK/23/Dockerfile
+++ b/OracleOpenJDK/23/Dockerfile
@@ -4,29 +4,29 @@
 #
 # ORACLE DOCKERFILES PROJECT
 # --------------------------
-# This is the Dockerfile for Oracle OpenJDK 22 on Oracle Linux 8
+# This is the Dockerfile for Oracle OpenJDK 23 on Oracle Linux 9
 #
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
 #
-# (1) openjdk-22.xx_linux-x64_bin.tar.gz
-#     Downloaded from https://jdk.java.net/22/
+# (1) openjdk-23.xx_linux-x64_bin.tar.gz
+#     Downloaded from https://jdk.java.net/23/
 #
 # HOW TO BUILD THIS IMAGE
 # -----------------------
 # Run:
-#      $ docker build -t oracle/openjdk:22 .
+#      $ docker build -t oracle/openjdk:23 .
 #
 # This command is already scripted in build.sh so you can alternatively run
 #		$ bash build.sh
 #
 
-FROM oraclelinux:8 
+FROM oraclelinux:9 
 
 LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
-ENV JAVA_URL=https://download.java.net/java/GA/jdk22.0.2/c9ecb94cd31b495da20a27d4581645e8/9/GPL \
-	JAVA_HOME=/usr/java/jdk-22 \
+ENV JAVA_URL=https://download.java.net/java/GA/jdk23/3c5b90190c68498b986a97f276efd28a/37/GPL \
+	JAVA_HOME=/usr/java/jdk-23 \
 	LANG=en_US.UTF-8
 	
 
@@ -35,7 +35,7 @@ ENV JAVA_URL=https://download.java.net/java/GA/jdk22.0.2/c9ecb94cd31b495da20a27d
 	
 ENV	PATH $JAVA_HOME/bin:$PATH
 	
-# Since the files are compressed as tar.gz first dnf install tar. gzip is already in oraclelinux:8
+# Since the files are compressed as tar.gz first dnf install tar. gzip is already in oraclelinux:9
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux; \
 	dnf -y update; \
@@ -50,7 +50,7 @@ RUN set -eux; \
     if [ "$ARCH" = "x86_64" ]; \
         then ARCH="x64"; \
     fi && \
-    JAVA_PKG="$JAVA_URL"/openjdk-22.0.2_linux-"${ARCH}"_bin.tar.gz ; \
+    JAVA_PKG="$JAVA_URL"/openjdk-23_linux-"${ARCH}"_bin.tar.gz ; \
 	JAVA_SHA256="$(curl "$JAVA_PKG".sha256)" ; \ 
 	curl --output /tmp/jdk.tgz "$JAVA_PKG" && \
 	echo "$JAVA_SHA256" */tmp/jdk.tgz | sha256sum -c -; \
@@ -67,10 +67,3 @@ RUN ln -sfT "$JAVA_HOME" /usr/java/default; \
 	done; 
 
 CMD ["jshell"]
-
-
-
-	
-
-
-

--- a/OracleOpenJDK/23/build.sh
+++ b/OracleOpenJDK/23/build.sh
@@ -4,5 +4,5 @@
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-echo "Building OpenJDK 22 on Oracle Linux 8"
-docker build --file Dockerfile --tag oracle/openjdk:22-ol8 .
+echo "Building OpenJDK 23 on Oracle Linux 9"
+docker build --file Dockerfile --tag oracle/openjdk:23-ol9 .

--- a/OracleOpenJDK/README.md
+++ b/OracleOpenJDK/README.md
@@ -6,11 +6,11 @@ This repository contains sample container configurations to facilitate installat
 
 Navigate to the folder containing the `Dockerfile` and run `docker build`, tagging the image with the version number:
 
-e.g. for OpenJDK 22 run
+e.g. for OpenJDK 23 run
 
 ```bash
-cd ../OracleOpenJDK/22
-docker build -t oracle/openjdk:22 .
+cd ../OracleOpenJDK/23
+docker build -t oracle/openjdk:23 .
 ```
 
 This command is already scripted in `build.sh` so you can alternatively run:
@@ -21,7 +21,7 @@ bash build.sh
 
 ### Parent image OS version
 
-The Oracle Java images for OpenJDK 22 uses `oraclelinux:8` as the default parent image.
+The Oracle Java images for OpenJDK 23 uses `oraclelinux:9` as the default parent image.
 
 ## License
 


### PR DESCRIPTION
Updated docker files for JDK 22 so that it now builds JDK 23. 
JDK 22 was not a long-term-support release so the launch of JDK 23 supersedes it.