### PR TITLE
OracleGoldenGate 23 - Adding support for python startup scripts

### DIFF
--- a/OracleGoldenGate/23/README.md
+++ b/OracleGoldenGate/23/README.md
@@ -160,7 +160,7 @@ Version 23.4 ...
 
 ### Running Scripts Before Setup and on Startup
 
-The container images can be configured to run scripts before setup and on startup. Currently, `.sh` extensions are supported. For setup scripts just mount the volume `/u01/ogg/scripts/setup` or extend the image to include scripts in this directory. For startup scripts just mount the volume `/u01/ogg/scripts/startup` or extend the image to include scripts in this directory. Both of those locations
+The container images can be configured to run scripts before setup and on startup. Currently, `.sh` and `.py` extensions are supported. For setup scripts just mount the volume `/u01/ogg/scripts/setup` or extend the image to include scripts in this directory. For startup scripts just mount the volume `/u01/ogg/scripts/startup` or extend the image to include scripts in this directory. Both of those locations
 are static and the content is controlled by the volume mount.
 
 The example below mounts the local directory `${PWD}/myScripts` to `/u01/ogg/scripts` which is then searched for custom startup scripts:

--- a/OracleGoldenGate/23/bin/deployment-main.sh
+++ b/OracleGoldenGate/23/bin/deployment-main.sh
@@ -125,9 +125,13 @@ function run_user_scripts {
 	while read -r script; do
 		case "${script}" in
 		*.sh)
-			echo "Running script '${script}'"
+			echo "Running shell script '${script}'"
 			# shellcheck disable=SC1090
 			source "${script}"
+			;;
+		*.py)
+			echo "Running Python script '${script}'"
+			python3 "${script}"
 			;;
 		*)
 			echo "Ignoring '${script}'"


### PR DESCRIPTION
I'm using this image to install GoldenGate and I need to run python scripts whenever a container starts.
I've added support for python scripts on startup.