### PR TITLE
updated release versions to the Oct 2024 CPU.  JDK 17.0.13 has a new license so it has to be download before building.

### DIFF
--- a/OracleJava/11/Dockerfile
+++ b/OracleJava/11/Dockerfile
@@ -19,7 +19,7 @@
 #      $ docker build -t oracle/jdk:11 .
 #
 # This command is already scripted in build.sh so you can alternatively run
-#		$ bash build.sh
+#      $ bash build.sh
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
@@ -28,8 +28,8 @@ FROM oraclelinux:7-slim as builder
 LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
 RUN yum install -y gzip tar
-		
-	
+        
+    
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
@@ -43,20 +43,20 @@ ENV JAVA_HOME=/usr/java/jdk-11
 COPY *.tar.gz /tmp/
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux; \
-	ARCH="$(uname -m)" && \
+    ARCH="$(uname -m)" && \
     if [ "$ARCH" = "x86_64" ]; \
     then \
-	mv "$(ls /tmp/jdk-11*_linux-x64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
+    mv "$(ls /tmp/jdk-11*_linux-x64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
         JAVA_SHA256=d22d0fcca761861a1eb2f5f6eb116c933354e8b1f76b3cda189c722cc0177c98 ; \
     else \
-	mv "$(ls /tmp/jdk-11*_linux-aarch64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
-    	JAVA_SHA256=3fc0d93f6363d32723c293ba5a9016e8ab27410351ed804020cfe71e87d3bc0a ; \    	
+    mv "$(ls /tmp/jdk-11*_linux-aarch64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
+        JAVA_SHA256=3fc0d93f6363d32723c293ba5a9016e8ab27410351ed804020cfe71e87d3bc0a ; \        
     fi && \
-	echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
-	mkdir -p "$JAVA_HOME"; \
-	tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
-	
-## Get a fresh version of SLIM for the final image	
+    echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
+    mkdir -p "$JAVA_HOME"; \
+    tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
+    
+## Get a fresh version of SLIM for the final image    
 FROM oraclelinux:7-slim
 
 # Default to UTF-8 file.encoding
@@ -64,27 +64,27 @@ ENV LANG en_US.UTF-8
 
 ENV JAVA_HOME=/usr/java/jdk-11
 
-ENV	PATH $JAVA_HOME/bin:$PATH	
+ENV PATH $JAVA_HOME/bin:$PATH    
 
 # Copy the uncompressed Java Runtime from the builder image
 COPY --from=builder $JAVA_HOME $JAVA_HOME
 
 RUN set -eux; \
 # Update the base image
-	yum -y update; \
-	yum install -y \
-# JDK assumes freetype is available		
-		freetype fontconfig \
-	; \
-	rm -rf /var/cache/yum; \
-	ln -sfT "$JAVA_HOME" /usr/java/default; \
-	ln -sfT "$JAVA_HOME" /usr/java/latest; \
-	for bin in "$JAVA_HOME/bin/"*; do \
-		base="$(basename "$bin")"; \
-		[ ! -e "/usr/bin/$base" ]; \
-		alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
-	done; \
-# -Xshare:dump will create a CDS archive to improve startup in subsequent runs	
-	java -Xshare:dump; 
+    yum -y update; \
+    yum install -y \
+# JDK assumes freetype is available        
+        freetype fontconfig \
+    ; \
+    rm -rf /var/cache/yum; \
+    ln -sfT "$JAVA_HOME" /usr/java/default; \
+    ln -sfT "$JAVA_HOME" /usr/java/latest; \
+    for bin in "$JAVA_HOME/bin/"*; do \
+        base="$(basename "$bin")"; \
+        [ ! -e "/usr/bin/$base" ]; \
+        alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
+    done; \
+# -Xshare:dump will create a CDS archive to improve startup in subsequent runs    
+    java -Xshare:dump; 
 
 CMD ["jshell"]

--- a/OracleJava/11/Dockerfile
+++ b/OracleJava/11/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
@@ -46,10 +46,10 @@ RUN set -eux; \
 	ARCH="$(uname -m)" && \
     if [ "$ARCH" = "x86_64" ]; \
     then \
-		mv "$(ls /tmp/jdk-11*_linux-x64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
+	mv "$(ls /tmp/jdk-11*_linux-x64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
         JAVA_SHA256=d22d0fcca761861a1eb2f5f6eb116c933354e8b1f76b3cda189c722cc0177c98 ; \
     else \
-	    mv "$(ls /tmp/jdk-11*_linux-aarch64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
+	mv "$(ls /tmp/jdk-11*_linux-aarch64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
     	JAVA_SHA256=3fc0d93f6363d32723c293ba5a9016e8ab27410351ed804020cfe71e87d3bc0a ; \    	
     fi && \
 	echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \

--- a/OracleJava/11/Dockerfile
+++ b/OracleJava/11/Dockerfile
@@ -28,8 +28,8 @@ FROM oraclelinux:7-slim as builder
 LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
 RUN yum install -y gzip tar
-        
-    
+
+
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
@@ -50,13 +50,13 @@ RUN set -eux; \
         JAVA_SHA256=d22d0fcca761861a1eb2f5f6eb116c933354e8b1f76b3cda189c722cc0177c98 ; \
     else \
     mv "$(ls /tmp/jdk-11*_linux-aarch64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
-        JAVA_SHA256=3fc0d93f6363d32723c293ba5a9016e8ab27410351ed804020cfe71e87d3bc0a ; \        
+        JAVA_SHA256=3fc0d93f6363d32723c293ba5a9016e8ab27410351ed804020cfe71e87d3bc0a ; \
     fi && \
     echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
     mkdir -p "$JAVA_HOME"; \
     tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
-    
-## Get a fresh version of SLIM for the final image    
+
+## Get a fresh version of Oracle Linux 7-slim for the final image
 FROM oraclelinux:7-slim
 
 # Default to UTF-8 file.encoding
@@ -64,7 +64,7 @@ ENV LANG en_US.UTF-8
 
 ENV JAVA_HOME=/usr/java/jdk-11
 
-ENV PATH $JAVA_HOME/bin:$PATH    
+ENV PATH $JAVA_HOME/bin:$PATH
 
 # Copy the uncompressed Java Runtime from the builder image
 COPY --from=builder $JAVA_HOME $JAVA_HOME
@@ -73,7 +73,7 @@ RUN set -eux; \
 # Update the base image
     yum -y update; \
     yum install -y \
-# JDK assumes freetype is available        
+# JDK assumes freetype is available
         freetype fontconfig \
     ; \
     rm -rf /var/cache/yum; \
@@ -84,7 +84,7 @@ RUN set -eux; \
         [ ! -e "/usr/bin/$base" ]; \
         alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
     done; \
-# -Xshare:dump will create a CDS archive to improve startup in subsequent runs    
-    java -Xshare:dump; 
+# -Xshare:dump will create a CDS archive to improve startup in subsequent runs
+    java -Xshare:dump;
 
 CMD ["jshell"]

--- a/OracleJava/11/Dockerfile
+++ b/OracleJava/11/Dockerfile
@@ -47,10 +47,10 @@ RUN set -eux; \
     if [ "$ARCH" = "x86_64" ]; \
     then \
 		mv "$(ls /tmp/jdk-11*_linux-x64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
-        JAVA_SHA256=f50fdec8a48a9b360d30ecc29af36f63f04f0b70ec829d3bf821e4e361682791 ; \
+        JAVA_SHA256=d22d0fcca761861a1eb2f5f6eb116c933354e8b1f76b3cda189c722cc0177c98 ; \
     else \
 	    mv "$(ls /tmp/jdk-11*_linux-aarch64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
-    	JAVA_SHA256=ff0c3387f47ed2eff9fdf936952573113824fc29de463bb13a3a804cc13d2ae8 ; \    	
+    	JAVA_SHA256=3fc0d93f6363d32723c293ba5a9016e8ab27410351ed804020cfe71e87d3bc0a ; \    	
     fi && \
 	echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
 	mkdir -p "$JAVA_HOME"; \

--- a/OracleJava/11/Dockerfile.ol8
+++ b/OracleJava/11/Dockerfile.ol8
@@ -19,7 +19,7 @@
 #      $ docker build -t oracle/jdk:11 .
 #
 # This command is already scripted in build.sh so you can alternatively run
-#		$ bash build.sh 8
+#      $ bash build.sh 8
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
@@ -42,18 +42,18 @@ ENV JAVA_HOME=/usr/java/jdk-11
 COPY *.tar.gz /tmp/
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux; \
-	ARCH="$(uname -m)" && \
+    ARCH="$(uname -m)" && \
     if [ "$ARCH" = "x86_64" ]; \
     then \
-	mv "$(ls /tmp/jdk-11*_linux-x64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
+    mv "$(ls /tmp/jdk-11*_linux-x64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
         JAVA_SHA256=d22d0fcca761861a1eb2f5f6eb116c933354e8b1f76b3cda189c722cc0177c98 ; \
     else \
-	mv "$(ls /tmp/jdk-11*_linux-aarch64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
-    	JAVA_SHA256=3fc0d93f6363d32723c293ba5a9016e8ab27410351ed804020cfe71e87d3bc0a ; \
+    mv "$(ls /tmp/jdk-11*_linux-aarch64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
+        JAVA_SHA256=3fc0d93f6363d32723c293ba5a9016e8ab27410351ed804020cfe71e87d3bc0a ; \
     fi && \
-	echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
-	mkdir -p "$JAVA_HOME"; \
-	tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
+    echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
+    mkdir -p "$JAVA_HOME"; \
+    tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
 
 ## Get a fresh version of OL8 for the final image
 FROM oraclelinux:8
@@ -63,26 +63,26 @@ ENV LANG en_US.UTF-8
 
 ENV JAVA_HOME=/usr/java/jdk-11
 
