### PR TITLE
docs(GraalVM/CE): fix broken link (#1)

### DIFF
--- a/GraalVM/CE/README.md
+++ b/GraalVM/CE/README.md
@@ -1,3 +1,3 @@
 # Update:
 
-The GraalVM CE dockerfiles moved to: https://github.com/graalvm/container/tree/master/community
+The GraalVM CE dockerfiles moved to: https://github.com/graalvm/container/tree/master/graalvm-community


### PR DESCRIPTION
- Update link due to changes in `graalvm-community` in [[GS-4824] Updating dockerfiles and readme file ](https://github.com/graalvm/container/pull/76)