### PR TITLE
OpenJDK update to Jan 2025 Critical Patch Update

### DIFF
--- a/OracleOpenJDK/23/Dockerfile.ol9
+++ b/OracleOpenJDK/23/Dockerfile.ol9
@@ -25,7 +25,7 @@ FROM oraclelinux:9
 
 LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
-ENV JAVA_URL=https://download.java.net/java/GA/jdk23.0.1/c28985cbf10d4e648e4004050f8781aa/11/GPL \
+ENV JAVA_URL=https://download.java.net/java/GA/jdk23.0.2/6da2a6609d6e406f85c491fcb119101b/7/GPL \
 	JAVA_HOME=/usr/java/jdk-23 \
 	LANG=en_US.UTF-8
 
@@ -49,7 +49,7 @@ RUN set -eux; \
     if [ "$ARCH" = "x86_64" ]; \
         then ARCH="x64"; \
     fi && \
-    JAVA_PKG="$JAVA_URL"/openjdk-23.0.1_linux-"${ARCH}"_bin.tar.gz ; \
+    JAVA_PKG="$JAVA_URL"/openjdk-23.0.2_linux-"${ARCH}"_bin.tar.gz ; \
 	JAVA_SHA256="$(curl "$JAVA_PKG".sha256)" ; \
 	curl --output /tmp/jdk.tgz "$JAVA_PKG" && \
 	echo "$JAVA_SHA256" */tmp/jdk.tgz | sha256sum -c -; \


### PR DESCRIPTION
updated download url and filename in the OpenJDK dockerfile from 23.0.1 to 23.0.2 per the Jan 2025 Critical Patch Update. 