-ENV	PATH $JAVA_HOME/bin:$PATH
+ENV PATH $JAVA_HOME/bin:$PATH
 
 # Copy the uncompressed Java Runtime from the builder image
 COPY --from=builder $JAVA_HOME $JAVA_HOME
 
 RUN set -eux; \
-	dnf -y update; \
-	dnf install -y \
+    dnf -y update; \
+    dnf install -y \
 # JDK assumes freetype is available
-		freetype fontconfig \
-	; \
-	rm -rf /var/cache/dnf; \
-	ln -sfT "$JAVA_HOME" /usr/java/default; \
-	ln -sfT "$JAVA_HOME" /usr/java/latest; \
-	for bin in "$JAVA_HOME/bin/"*; do \
-		base="$(basename "$bin")"; \
-		[ ! -e "/usr/bin/$base" ]; \
-		alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
-	done; \
+        freetype fontconfig \
+    ; \
+    rm -rf /var/cache/dnf; \
+    ln -sfT "$JAVA_HOME" /usr/java/default; \
+    ln -sfT "$JAVA_HOME" /usr/java/latest; \
+    for bin in "$JAVA_HOME/bin/"*; do \
+        base="$(basename "$bin")"; \
+        [ ! -e "/usr/bin/$base" ]; \
+        alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
+    done; \
 # -Xshare:dump will create a CDS archive to improve startup in subsequent runs
-	java -Xshare:dump;
+    java -Xshare:dump;
 
 CMD ["jshell"]

--- a/OracleJava/11/Dockerfile.ol8
+++ b/OracleJava/11/Dockerfile.ol8
@@ -55,7 +55,7 @@ RUN set -eux; \
     mkdir -p "$JAVA_HOME"; \
     tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
 
-## Get a fresh version of OL8 for the final image
+## Get a fresh version of Oracle Linux 8 for the final image
 FROM oraclelinux:8
 
 # Default to UTF-8 file.encoding

--- a/OracleJava/11/Dockerfile.ol8
+++ b/OracleJava/11/Dockerfile.ol8
@@ -46,10 +46,10 @@ RUN set -eux; \
     if [ "$ARCH" = "x86_64" ]; \
     then \
 		mv "$(ls /tmp/jdk-11*_linux-x64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
-        JAVA_SHA256=f50fdec8a48a9b360d30ecc29af36f63f04f0b70ec829d3bf821e4e361682791 ; \
+        JAVA_SHA256=d22d0fcca761861a1eb2f5f6eb116c933354e8b1f76b3cda189c722cc0177c98 ; \
     else \
 	    mv "$(ls /tmp/jdk-11*_linux-aarch64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
-    	JAVA_SHA256=ff0c3387f47ed2eff9fdf936952573113824fc29de463bb13a3a804cc13d2ae8 ; \
+    	JAVA_SHA256=3fc0d93f6363d32723c293ba5a9016e8ab27410351ed804020cfe71e87d3bc0a ; \
     fi && \
 	echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
 	mkdir -p "$JAVA_HOME"; \

--- a/OracleJava/11/Dockerfile.ol8
+++ b/OracleJava/11/Dockerfile.ol8
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
@@ -45,10 +45,10 @@ RUN set -eux; \
 	ARCH="$(uname -m)" && \
     if [ "$ARCH" = "x86_64" ]; \
     then \
-		mv "$(ls /tmp/jdk-11*_linux-x64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
+	mv "$(ls /tmp/jdk-11*_linux-x64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
         JAVA_SHA256=d22d0fcca761861a1eb2f5f6eb116c933354e8b1f76b3cda189c722cc0177c98 ; \
     else \
-	    mv "$(ls /tmp/jdk-11*_linux-aarch64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
+	mv "$(ls /tmp/jdk-11*_linux-aarch64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
     	JAVA_SHA256=3fc0d93f6363d32723c293ba5a9016e8ab27410351ed804020cfe71e87d3bc0a ; \
     fi && \
 	echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \

--- a/OracleJava/11/build.sh
+++ b/OracleJava/11/build.sh
@@ -6,9 +6,9 @@
 
 if test "$1" = "8"
 then
-	echo "Building Oracle JDK 11 on Oracle Linux 8"
-	docker build --file Dockerfile.ol8 --tag oracle/jdk:11-ol8 .
+    echo "Building Oracle JDK 11 on Oracle Linux 8"
+    docker build --file Dockerfile.ol8 --tag oracle/jdk:11-ol8 .
 else
-	echo "Building Oracle JDK 11 on Oracle Linux 7 slim"
-	docker build --tag oracle/jdk:11-ol7 .
+    echo "Building Oracle JDK 11 on Oracle Linux 7 slim"
+    docker build --tag oracle/jdk:11-ol7 .
 fi

--- a/OracleJava/17/Dockerfile
+++ b/OracleJava/17/Dockerfile
@@ -18,7 +18,7 @@
 #      $ docker build -t oracle/jdk:17 .
 #
 # This command is already scripted in build.sh so you can alternatively run
-#		$ bash build.sh
+#      $ bash build.sh
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
@@ -41,26 +41,26 @@ ENV JAVA_HOME=/usr/java/jdk-17
 COPY *.tar.gz /tmp/
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux; \
-	ARCH="$(uname -m)" && \
+    ARCH="$(uname -m)" && \
     if [ "$ARCH" = "x86_64" ]; \
     then \
-	mv "$(ls /tmp/jdk-17*_linux-x64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
+    mv "$(ls /tmp/jdk-17*_linux-x64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
         JAVA_SHA256=f7a6fdebeb11840e1f5314bc330feb75b67e52491cf39073dbf3e51e3889ff08 ; \
     else \
-	mv "$(ls /tmp/jdk-17*_linux-aarch64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
-    	JAVA_SHA256=277e0010e7b17583e63827f9537a153ea79cb4b6ca28d523cd8a82f14a24a769 ; \
+    mv "$(ls /tmp/jdk-17*_linux-aarch64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
+        JAVA_SHA256=277e0010e7b17583e63827f9537a153ea79cb4b6ca28d523cd8a82f14a24a769 ; \
     fi && \
-	echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
-	mkdir -p "$JAVA_HOME"; \
-	tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
-	
-## Get a fresh version of OL8 for the final image	
+    echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
+    mkdir -p "$JAVA_HOME"; \
+    tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
+    
+## Get a fresh version of OL8 for the final image    
 FROM oraclelinux:8
 
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
-ENV	JAVA_HOME=/usr/java/jdk-17
-ENV	PATH $JAVA_HOME/bin:$PATH	
+ENV JAVA_HOME=/usr/java/jdk-17
+ENV PATH $JAVA_HOME/bin:$PATH    
 
 # If you need the Java Version you can read it from the release file with 
 # JAVA_VERSION=$(sed -n '/^JAVA_VERSION="/{s///;s/"//;p;}' "$JAVA_HOME"/release);
@@ -70,18 +70,18 @@ COPY --from=builder $JAVA_HOME $JAVA_HOME
 
 RUN set -eux; \
 # Ensure we get the latest OL 8 updates available at build time
-	dnf -y update; \
-# JDK assumes freetype is available	
-	dnf install -y \
-		freetype fontconfig \
-	; \
-	rm -rf /var/cache/dnf; \
-	ln -sfT "$JAVA_HOME" /usr/java/default; \
-	ln -sfT "$JAVA_HOME" /usr/java/latest; \
-	for bin in "$JAVA_HOME/bin/"*; do \
-		base="$(basename "$bin")"; \
-		[ ! -e "/usr/bin/$base" ]; \
-		alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
-	done;
-	
+    dnf -y update; \
+# JDK assumes freetype is available    
+    dnf install -y \
+        freetype fontconfig \
+    ; \
+    rm -rf /var/cache/dnf; \
+    ln -sfT "$JAVA_HOME" /usr/java/default; \
+    ln -sfT "$JAVA_HOME" /usr/java/latest; \
+    for bin in "$JAVA_HOME/bin/"*; do \
+        base="$(basename "$bin")"; \
+        [ ! -e "/usr/bin/$base" ]; \
+        alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
+    done;
+    
 CMD ["jshell"]

--- a/OracleJava/17/Dockerfile
+++ b/OracleJava/17/Dockerfile
@@ -53,16 +53,16 @@ RUN set -eux; \
     echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
     mkdir -p "$JAVA_HOME"; \
     tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
-    
-## Get a fresh version of OL8 for the final image    
+
+## Get a fresh version of Oracle Linux 8 for the final image
 FROM oraclelinux:8
 
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 ENV JAVA_HOME=/usr/java/jdk-17
-ENV PATH $JAVA_HOME/bin:$PATH    
+ENV PATH $JAVA_HOME/bin:$PATH
 
-# If you need the Java Version you can read it from the release file with 
+# If you need the Java Version you can read it from the release file with
 # JAVA_VERSION=$(sed -n '/^JAVA_VERSION="/{s///;s/"//;p;}' "$JAVA_HOME"/release);
 
 # Copy the uncompressed Java Runtime from the builder image
@@ -71,7 +71,7 @@ COPY --from=builder $JAVA_HOME $JAVA_HOME
 RUN set -eux; \
 # Ensure we get the latest OL 8 updates available at build time
     dnf -y update; \
-# JDK assumes freetype is available    
+# JDK assumes freetype is available
     dnf install -y \
         freetype fontconfig \
     ; \
@@ -83,5 +83,5 @@ RUN set -eux; \
         [ ! -e "/usr/bin/$base" ]; \
         alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
     done;
-    
+
 CMD ["jshell"]

