### PR TITLE
Wrong Checksum in RAC 19.3(containerfiles)

### DIFF
--- a/OracleDatabase/RAC/OracleRealApplicationClusters/containerfiles/19.3.0/Checksum
+++ b/OracleDatabase/RAC/OracleRealApplicationClusters/containerfiles/19.3.0/Checksum
@@ -1,2 +1,2 @@
-b7c4c66f801f92d14faa0d791ccda721  19.3.0/LINUX.X64_193000_db_home.zip
-1858bd0d281c60f4ddabd87b1c214a4f  19.3.0/LINUX.X64_193000_grid_home.zip
+1858bd0d281c60f4ddabd87b1c214a4f  19.3.0/LINUX.X64_193000_db_home.zip
+b7c4c66f801f92d14faa0d791ccda721  19.3.0/LINUX.X64_193000_grid_home.zip


### PR DESCRIPTION
## Detail
The checksum values differ between the following two files:

### Checusum in dockerfiles

https://github.com/oracle/docker-images/blob/c13f8dfd220a5339ee236eedb9b2a3e5437eb666/OracleDatabase/RAC/OracleRealApplicationClusters/dockerfiles/19.3.0/Checksum#L1-L2

## Checusum in containerfiles

https://github.com/oracle/docker-images/blob/c13f8dfd220a5339ee236eedb9b2a3e5437eb666/OracleDatabase/RAC/OracleRealApplicationClusters/containerfiles/19.3.0/Checksum#L1-L2

Based on the results below, the former appears to be correct, while the latter seems to be reversed.

```bash
[root@ractest02 containerfiles]# md5sum 19.3.0/LINUX.X64_193000_db_home.zip  
1858bd0d281c60f4ddabd87b1c214a4f  19.3.0/LINUX.X64_193000_db_home.zip  
[root@ractest02 containerfiles]# md5sum 19.3.0/LINUX.X64_193000_grid_home.zip  
b7c4c66f801f92d14faa0d791ccda721  19.3.0/LINUX.X64_193000_grid_home.zip  
```