### PR TITLE
Add new python-oracledb images

### DIFF
--- a/OracleLinuxDevelopers/README.md
+++ b/OracleLinuxDevelopers/README.md
@@ -110,7 +110,11 @@ opt-in. To activate `yarn`, run `corepack enable` when building your downstream 
 * [`oraclelinux8-python:3.6-oracledb`](oraclelinux8/python/3.6-oracledb/Dockerfile)
 * [`oraclelinux8-python:3.8`](oraclelinux8/python/3.8/Dockerfile)
 * [`oraclelinux8-python:3.9`](oraclelinux8/python/3.9/Dockerfile)
+* [`oraclelinux8-python:3.9-oracledb`](oraclelinux8/python/3.9-oracledb/Dockerfile)
 * [`oraclelinux8-python:3.11`](oraclelinux8/python/3.11/Dockerfile)
+* [`oraclelinux8-python:3.11-oracledb`](oraclelinux8/python/3.11-oracledb/Dockerfile)
+* [`oraclelinux8-python:3.12`](oraclelinux8/python/3.12/Dockerfile)
+* [`oraclelinux8-python:3.12-oracledb`](oraclelinux8/python/3.12-oracledb/Dockerfile)
 
 ### Ruby module
 
@@ -129,6 +133,32 @@ You should then be able to create a new Ruby on Rails application.
 * [`oraclelinux8-ruby:2.7-nodejs`](oraclelinux8/ruby/2.7-nodejs/Dockerfile)
 * [`oraclelinux8-ruby:3.0`](oraclelinux8/ruby/3.0/Dockerfile)
 * [`oraclelinux8-ruby:3.1`](oraclelinux8/ruby/3.1/Dockerfile)
+
+## Oracle Linux 9 based images
+
+### Go Toolset module
+
+* [`oraclelinux9-golang:1.18`](oraclelinux9/golang/1.18/Dockerfile)
+
+### NGINX module
+
+* [`oraclelinux9-nginx:1.20`](oraclelinux9/nginx/1.20/Dockerfile)
+* [`oraclelinux9-nginx:1.20-core`](oraclelinux9/nginx/1.20-core/Dockerfile)
+* [`oraclelinux9-nginx:1.20-full`](oraclelinux9/nginx/1.20-full/Dockerfile)
+
+### Node.js module
+
+* [`oraclelinux9-nodejs:16`](oraclelinux9/nodejs/16/Dockerfile)
+* [`oraclelinux9-nodejs:18`](oraclelinux9/nodejs/18/Dockerfile)
+
+### Python modules
+
+* [`oraclelinux9-python:3.9`](oraclelinux9/python/3.9/Dockerfile)
+* [`oraclelinux9-python:3.11`](oraclelinux9/python/3.11/Dockerfile)
+* [`oraclelinux9-python:3.11-oracledb`](oraclelinux9/python/3.11-oracledb/Dockerfile)
+* [`oraclelinux9-python:3.12`](oraclelinux9/python/3.12/Dockerfile)
+* [`oraclelinux9-python:3.12-oracledb`](oraclelinux9/python/3.12-oracledb/Dockerfile)
+
 
 [1]: https://github.com/orgs/oracle/packages?repo_name=docker-images
 [2]: https://yum.oracle.com

--- a/OracleLinuxDevelopers/oraclelinux8/python/3.12-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/python/3.12-oracledb/Dockerfile
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+FROM ghcr.io/oracle/oraclelinux8-python:3.12
+
+RUN dnf -y install oraclelinux-developer-release-el8 && \
+    dnf -y install python3.12-oracledb && \
+    # Optionally install Oracle Instant Client to use python-oracledb Thick mode
+    # dnf -y install oracle-instantclient-release-23ai-el8 && \
+    # dnf -y install oracle-instantclient-basic && \
+    rm -rf /var/cache/dnf
+
+CMD ["/bin/python3", "--version"]

--- a/OracleLinuxDevelopers/oraclelinux9/python/3.11-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux9/python/3.11-oracledb/Dockerfile
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+FROM ghcr.io/oracle/oraclelinux9-python:3.11
+
+RUN dnf -y install oraclelinux-developer-release-el9 && \
+    dnf -y install python3.11-oracledb && \
+    # Optionally install Oracle Instant Client to use python-oracledb Thick mode
+    # dnf -y install oracle-instantclient-release-23ai-el9 && \
+    # dnf -y install oracle-instantclient-basic && \
+    rm -rf /var/cache/dnf
+
+CMD ["/bin/python3", "--version"]

--- a/OracleLinuxDevelopers/oraclelinux9/python/3.12-oracledb/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux9/python/3.12-oracledb/Dockerfile
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+FROM ghcr.io/oracle/oraclelinux9-python:3.12
+
+RUN dnf -y install oraclelinux-developer-release-el9 && \
+    dnf -y install python3.12-oracledb && \
+    # Optionally install Oracle Instant Client to use python-oracledb Thick mode
+    # dnf -y install oracle-instantclient-release-23ai-el9 && \
+    # dnf -y install oracle-instantclient-basic && \
+    rm -rf /var/cache/dnf
+
+CMD ["/bin/python3", "--version"]


### PR DESCRIPTION
- Added new python-oracledb images

- Did a pass through the Linux README and added basic missing info.  The owner (@AmedeeBulle ?) should do further updates to add missing info about existing containers.