--- a/OracleJava/17/Dockerfile
+++ b/OracleJava/17/Dockerfile
@@ -8,13 +8,12 @@
 #
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
-# This dockerfile will download a copy of JDK 17 from
-#	https://download.oracle.com/java/17/latest/jdk-17_linux-<ARCH>_bin.tar.gz
-# 
-# It will use either x64 or aarch64 depending on the target platform
+# (1) jdk-17.XX_linux-x64_bin.tar.gz or jdk-17.XX_linux-aarch64_bin.tar.gz
+#     Download from https://www.oracle.com/java/technologies/downloads
 #
 # HOW TO BUILD THIS IMAGE
 # -----------------------
+# Put all downloaded files in the same directory as this Dockerfile
 # Run:
 #      $ docker build -t oracle/jdk:17 .
 #
@@ -29,30 +28,31 @@ LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
 # Since the files are compressed as tar.gz first dnf install tar. gzip is already in oraclelinux:8
 RUN dnf install -y tar
-	
+
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
 # Environment variables for the builder image.
 # Required to validate that you are using the correct file
 
-ENV JAVA_URL=https://download.oracle.com/java/17/latest \
-	JAVA_HOME=/usr/java/jdk-17
+ENV JAVA_HOME=/usr/java/jdk-17
 
 ##
+COPY *.tar.gz /tmp/
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux; \
 	ARCH="$(uname -m)" && \
-	# Java uses just x64 in the name of the tarball
     if [ "$ARCH" = "x86_64" ]; \
-        then ARCH="x64"; \
+    then \
+		mv "$(ls /tmp/jdk-17*_linux-x64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
+        JAVA_SHA256=f7a6fdebeb11840e1f5314bc330feb75b67e52491cf39073dbf3e51e3889ff08 ; \
+    else \
+	    mv "$(ls /tmp/jdk-17*_linux-aarch64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
+    	JAVA_SHA256=277e0010e7b17583e63827f9537a153ea79cb4b6ca28d523cd8a82f14a24a769 ; \
     fi && \
-    JAVA_PKG="$JAVA_URL"/jdk-17_linux-"${ARCH}"_bin.tar.gz ; \
-	JAVA_SHA256="$(curl "$JAVA_PKG".sha256)" ; \ 
-	curl --output /tmp/jdk.tgz "$JAVA_PKG" && \
-	echo "$JAVA_SHA256" */tmp/jdk.tgz | sha256sum -c; \
+	echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
 	mkdir -p "$JAVA_HOME"; \
-	tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1
+	tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
 	
 ## Get a fresh version of OL8 for the final image	
 FROM oraclelinux:8

--- a/OracleJava/17/Dockerfile
+++ b/OracleJava/17/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
@@ -44,10 +44,10 @@ RUN set -eux; \
 	ARCH="$(uname -m)" && \
     if [ "$ARCH" = "x86_64" ]; \
     then \
-		mv "$(ls /tmp/jdk-17*_linux-x64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
+	mv "$(ls /tmp/jdk-17*_linux-x64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
         JAVA_SHA256=f7a6fdebeb11840e1f5314bc330feb75b67e52491cf39073dbf3e51e3889ff08 ; \
     else \
-	    mv "$(ls /tmp/jdk-17*_linux-aarch64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
+	mv "$(ls /tmp/jdk-17*_linux-aarch64_bin.tar.gz)" /tmp/jdk.tar.gz ; \
     	JAVA_SHA256=277e0010e7b17583e63827f9537a153ea79cb4b6ca28d523cd8a82f14a24a769 ; \
     fi && \
 	echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \

--- a/OracleJava/21/Dockerfile
+++ b/OracleJava/21/Dockerfile
@@ -9,8 +9,8 @@
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
 # This dockerfile will download a copy of JDK 21 from
-#    https://download.oracle.com/java/21/latest/jdk-21_linux-<ARCH>_bin.tar.gz  
-# 
+#    https://download.oracle.com/java/21/latest/jdk-21_linux-<ARCH>_bin.tar.gz
+#
 # It will use either x64 or aarch64 depending on the target platform
 #
 # HOW TO BUILD THIS IMAGE
@@ -29,14 +29,14 @@ LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
 # Since the files are compressed as tar.gz first dnf install tar. gzip is already in oraclelinux:8
 RUN set -eux; \
-    dnf install -y tar; 
-    
+    dnf install -y tar;
+
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
 # Environment variables for the builder image.
 # Required to validate that you are using the correct file
-    
+
 ENV JAVA_URL=https://download.oracle.com/java/21/latest \
     JAVA_HOME=/usr/java/jdk-21
 
@@ -49,21 +49,21 @@ RUN set -eux; \
         then ARCH="x64"; \
     fi && \
     JAVA_PKG="$JAVA_URL"/jdk-21_linux-"${ARCH}"_bin.tar.gz ; \
-    JAVA_SHA256=$(curl "$JAVA_PKG".sha256) ; \ 
+    JAVA_SHA256=$(curl "$JAVA_PKG".sha256) ; \
     curl --output /tmp/jdk.tgz "$JAVA_PKG" && \
     echo "$JAVA_SHA256" */tmp/jdk.tgz | sha256sum -c; \
     mkdir -p "$JAVA_HOME"; \
     tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1
-    
-## Get a fresh version of OL8 for the final image    
+
+## Get a fresh version of Oracle Linux 8 for the final image
 FROM oraclelinux:8
 
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 ENV JAVA_HOME=/usr/java/jdk-21
-ENV PATH $JAVA_HOME/bin:$PATH    
+ENV PATH $JAVA_HOME/bin:$PATH
 
-# If you need the Java Version you can read it from the release file with 
+# If you need the Java Version you can read it from the release file with
 # JAVA_VERSION=$(sed -n '/^JAVA_VERSION="/{s///;s/"//;p;}' "$JAVA_HOME"/release);
 
 # Copy the uncompressed Java Runtime from the builder image
@@ -72,7 +72,7 @@ COPY --from=builder $JAVA_HOME $JAVA_HOME
 RUN set -eux; \
 # Ensure we get the latest OL 8 updates available at build time
     dnf -y update; \
-# JDK assumes freetype is available    
+# JDK assumes freetype is available
     dnf install -y \
         freetype fontconfig \
     ; \
@@ -84,5 +84,5 @@ RUN set -eux; \
         [ ! -e "/usr/bin/$base" ]; \
         alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
     done;
-    
+
 CMD ["jshell"]

--- a/OracleJava/21/Dockerfile
+++ b/OracleJava/21/Dockerfile
@@ -9,7 +9,7 @@
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
 # This dockerfile will download a copy of JDK 21 from
-#	https://download.oracle.com/java/21/latest/jdk-21_linux-<ARCH>_bin.tar.gz  
+#    https://download.oracle.com/java/21/latest/jdk-21_linux-<ARCH>_bin.tar.gz  
 # 
 # It will use either x64 or aarch64 depending on the target platform
 #
@@ -19,7 +19,7 @@
 #      $ docker build -t oracle/jdk:21 .
 #
 # This command is already scripted in build.sh so you can alternatively run
-#		$ bash build.sh
+#      $ bash build.sh
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
@@ -29,39 +29,39 @@ LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
 # Since the files are compressed as tar.gz first dnf install tar. gzip is already in oraclelinux:8
 RUN set -eux; \
-	dnf install -y tar; 
-	
+    dnf install -y tar; 
+    
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
 # Environment variables for the builder image.
 # Required to validate that you are using the correct file
-	
+    
 ENV JAVA_URL=https://download.oracle.com/java/21/latest \
-	JAVA_HOME=/usr/java/jdk-21
+    JAVA_HOME=/usr/java/jdk-21
 
 ##
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux; \
-	ARCH="$(uname -m)" && \
-	# Java uses just x64 in the name of the tarball
+    ARCH="$(uname -m)" && \
+    # Java uses just x64 in the name of the tarball
     if [ "$ARCH" = "x86_64" ]; \
         then ARCH="x64"; \
     fi && \
     JAVA_PKG="$JAVA_URL"/jdk-21_linux-"${ARCH}"_bin.tar.gz ; \
-	JAVA_SHA256=$(curl "$JAVA_PKG".sha256) ; \ 
-	curl --output /tmp/jdk.tgz "$JAVA_PKG" && \
-	echo "$JAVA_SHA256" */tmp/jdk.tgz | sha256sum -c; \
-	mkdir -p "$JAVA_HOME"; \
-	tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1
-	
-## Get a fresh version of OL8 for the final image	
+    JAVA_SHA256=$(curl "$JAVA_PKG".sha256) ; \ 
+    curl --output /tmp/jdk.tgz "$JAVA_PKG" && \
+    echo "$JAVA_SHA256" */tmp/jdk.tgz | sha256sum -c; \
+    mkdir -p "$JAVA_HOME"; \
+    tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1
+    
+## Get a fresh version of OL8 for the final image    
 FROM oraclelinux:8
 
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
-ENV	JAVA_HOME=/usr/java/jdk-21
-ENV	PATH $JAVA_HOME/bin:$PATH	
+ENV JAVA_HOME=/usr/java/jdk-21
+ENV PATH $JAVA_HOME/bin:$PATH    
 
 # If you need the Java Version you can read it from the release file with 
 # JAVA_VERSION=$(sed -n '/^JAVA_VERSION="/{s///;s/"//;p;}' "$JAVA_HOME"/release);
@@ -71,18 +71,18 @@ COPY --from=builder $JAVA_HOME $JAVA_HOME
 
 RUN set -eux; \
 # Ensure we get the latest OL 8 updates available at build time
-	dnf -y update; \
-# JDK assumes freetype is available	
-	dnf install -y \
-		freetype fontconfig \
-	; \
-	rm -rf /var/cache/dnf; \
-	ln -sfT "$JAVA_HOME" /usr/java/default; \
-	ln -sfT "$JAVA_HOME" /usr/java/latest; \
-	for bin in "$JAVA_HOME/bin/"*; do \
-		base="$(basename "$bin")"; \
-		[ ! -e "/usr/bin/$base" ]; \
-		alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
-	done;
-	
+    dnf -y update; \
+# JDK assumes freetype is available    
+    dnf install -y \
+        freetype fontconfig \
+    ; \
+    rm -rf /var/cache/dnf; \
+    ln -sfT "$JAVA_HOME" /usr/java/default; \
+    ln -sfT "$JAVA_HOME" /usr/java/latest; \
+    for bin in "$JAVA_HOME/bin/"*; do \
+        base="$(basename "$bin")"; \
+        [ ! -e "/usr/bin/$base" ]; \
+        alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
+    done;
+    
 CMD ["jshell"]

--- a/OracleJava/21/Dockerfile.ol9
+++ b/OracleJava/21/Dockerfile.ol9
@@ -9,7 +9,7 @@
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
 # This dockerfile will download a copy of JDK 21 from
-#	https://download.oracle.com/java/21/latest/jdk-21_linux-<ARCH>_bin.tar.gz  
+#    https://download.oracle.com/java/21/latest/jdk-21_linux-<ARCH>_bin.tar.gz  
 # 
 # It will use either x64 or aarch64 depending on the target platform
 #
@@ -19,7 +19,7 @@
 #      $ docker build -t oracle/jdk:21 .
 #
 # This command is already scripted in build.sh so you can alternatively run
-#		$ bash build.sh 9
+#      $ bash build.sh 9
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
@@ -29,39 +29,39 @@ LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
 # Since the files are compressed as tar.gz first dnf install tar. gzip is already in oraclelinux:9
 RUN set -eux; \
-	dnf install -y tar; 
-	
+    dnf install -y tar; 
+    
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
 # Environment variables for the builder image.
 # Required to validate that you are using the correct file
-	
+    
 ENV JAVA_URL=https://download.oracle.com/java/21/latest \
-	JAVA_HOME=/usr/java/jdk-21
+    JAVA_HOME=/usr/java/jdk-21
 
 ##
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux; \
-	ARCH="$(uname -m)" && \
-	# Java uses just x64 in the name of the tarball
+    ARCH="$(uname -m)" && \
+    # Java uses just x64 in the name of the tarball
     if [ "$ARCH" = "x86_64" ]; \
         then ARCH="x64"; \
     fi && \
     JAVA_PKG="$JAVA_URL"/jdk-21_linux-"${ARCH}"_bin.tar.gz ; \
-	JAVA_SHA256=$(curl "$JAVA_PKG".sha256) ; \ 
-	curl --output /tmp/jdk.tgz "$JAVA_PKG" && \
-	echo "$JAVA_SHA256" */tmp/jdk.tgz | sha256sum -c; \
-	mkdir -p "$JAVA_HOME"; \
-	tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1
-	
-## Get a fresh version of OL9 for the final image	
+    JAVA_SHA256=$(curl "$JAVA_PKG".sha256) ; \ 
+    curl --output /tmp/jdk.tgz "$JAVA_PKG" && \
+    echo "$JAVA_SHA256" */tmp/jdk.tgz | sha256sum -c; \
+    mkdir -p "$JAVA_HOME"; \
+    tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1
+    
+## Get a fresh version of OL9 for the final image    
 FROM oraclelinux:9
 
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
-ENV	JAVA_HOME=/usr/java/jdk-21
-ENV	PATH $JAVA_HOME/bin:$PATH	
+ENV JAVA_HOME=/usr/java/jdk-21
+ENV PATH $JAVA_HOME/bin:$PATH    
 
 # If you need the Java Version you can read it from the release file with 
 # JAVA_VERSION=$(sed -n '/^JAVA_VERSION="/{s///;s/"//;p;}' "$JAVA_HOME"/release);
@@ -71,18 +71,18 @@ COPY --from=builder $JAVA_HOME $JAVA_HOME
 
 RUN set -eux; \
 # Ensure we get the latest OL 9 updates available at build time
-	dnf -y update; \
-# JDK assumes freetype is available	
-	dnf install -y \
-		freetype fontconfig \
-	; \
-	rm -rf /var/cache/dnf; \
-	ln -sfT "$JAVA_HOME" /usr/java/default; \
-	ln -sfT "$JAVA_HOME" /usr/java/latest; \
-	for bin in "$JAVA_HOME/bin/"*; do \
-		base="$(basename "$bin")"; \
-		[ ! -e "/usr/bin/$base" ]; \
-		alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
-	done;
-	
+    dnf -y update; \
+# JDK assumes freetype is available    
+    dnf install -y \
+        freetype fontconfig \
+    ; \
+    rm -rf /var/cache/dnf; \
+    ln -sfT "$JAVA_HOME" /usr/java/default; \
+    ln -sfT "$JAVA_HOME" /usr/java/latest; \
+    for bin in "$JAVA_HOME/bin/"*; do \
+        base="$(basename "$bin")"; \
+        [ ! -e "/usr/bin/$base" ]; \
+        alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
+    done;
+    
 CMD ["jshell"]

--- a/OracleJava/21/Dockerfile.ol9
+++ b/OracleJava/21/Dockerfile.ol9
@@ -9,8 +9,8 @@
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
 # This dockerfile will download a copy of JDK 21 from
-#    https://download.oracle.com/java/21/latest/jdk-21_linux-<ARCH>_bin.tar.gz  
-# 
+#    https://download.oracle.com/java/21/latest/jdk-21_linux-<ARCH>_bin.tar.gz
+#
 # It will use either x64 or aarch64 depending on the target platform
 #
 # HOW TO BUILD THIS IMAGE
@@ -29,14 +29,14 @@ LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
 # Since the files are compressed as tar.gz first dnf install tar. gzip is already in oraclelinux:9
 RUN set -eux; \
-    dnf install -y tar; 
-    
+    dnf install -y tar;
+
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
 # Environment variables for the builder image.
 # Required to validate that you are using the correct file
-    
+
 ENV JAVA_URL=https://download.oracle.com/java/21/latest \
     JAVA_HOME=/usr/java/jdk-21
 
@@ -49,30 +49,30 @@ RUN set -eux; \
         then ARCH="x64"; \
     fi && \
     JAVA_PKG="$JAVA_URL"/jdk-21_linux-"${ARCH}"_bin.tar.gz ; \
-    JAVA_SHA256=$(curl "$JAVA_PKG".sha256) ; \ 
+    JAVA_SHA256=$(curl "$JAVA_PKG".sha256) ; \
     curl --output /tmp/jdk.tgz "$JAVA_PKG" && \
     echo "$JAVA_SHA256" */tmp/jdk.tgz | sha256sum -c; \
     mkdir -p "$JAVA_HOME"; \
     tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1
-    
-## Get a fresh version of OL9 for the final image    
+
+## Get a fresh version of Oracle Linux 9 for the final image
 FROM oraclelinux:9
 
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 ENV JAVA_HOME=/usr/java/jdk-21
-ENV PATH $JAVA_HOME/bin:$PATH    
+ENV PATH $JAVA_HOME/bin:$PATH
 
-# If you need the Java Version you can read it from the release file with 
+# If you need the Java Version you can read it from the release file with
 # JAVA_VERSION=$(sed -n '/^JAVA_VERSION="/{s///;s/"//;p;}' "$JAVA_HOME"/release);
 
 # Copy the uncompressed Java Runtime from the builder image
 COPY --from=builder $JAVA_HOME $JAVA_HOME
 
 RUN set -eux; \
-# Ensure we get the latest OL 9 updates available at build time
+# Ensure we get the latest Oracle Linux 9 updates available at build time
     dnf -y update; \
-# JDK assumes freetype is available    
+# JDK assumes freetype is available
     dnf install -y \
         freetype fontconfig \
     ; \
@@ -84,5 +84,5 @@ RUN set -eux; \
         [ ! -e "/usr/bin/$base" ]; \
         alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
     done;
-    
+
 CMD ["jshell"]

--- a/OracleJava/21/build.sh
+++ b/OracleJava/21/build.sh
@@ -7,9 +7,9 @@
 
 if test "$1" = "9"
 then
-	echo "Building Oracle JDK 21 on Oracle Linux 9"
-	docker build --file Dockerfile.ol9 --tag oracle/jdk:21-ol9 .
+    echo "Building Oracle JDK 21 on Oracle Linux 9"
+    docker build --file Dockerfile.ol9 --tag oracle/jdk:21-ol9 .
 else
-	echo "Building Oracle JDK 21 on Oracle Linux 8"
-	docker build --file Dockerfile --tag oracle/jdk:21-ol8 .
+    echo "Building Oracle JDK 21 on Oracle Linux 8"
+    docker build --file Dockerfile --tag oracle/jdk:21-ol8 .
 fi

--- a/OracleJava/23/Dockerfile
+++ b/OracleJava/23/Dockerfile
@@ -9,7 +9,7 @@
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
 # This dockerfile will download a copy of JDK 23 from
-#	https://download.oracle.com/java/23/latest/jdk-23_linux-<ARCH>_bin.tar.gz  
+#    https://download.oracle.com/java/23/latest/jdk-23_linux-<ARCH>_bin.tar.gz  
 # 
 # It will use either x64 or aarch64 depending on the target platform
 #
@@ -19,7 +19,7 @@
 #      $ docker build -t oracle/jdk:23 .
 #
 # This command is already scripted in build.sh so you can alternatively run
-#		$ bash build.sh
+#      $ bash build.sh
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
@@ -29,39 +29,39 @@ LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
 # Since the files are compressed as tar.gz first dnf install tar. gzip is already in oraclelinux:9
 RUN set -eux; \
-	dnf install -y tar; 
-	
+    dnf install -y tar; 
+    
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
 # Environment variables for the builder image.
 # Required to validate that you are using the correct file
-	
+    
 ENV JAVA_URL=https://download.oracle.com/java/23/latest \
-	JAVA_HOME=/usr/java/jdk-23
+    JAVA_HOME=/usr/java/jdk-23
 
 ##
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux; \
-	ARCH="$(uname -m)" && \
-	# Java uses just x64 in the name of the tarball
+    ARCH="$(uname -m)" && \
+    # Java uses just x64 in the name of the tarball
     if [ "$ARCH" = "x86_64" ]; \
         then ARCH="x64"; \
     fi && \
     JAVA_PKG="$JAVA_URL"/jdk-23_linux-"${ARCH}"_bin.tar.gz ; \
-	JAVA_SHA256=$(curl "$JAVA_PKG".sha256) ; \ 
-	curl --output /tmp/jdk.tgz "$JAVA_PKG" && \
-	echo "$JAVA_SHA256" */tmp/jdk.tgz | sha256sum -c; \
-	mkdir -p "$JAVA_HOME"; \
-	tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1
-	
-## Get a fresh version of OL8 for the final image	
+    JAVA_SHA256=$(curl "$JAVA_PKG".sha256) ; \ 
+    curl --output /tmp/jdk.tgz "$JAVA_PKG" && \
+    echo "$JAVA_SHA256" */tmp/jdk.tgz | sha256sum -c; \
+    mkdir -p "$JAVA_HOME"; \
+    tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1
+    
+## Get a fresh version of OL8 for the final image    
 FROM oraclelinux:9
 
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
-ENV	JAVA_HOME=/usr/java/jdk-23
-ENV	PATH $JAVA_HOME/bin:$PATH	
+ENV JAVA_HOME=/usr/java/jdk-23
+ENV PATH $JAVA_HOME/bin:$PATH    
 
 # If you need the Java Version you can read it from the release file with 
 # JAVA_VERSION=$(sed -n '/^JAVA_VERSION="/{s///;s/"//;p;}' "$JAVA_HOME"/release);
@@ -71,18 +71,18 @@ COPY --from=builder $JAVA_HOME $JAVA_HOME
 
 RUN set -eux; \
 # Ensure we get the latest OL 8 updates available at build time
-	dnf -y update; \
-# JDK assumes freetype is available	
-	dnf install -y \
-		freetype fontconfig \
-	; \
-	rm -rf /var/cache/dnf; \
-	ln -sfT "$JAVA_HOME" /usr/java/default; \
-	ln -sfT "$JAVA_HOME" /usr/java/latest; \
-	for bin in "$JAVA_HOME/bin/"*; do \
-		base="$(basename "$bin")"; \
-		[ ! -e "/usr/bin/$base" ]; \
-		alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
-	done;
-	
+    dnf -y update; \
+# JDK assumes freetype is available    
+    dnf install -y \
+        freetype fontconfig \
+    ; \
+    rm -rf /var/cache/dnf; \
+    ln -sfT "$JAVA_HOME" /usr/java/default; \
+    ln -sfT "$JAVA_HOME" /usr/java/latest; \
+    for bin in "$JAVA_HOME/bin/"*; do \
+        base="$(basename "$bin")"; \
+        [ ! -e "/usr/bin/$base" ]; \
+        alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
+    done;
+    
 CMD ["jshell"]

--- a/OracleJava/23/Dockerfile
+++ b/OracleJava/23/Dockerfile
@@ -9,8 +9,8 @@
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
 # This dockerfile will download a copy of JDK 23 from
-#    https://download.oracle.com/java/23/latest/jdk-23_linux-<ARCH>_bin.tar.gz  
-# 
+#    https://download.oracle.com/java/23/latest/jdk-23_linux-<ARCH>_bin.tar.gz
+#
 # It will use either x64 or aarch64 depending on the target platform
 #
 # HOW TO BUILD THIS IMAGE
@@ -29,14 +29,14 @@ LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
 # Since the files are compressed as tar.gz first dnf install tar. gzip is already in oraclelinux:9
 RUN set -eux; \
-    dnf install -y tar; 
-    
+    dnf install -y tar;
+
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
 # Environment variables for the builder image.
 # Required to validate that you are using the correct file
-    
+
 ENV JAVA_URL=https://download.oracle.com/java/23/latest \
     JAVA_HOME=/usr/java/jdk-23
 
@@ -49,30 +49,30 @@ RUN set -eux; \
         then ARCH="x64"; \
     fi && \
     JAVA_PKG="$JAVA_URL"/jdk-23_linux-"${ARCH}"_bin.tar.gz ; \
-    JAVA_SHA256=$(curl "$JAVA_PKG".sha256) ; \ 
+    JAVA_SHA256=$(curl "$JAVA_PKG".sha256) ; \
     curl --output /tmp/jdk.tgz "$JAVA_PKG" && \
     echo "$JAVA_SHA256" */tmp/jdk.tgz | sha256sum -c; \
     mkdir -p "$JAVA_HOME"; \
     tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1
-    
-## Get a fresh version of OL8 for the final image    
+
+## Get a fresh version of Oracle Linux 9 for the final image
 FROM oraclelinux:9
 
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 ENV JAVA_HOME=/usr/java/jdk-23
-ENV PATH $JAVA_HOME/bin:$PATH    
+ENV PATH $JAVA_HOME/bin:$PATH
 
-# If you need the Java Version you can read it from the release file with 
+# If you need the Java Version you can read it from the release file with
 # JAVA_VERSION=$(sed -n '/^JAVA_VERSION="/{s///;s/"//;p;}' "$JAVA_HOME"/release);
 
 # Copy the uncompressed Java Runtime from the builder image
 COPY --from=builder $JAVA_HOME $JAVA_HOME
 
 RUN set -eux; \
-# Ensure we get the latest OL 8 updates available at build time
+# Ensure we get the latest Oracle Linux 8 updates available at build time
     dnf -y update; \
-# JDK assumes freetype is available    
+# JDK assumes freetype is available
     dnf install -y \
         freetype fontconfig \
     ; \
@@ -84,5 +84,5 @@ RUN set -eux; \
         [ ! -e "/usr/bin/$base" ]; \
         alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
     done;
-    
+
 CMD ["jshell"]

--- a/OracleJava/23/build.sh
+++ b/OracleJava/23/build.sh
@@ -4,5 +4,5 @@
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-echo "Building Oracle JDK 23 on Oracle Linux 0"
+echo "Building Oracle JDK 23 on Oracle Linux 9"
 docker build --file Dockerfile --tag oracle/jdk:23-ol9 .

--- a/OracleJava/8/jdk/Dockerfile
+++ b/OracleJava/8/jdk/Dockerfile
@@ -45,10 +45,10 @@ RUN set -eux; \
     if [ "$ARCH" = "x86_64" ]; \
     then \
 		mv "$(ls /tmp/jdk-8*-linux-x64.tar.gz)" /tmp/jdk.tar.gz ; \
-        JAVA_SHA256=92bfdee599c334f641de2d4ae08a4a082b966cb19b88d13d48b8486f80727b58 ; \
+        JAVA_SHA256=b396978a716b7d23ccccabfe5c47c3b75d2434d7f8f7af690bc648172382720d ; \
     else \
 	    mv "$(ls /tmp/jdk-8*-linux-aarch64.tar.gz)" /tmp/jdk.tar.gz ; \
-    	JAVA_SHA256=2cec03d24cf622d3c97af5fb3e6d0465de8cf7ce599b586e254bedb5ba23a9ca ; \    	
+    	JAVA_SHA256=e68d3e31ffcf7f05a4de65d04974843073bdff238bb6524adb272de9e616be7c ; \    	
     fi && \
 	echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
 	mkdir -p "$JAVA_HOME"; \

--- a/OracleJava/8/jdk/Dockerfile
+++ b/OracleJava/8/jdk/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Oracle and/or its affiliates. 
+# Copyright (c) 2024 Oracle and/or its affiliates. 
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
@@ -19,7 +19,7 @@
 #      $ docker build -t oracle/jdk:8 .
 #
 # This command is already scripted in build.sh so you can alternatively run
-#		$ bash build.sh
+#        $ bash build.sh
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
@@ -41,19 +41,18 @@ ENV JAVA_HOME=/usr/java/jdk-8
 COPY jdk-8u*.tar.gz /tmp/
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux; \
-	ARCH="$(uname -m)" && \
+    ARCH="$(uname -m)" && \
     if [ "$ARCH" = "x86_64" ]; \
     then \
-		mv "$(ls /tmp/jdk-8*-linux-x64.tar.gz)" /tmp/jdk.tar.gz ; \
+        mv "$(ls /tmp/jdk-8*-linux-x64.tar.gz)" /tmp/jdk.tar.gz ; \
         JAVA_SHA256=b396978a716b7d23ccccabfe5c47c3b75d2434d7f8f7af690bc648172382720d ; \
     else \
-	    mv "$(ls /tmp/jdk-8*-linux-aarch64.tar.gz)" /tmp/jdk.tar.gz ; \
-    	JAVA_SHA256=e68d3e31ffcf7f05a4de65d04974843073bdff238bb6524adb272de9e616be7c ; \    	
+        mv "$(ls /tmp/jdk-8*-linux-aarch64.tar.gz)" /tmp/jdk.tar.gz ; \
+        JAVA_SHA256=e68d3e31ffcf7f05a4de65d04974843073bdff238bb6524adb272de9e616be7c ; \        
     fi && \
-	echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
-	mkdir -p "$JAVA_HOME"; \
-	tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
-
+    echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
+    mkdir -p "$JAVA_HOME"; \
+    tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
 
 ## Get a fresh version of SLIM for the final image
 FROM oraclelinux:7-slim
@@ -62,24 +61,24 @@ FROM oraclelinux:7-slim
 ENV LANG en_US.UTF-8
 
 ENV JAVA_HOME=/usr/java/jdk-8 
-	
-ENV	PATH $JAVA_HOME/bin:$PATH
+    
+ENV PATH $JAVA_HOME/bin:$PATH
 
 # Copy the uncompressed Java Runtime from the builder image
 COPY --from=builder $JAVA_HOME $JAVA_HOME
 
 ##
-RUN	yum -y update; \
-	rm -rf /var/cache/yum; \
-	ln -sfT "$JAVA_HOME" /usr/java/default; \
-	ln -sfT "$JAVA_HOME" /usr/java/latest; \
-	for bin in "$JAVA_HOME/bin/"*; do \
-		base="$(basename "$bin")"; \
-		[ ! -e "/usr/bin/$base" ]; \
-		alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
-	done; \
-# -Xshare:dump will create a CDS archive to improve startup in subsequent runs	
+RUN yum -y update; \
+    rm -rf /var/cache/yum; \
+    ln -sfT "$JAVA_HOME" /usr/java/default; \
+    ln -sfT "$JAVA_HOME" /usr/java/latest; \
+    for bin in "$JAVA_HOME/bin/"*; do \
+        base="$(basename "$bin")"; \
+        [ ! -e "/usr/bin/$base" ]; \
+        alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
+    done; \
+# -Xshare:dump will create a CDS archive to improve startup in subsequent runs    
 # the file will be stored as /usr/java/jdk-8/jre/lib/amd64/server/classes.jsa 
 # See https://docs.oracle.com/javase/8/docs/technotes/guides/vm/class-data-sharing.html
-	java -Xshare:dump;
-	
+    java -Xshare:dump;
+    

--- a/OracleJava/8/jdk/Dockerfile
+++ b/OracleJava/8/jdk/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Oracle and/or its affiliates. 
+# Copyright (c) 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
@@ -48,20 +48,20 @@ RUN set -eux; \
         JAVA_SHA256=b396978a716b7d23ccccabfe5c47c3b75d2434d7f8f7af690bc648172382720d ; \
     else \
         mv "$(ls /tmp/jdk-8*-linux-aarch64.tar.gz)" /tmp/jdk.tar.gz ; \
-        JAVA_SHA256=e68d3e31ffcf7f05a4de65d04974843073bdff238bb6524adb272de9e616be7c ; \        
+        JAVA_SHA256=e68d3e31ffcf7f05a4de65d04974843073bdff238bb6524adb272de9e616be7c ; \
     fi && \
     echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
     mkdir -p "$JAVA_HOME"; \
     tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
 
-## Get a fresh version of SLIM for the final image
+## Get a fresh version of Oracle Linux 7-slim for the final image
 FROM oraclelinux:7-slim
 
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
-ENV JAVA_HOME=/usr/java/jdk-8 
-    
+ENV JAVA_HOME=/usr/java/jdk-8
+
 ENV PATH $JAVA_HOME/bin:$PATH
 
 # Copy the uncompressed Java Runtime from the builder image
@@ -77,8 +77,7 @@ RUN yum -y update; \
         [ ! -e "/usr/bin/$base" ]; \
         alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
     done; \
-# -Xshare:dump will create a CDS archive to improve startup in subsequent runs    
-# the file will be stored as /usr/java/jdk-8/jre/lib/amd64/server/classes.jsa 
+# -Xshare:dump will create a CDS archive to improve startup in subsequent runs
+# the file will be stored as /usr/java/jdk-8/jre/lib/amd64/server/classes.jsa
 # See https://docs.oracle.com/javase/8/docs/technotes/guides/vm/class-data-sharing.html
     java -Xshare:dump;
-    

--- a/OracleJava/8/jdk/Dockerfile.ol8
+++ b/OracleJava/8/jdk/Dockerfile.ol8
@@ -45,10 +45,10 @@ RUN set -eux; \
     if [ "$ARCH" = "x86_64" ]; \
     then \
 		mv "$(ls /tmp/jdk-8*-linux-x64.tar.gz)" /tmp/jdk.tar.gz ; \
-        JAVA_SHA256=92bfdee599c334f641de2d4ae08a4a082b966cb19b88d13d48b8486f80727b58 ; \
+        JAVA_SHA256=b396978a716b7d23ccccabfe5c47c3b75d2434d7f8f7af690bc648172382720d ; \
     else \
 	    mv "$(ls /tmp/jdk-8*-linux-aarch64.tar.gz)" /tmp/jdk.tar.gz ; \
-    	JAVA_SHA256=2cec03d24cf622d3c97af5fb3e6d0465de8cf7ce599b586e254bedb5ba23a9ca ; \    	
+    	JAVA_SHA256=e68d3e31ffcf7f05a4de65d04974843073bdff238bb6524adb272de9e616be7c ; \    	
     fi && \
 	echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
 	mkdir -p "$JAVA_HOME"; \

--- a/OracleJava/8/jdk/Dockerfile.ol8
+++ b/OracleJava/8/jdk/Dockerfile.ol8
@@ -48,13 +48,13 @@ RUN set -eux; \
         JAVA_SHA256=b396978a716b7d23ccccabfe5c47c3b75d2434d7f8f7af690bc648172382720d ; \
     else \
         mv "$(ls /tmp/jdk-8*-linux-aarch64.tar.gz)" /tmp/jdk.tar.gz ; \
-        JAVA_SHA256=e68d3e31ffcf7f05a4de65d04974843073bdff238bb6524adb272de9e616be7c ; \        
+        JAVA_SHA256=e68d3e31ffcf7f05a4de65d04974843073bdff238bb6524adb272de9e616be7c ; \
     fi && \
     echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
     mkdir -p "$JAVA_HOME"; \
     tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
 
-## Get a fresh version of OL 8 for the final image
+## Get a fresh version of Oracle Linux 8 for the final image
 
 FROM oraclelinux:8
 

--- a/OracleJava/8/jdk/Dockerfile.ol8
+++ b/OracleJava/8/jdk/Dockerfile.ol8
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Oracle and/or its affiliates.
+# Copyright (c) 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
@@ -19,7 +19,7 @@
 #      $ docker build -t oracle/jdk:8 .
 #
 # This command is already scripted in build.sh so you can alternatively run
-#		$ bash build.sh 8
+#        $ bash build.sh 8
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
@@ -41,18 +41,18 @@ ENV JAVA_HOME=/usr/java/jdk-8
 COPY jdk-8u*.tar.gz /tmp/
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux; \
-	ARCH="$(uname -m)" && \
+    ARCH="$(uname -m)" && \
     if [ "$ARCH" = "x86_64" ]; \
     then \
-		mv "$(ls /tmp/jdk-8*-linux-x64.tar.gz)" /tmp/jdk.tar.gz ; \
+        mv "$(ls /tmp/jdk-8*-linux-x64.tar.gz)" /tmp/jdk.tar.gz ; \
         JAVA_SHA256=b396978a716b7d23ccccabfe5c47c3b75d2434d7f8f7af690bc648172382720d ; \
     else \
-	    mv "$(ls /tmp/jdk-8*-linux-aarch64.tar.gz)" /tmp/jdk.tar.gz ; \
-    	JAVA_SHA256=e68d3e31ffcf7f05a4de65d04974843073bdff238bb6524adb272de9e616be7c ; \    	
+        mv "$(ls /tmp/jdk-8*-linux-aarch64.tar.gz)" /tmp/jdk.tar.gz ; \
+        JAVA_SHA256=e68d3e31ffcf7f05a4de65d04974843073bdff238bb6524adb272de9e616be7c ; \        
     fi && \
-	echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
-	mkdir -p "$JAVA_HOME"; \
-	tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
+    echo "$JAVA_SHA256 */tmp/jdk.tar.gz" | sha256sum -c -; \
+    mkdir -p "$JAVA_HOME"; \
+    tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
 
 ## Get a fresh version of OL 8 for the final image
 
@@ -63,22 +63,22 @@ ENV LANG en_US.UTF-8
 
 ENV JAVA_HOME=/usr/java/jdk-8
 
-ENV	PATH $JAVA_HOME/bin:$PATH
+ENV PATH $JAVA_HOME/bin:$PATH
 
 # Copy the uncompressed Java Runtime from the builder image
 COPY --from=builder $JAVA_HOME $JAVA_HOME
 
 ##
-RUN	dnf -y update; \
-	rm -rf /var/cache/dnf; \
-	ln -sfT "$JAVA_HOME" /usr/java/default; \
-	ln -sfT "$JAVA_HOME" /usr/java/latest; \
-	for bin in "$JAVA_HOME/bin/"*; do \
-		base="$(basename "$bin")"; \
-		[ ! -e "/usr/bin/$base" ]; \
-		alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
-	done; \
+RUN dnf -y update; \
+    rm -rf /var/cache/dnf; \
+    ln -sfT "$JAVA_HOME" /usr/java/default; \
+    ln -sfT "$JAVA_HOME" /usr/java/latest; \
+    for bin in "$JAVA_HOME/bin/"*; do \
+        base="$(basename "$bin")"; \
+        [ ! -e "/usr/bin/$base" ]; \
+        alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
+    done; \
 # -Xshare:dump will create a CDS archive to improve startup in subsequent runs
 # the file will be stored as /usr/java/jdk-8/jre/lib/amd64/server/classes.jsa
 # See https://docs.oracle.com/javase/8/docs/technotes/guides/vm/class-data-sharing.html
-	java -Xshare:dump;
+    java -Xshare:dump;

--- a/OracleJava/8/jdk/build.sh
+++ b/OracleJava/8/jdk/build.sh
@@ -6,10 +6,10 @@
 
 if test "$1" = "8"
 then
-	echo "Building Oracle JDK 8 on Oracle Linux 8"
-	docker build --file Dockerfile.ol8 --tag oracle/jdk:8-ol8 .
+    echo "Building Oracle JDK 8 on Oracle Linux 8"
+    docker build --file Dockerfile.ol8 --tag oracle/jdk:8-ol8 .
 else
-	echo "Building Oracle JDK 8 on Oracle Linux 7 slim"
-	docker build --tag oracle/jdk:8-ol7 .
+    echo "Building Oracle JDK 8 on Oracle Linux 7 slim"
+    docker build --tag oracle/jdk:8-ol7 .
 fi
 

--- a/OracleJava/8/serverjre/Dockerfile
+++ b/OracleJava/8/serverjre/Dockerfile
@@ -35,17 +35,16 @@ ENV LANG en_US.UTF-8
 
 # Environment variables for the builder image.
 # Required to validate that you are using the correct file
-
 	
 ENV JAVA_HOME=/usr/java/jdk-8
 
 COPY server-jre-8u*-linux-x64.tar.gz /tmp/jdk.tgz
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux; \
-	JAVA_SHA256=f6ad55ddd04f3a3a920312092e29be872b76104aded2cd5df51edb50c14136f2 ; \
+	JAVA_SHA256=7c9a3a87045c226647c09bc1eb1fc832f99a9105dbc924cfeab3bf16b3504d24 ; \
 	echo "$JAVA_SHA256 */tmp/jdk.tgz" | sha256sum -c -; \
 	mkdir -p "$JAVA_HOME"; \
-	tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1; 
+	tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1;
 
 ## Get a fresh version of SLIM for the final image
 
@@ -54,7 +53,7 @@ FROM oraclelinux:7-slim
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 
-ENV JAVA_HOME=/usr/java/jdk-8 
+ENV JAVA_HOME=/usr/java/jdk-8
 
 ENV	PATH $JAVA_HOME/bin:$PATH
 
@@ -71,8 +70,7 @@ RUN	yum -y update; \
 		[ ! -e "/usr/bin/$base" ]; \
 		alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
 	done; \
-# -Xshare:dump will create a CDS archive to improve startup in subsequent runs	
+# -Xshare:dump will create a CDS archive to improve startup in subsequent runs
 # the file will be stored as /usr/java/jdk-8/jre/lib/amd64/server/classes.jsa 
 # See https://docs.oracle.com/javase/8/docs/technotes/guides/vm/class-data-sharing.html
 	java -Xshare:dump;
-	

--- a/OracleJava/8/serverjre/Dockerfile
+++ b/OracleJava/8/serverjre/Dockerfile
@@ -46,7 +46,7 @@ RUN set -eux; \
     mkdir -p "$JAVA_HOME"; \
     tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1;
 
-## Get a fresh version of SLIM for the final image
+## Get a fresh version of Oracle Linux 7-slim for the final image
 
 FROM oraclelinux:7-slim
 

--- a/OracleJava/8/serverjre/Dockerfile
+++ b/OracleJava/8/serverjre/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, 2023 Oracle and/or its affiliates. 
+# Copyright (c) 2019, 2024 Oracle and/or its affiliates. 
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
@@ -19,7 +19,7 @@
 #      $ docker build -t oracle/serverjre:8 .
 #
 # This command is already scripted in build.sh so you can alternatively run
-#		$ bash build.sh
+#      $ bash build.sh
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
@@ -35,16 +35,16 @@ ENV LANG en_US.UTF-8
 
 # Environment variables for the builder image.
 # Required to validate that you are using the correct file
-	
+    
 ENV JAVA_HOME=/usr/java/jdk-8
 
 COPY server-jre-8u*-linux-x64.tar.gz /tmp/jdk.tgz
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux; \
-	JAVA_SHA256=7c9a3a87045c226647c09bc1eb1fc832f99a9105dbc924cfeab3bf16b3504d24 ; \
-	echo "$JAVA_SHA256 */tmp/jdk.tgz" | sha256sum -c -; \
-	mkdir -p "$JAVA_HOME"; \
-	tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1;
+    JAVA_SHA256=7c9a3a87045c226647c09bc1eb1fc832f99a9105dbc924cfeab3bf16b3504d24 ; \
+    echo "$JAVA_SHA256 */tmp/jdk.tgz" | sha256sum -c -; \
+    mkdir -p "$JAVA_HOME"; \
+    tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1;
 
 ## Get a fresh version of SLIM for the final image
 
@@ -55,22 +55,22 @@ ENV LANG en_US.UTF-8
 
 ENV JAVA_HOME=/usr/java/jdk-8
 
-ENV	PATH $JAVA_HOME/bin:$PATH
+ENV PATH $JAVA_HOME/bin:$PATH
 
 # Copy the uncompressed Java Runtime from the builder image
 COPY --from=builder $JAVA_HOME $JAVA_HOME
 
 ##
-RUN	yum -y update; \
-	rm -rf /var/cache/yum; \
-	ln -sfT "$JAVA_HOME" /usr/java/default; \
-	ln -sfT "$JAVA_HOME" /usr/java/latest; \
-	for bin in "$JAVA_HOME/bin/"*; do \
-		base="$(basename "$bin")"; \
-		[ ! -e "/usr/bin/$base" ]; \
-		alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
-	done; \
+RUN yum -y update; \
+    rm -rf /var/cache/yum; \
+    ln -sfT "$JAVA_HOME" /usr/java/default; \
+    ln -sfT "$JAVA_HOME" /usr/java/latest; \
+    for bin in "$JAVA_HOME/bin/"*; do \
+        base="$(basename "$bin")"; \
+        [ ! -e "/usr/bin/$base" ]; \
+        alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
+    done; \
 # -Xshare:dump will create a CDS archive to improve startup in subsequent runs
 # the file will be stored as /usr/java/jdk-8/jre/lib/amd64/server/classes.jsa 
 # See https://docs.oracle.com/javase/8/docs/technotes/guides/vm/class-data-sharing.html
-	java -Xshare:dump;
+    java -Xshare:dump;

--- a/OracleJava/8/serverjre/Dockerfile
+++ b/OracleJava/8/serverjre/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, 2024 Oracle and/or its affiliates. 
+# Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
@@ -35,7 +35,7 @@ ENV LANG en_US.UTF-8
 
 # Environment variables for the builder image.
 # Required to validate that you are using the correct file
-    
+
 ENV JAVA_HOME=/usr/java/jdk-8
 
 COPY server-jre-8u*-linux-x64.tar.gz /tmp/jdk.tgz
@@ -71,6 +71,6 @@ RUN yum -y update; \
         alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
     done; \
 # -Xshare:dump will create a CDS archive to improve startup in subsequent runs
-# the file will be stored as /usr/java/jdk-8/jre/lib/amd64/server/classes.jsa 
+# the file will be stored as /usr/java/jdk-8/jre/lib/amd64/server/classes.jsa
 # See https://docs.oracle.com/javase/8/docs/technotes/guides/vm/class-data-sharing.html
     java -Xshare:dump;

--- a/OracleJava/8/serverjre/Dockerfile.ol8
+++ b/OracleJava/8/serverjre/Dockerfile.ol8
@@ -41,7 +41,7 @@ ENV JAVA_HOME=/usr/java/jdk-8
 COPY server-jre-8u*-linux-x64.tar.gz /tmp/jdk.tgz
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux; \
-	JAVA_SHA256=f6ad55ddd04f3a3a920312092e29be872b76104aded2cd5df51edb50c14136f2 ; \
+	JAVA_SHA256=7c9a3a87045c226647c09bc1eb1fc832f99a9105dbc924cfeab3bf16b3504d24 ; \
 	echo "$JAVA_SHA256 */tmp/jdk.tgz" | sha256sum -c -; \
 	mkdir -p "$JAVA_HOME"; \
 	tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1;

--- a/OracleJava/8/serverjre/Dockerfile.ol8
+++ b/OracleJava/8/serverjre/Dockerfile.ol8
@@ -46,7 +46,7 @@ RUN set -eux; \
     mkdir -p "$JAVA_HOME"; \
     tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1;
 
-## Get a fresh version of OL 8 for the final image
+## Get a fresh version of Oracle Linux 8 for the final image
 
 FROM oraclelinux:8
 

--- a/OracleJava/8/serverjre/Dockerfile.ol8
+++ b/OracleJava/8/serverjre/Dockerfile.ol8
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
@@ -19,7 +19,7 @@
 #      $ docker build -t oracle/serverjre:8 .
 #
 # This command is already scripted in build.sh so you can alternatively run
-#		$ bash build.sh 8
+#      $ bash build.sh 8
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
@@ -41,10 +41,10 @@ ENV JAVA_HOME=/usr/java/jdk-8
 COPY server-jre-8u*-linux-x64.tar.gz /tmp/jdk.tgz
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux; \
-	JAVA_SHA256=7c9a3a87045c226647c09bc1eb1fc832f99a9105dbc924cfeab3bf16b3504d24 ; \
-	echo "$JAVA_SHA256 */tmp/jdk.tgz" | sha256sum -c -; \
-	mkdir -p "$JAVA_HOME"; \
-	tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1;
+    JAVA_SHA256=7c9a3a87045c226647c09bc1eb1fc832f99a9105dbc924cfeab3bf16b3504d24 ; \
+    echo "$JAVA_SHA256 */tmp/jdk.tgz" | sha256sum -c -; \
+    mkdir -p "$JAVA_HOME"; \
+    tar --extract --file /tmp/jdk.tgz --directory "$JAVA_HOME" --strip-components 1;
 
 ## Get a fresh version of OL 8 for the final image
 
@@ -55,22 +55,22 @@ ENV LANG en_US.UTF-8
 
 ENV JAVA_HOME=/usr/java/jdk-8
 
-ENV	PATH $JAVA_HOME/bin:$PATH
+ENV PATH $JAVA_HOME/bin:$PATH
 
 # Copy the uncompressed Java Runtime from the builder image
 COPY --from=builder $JAVA_HOME $JAVA_HOME
 
 ##
-RUN	dnf -y update; \
-	rm -rf /var/cache/dnf; \
-	ln -sfT "$JAVA_HOME" /usr/java/default; \
-	ln -sfT "$JAVA_HOME" /usr/java/latest; \
-	for bin in "$JAVA_HOME/bin/"*; do \
-		base="$(basename "$bin")"; \
-		[ ! -e "/usr/bin/$base" ]; \
-		alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
-	done; \
+RUN dnf -y update; \
+    rm -rf /var/cache/dnf; \
+    ln -sfT "$JAVA_HOME" /usr/java/default; \
+    ln -sfT "$JAVA_HOME" /usr/java/latest; \
+    for bin in "$JAVA_HOME/bin/"*; do \
+        base="$(basename "$bin")"; \
+        [ ! -e "/usr/bin/$base" ]; \
+        alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
+    done; \
 # -Xshare:dump will create a CDS archive to improve startup in subsequent runs
 # the file will be stored as /usr/java/jdk-8/jre/lib/amd64/server/classes.jsa
 # See https://docs.oracle.com/javase/8/docs/technotes/guides/vm/class-data-sharing.html
-	java -Xshare:dump;
+    java -Xshare:dump;

--- a/OracleJava/8/serverjre/build.sh
+++ b/OracleJava/8/serverjre/build.sh
@@ -6,10 +6,10 @@
 
 if test "$1" = "8"
 then
-	echo "Building Oracle Server JRE 8 on Oracle Linux 8"
-	docker build --file Dockerfile.ol8 --tag oracle/serverjre:8-ol8 .
+    echo "Building Oracle Server JRE 8 on Oracle Linux 8"
+    docker build --file Dockerfile.ol8 --tag oracle/serverjre:8-ol8 .
 else
-	echo "Building Oracle Server JRE 8 on Oracle Linux 7 slim"
-	docker build --tag oracle/serverjre:8-ol7 .
+    echo "Building Oracle Server JRE 8 on Oracle Linux 7 slim"
+    docker build --tag oracle/serverjre:8-ol7 .
 fi
 

--- a/OracleJava/README.md
+++ b/OracleJava/README.md
@@ -67,7 +67,7 @@ The script `build.sh` will tag the images it creates with the JDK version, and w
 
 JDK 23 and 21 are downloaded, as part of the build process, from the [Oracle Website](https://www.oracle.com/javadownload) under the [Oracle No-Fee Terms and Conditions (NFTC)](https://java.com/freeuselicense).
 
-For building JDK17, JDK 11, JDK 8, and Server JRE 8 you must first download the corresponding Java Runtime from the [Oracle Website](https://www.oracle.com/javadownload) and accept the license indicated on that page.
+For building JDK 17, JDK 11, JDK 8, and Server JRE 8 you must first download the corresponding Java Runtime from the [Oracle Website](https://www.oracle.com/javadownload) and accept the license indicated on that page.
 
 All scripts and files hosted in this project and GitHub [`docker/OracleJava`](./) repository, required to build the container images are, unless otherwise noted, released under the [UPL 1.0](https://oss.oracle.com/licenses/upl/) license.
 

--- a/OracleJava/README.md
+++ b/OracleJava/README.md
@@ -6,11 +6,11 @@ Oracle Java Server JRE provides the features from Oracle Java JDK commonly requi
 
 ## Building the Oracle Java base image
 
-For JDK 23, 21, and 17 the required JDK binaries will be downloaded from [Oracle](https://www.oracle.com/javadownload) as part of the build using curl.
+For JDK 23 and 21 the required JDK binaries will be downloaded from [Oracle](https://www.oracle.com/javadownload) as part of the build using curl.
 
-For JDK 11 and JDK 8 you must first download the linux x64 or linux aarch64 compressed archive (tar.gz), for Server JRE 8 you must download the linux x64 compressed archive, from [https://oracle.com/javadownload](https://www.oracle.com/javadownload) and place it in the same directory as the corresponding Dockerfile.
+For JDK 17, JDK 11, and JDK 8 you must first download the linux x64 or linux aarch64 compressed archive (tar.gz), for Server JRE 8 you must download the linux x64 compressed archive, from [https://oracle.com/javadownload](https://www.oracle.com/javadownload) and place it in the same directory as the corresponding Dockerfile.
 
-e.g. for JDK 11 download jdk-11[X]_linux-x64_bin.tar.gz into OracleJava/11, for Server JRE 8 download server-jre-8uXXX-linux-x64.tar.gz into OracleJava/8/serverjre
+e.g. for JDK 17 download jdk-17[X]_linux-x64_bin.tar.gz into OracleJava/17, for Server JRE 8 download server-jre-8uXXX-linux-x64.tar.gz into OracleJava/8/serverjre
 
 To build the container image run `docker build`. Tag it with the correct version number.
 
@@ -65,9 +65,9 @@ The script `build.sh` will tag the images it creates with the JDK version, and w
 
 ## Licenses
 
-JDK 23, 21, and 17 are downloaded, as part of the build process, from the [Oracle Website](https://www.oracle.com/javadownload) under the [Oracle No-Fee Terms and Conditions (NFTC)](https://java.com/freeuselicense).
+JDK 23 and 21 are downloaded, as part of the build process, from the [Oracle Website](https://www.oracle.com/javadownload) under the [Oracle No-Fee Terms and Conditions (NFTC)](https://java.com/freeuselicense).
 
-For building JDK 11, JDK 8, and Server JRE 8 you must first download the corresponding Java Runtime from the [Oracle Website](https://www.oracle.com/javadownload) and accept the license indicated on that page.
+For building JDK17, JDK 11, JDK 8, and Server JRE 8 you must first download the corresponding Java Runtime from the [Oracle Website](https://www.oracle.com/javadownload) and accept the license indicated on that page.
 
 All scripts and files hosted in this project and GitHub [`docker/OracleJava`](./) repository, required to build the container images are, unless otherwise noted, released under the [UPL 1.0](https://oss.oracle.com/licenses/upl/) license.
 

--- a/OracleOpenJDK/23/Dockerfile
+++ b/OracleOpenJDK/23/Dockerfile
@@ -21,7 +21,7 @@
 #		$ bash build.sh
 #
 
-FROM oraclelinux:9 
+FROM oraclelinux:9
 
 LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
@@ -29,18 +29,18 @@ ENV JAVA_URL=https://download.java.net/java/GA/jdk23.0.1/c28985cbf10d4e648e40040
 	JAVA_HOME=/usr/java/jdk-23 \
 	LANG=en_US.UTF-8
 
-# If you need the Java Version you can read it from the release file with 
+# If you need the Java Version you can read it from the release file with
 #JAVA_VERSION=$(sed -n '/^JAVA_VERSION="/{s///;s/"//;p;}' "$JAVA_HOME"/release);
-	
+
 ENV	PATH $JAVA_HOME/bin:$PATH
-	
+
 # Since the files are compressed as tar.gz first dnf install tar. gzip is already in oraclelinux:9
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux; \
 	dnf -y update; \
 	dnf install -y \
 		tar \
-		# JDK assumes freetype is available		
+		# JDK assumes freetype is available
 		freetype fontconfig \
 	; \
 	rm -rf /var/cache/dnf; \
@@ -50,7 +50,7 @@ RUN set -eux; \
         then ARCH="x64"; \
     fi && \
     JAVA_PKG="$JAVA_URL"/openjdk-23.0.1_linux-"${ARCH}"_bin.tar.gz ; \
-	JAVA_SHA256="$(curl "$JAVA_PKG".sha256)" ; \ 
+	JAVA_SHA256="$(curl "$JAVA_PKG".sha256)" ; \
 	curl --output /tmp/jdk.tgz "$JAVA_PKG" && \
 	echo "$JAVA_SHA256" */tmp/jdk.tgz | sha256sum -c -; \
 	mkdir -p "$JAVA_HOME"; \
@@ -63,6 +63,6 @@ RUN ln -sfT "$JAVA_HOME" /usr/java/default; \
 		base="$(basename "$bin")"; \
 		[ ! -e "/usr/bin/$base" ]; \
 		alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
-	done; 
+	done;
 
 CMD ["jshell"]

--- a/OracleOpenJDK/23/Dockerfile
+++ b/OracleOpenJDK/23/Dockerfile
@@ -25,10 +25,9 @@ FROM oraclelinux:9
 
 LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
-ENV JAVA_URL=https://download.java.net/java/GA/jdk23/3c5b90190c68498b986a97f276efd28a/37/GPL \
+ENV JAVA_URL=https://download.java.net/java/GA/jdk23.0.1/c28985cbf10d4e648e4004050f8781aa/11/GPL \
 	JAVA_HOME=/usr/java/jdk-23 \
 	LANG=en_US.UTF-8
-	
 
 # If you need the Java Version you can read it from the release file with 
 #JAVA_VERSION=$(sed -n '/^JAVA_VERSION="/{s///;s/"//;p;}' "$JAVA_HOME"/release);
@@ -50,7 +49,7 @@ RUN set -eux; \
     if [ "$ARCH" = "x86_64" ]; \
         then ARCH="x64"; \
     fi && \
-    JAVA_PKG="$JAVA_URL"/openjdk-23_linux-"${ARCH}"_bin.tar.gz ; \
+    JAVA_PKG="$JAVA_URL"/openjdk-23.0.1_linux-"${ARCH}"_bin.tar.gz ; \
 	JAVA_SHA256="$(curl "$JAVA_PKG".sha256)" ; \ 
 	curl --output /tmp/jdk.tgz "$JAVA_PKG" && \
 	echo "$JAVA_SHA256" */tmp/jdk.tgz | sha256sum -c -; \

--- a/OracleOpenJDK/23/build.sh
+++ b/OracleOpenJDK/23/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (c) 2023 Oracle and/or its affiliates. 
+# Copyright (c) 2023 Oracle and/or its affiliates.
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 


### PR DESCRIPTION
JDK 17 is no longer available under no fee-term-and-conditions so it now requires users to download the binary first, as was the case before for JDK 8 and JDK 11.

Update the checksums for 11 and 8, and the download URL for OpenJDK 23.0.1