### PR TITLE
NOSQL - Update to version 24.4.9

### DIFF
--- a/NoSQL/README-sec.md
+++ b/NoSQL/README-sec.md
@@ -86,7 +86,7 @@ For example, to check the version of KVLite, use the `version` command:
 
 ```shell
 $ docker run --rm -ti --link kvlite:store oracle/nosql:ce-sec  java -Xmx64m -Xms64m -jar lib/kvstore.jar version
-24.3.9 2024-09-26 18:01:32 UTC  Build id: 0d82533c492e Edition: Community
+24.4.9 2024-11-21 17:06:06 UTC  Build id: 95fa28ea4441 Edition: Community
 ```
 
 To check the size of the storage shard:
@@ -113,13 +113,13 @@ $ docker run --rm -ti -v secfiles:/shared_conf:ro --link kvlite:store oracle/nos
 
 Pinging components of store kvstore based upon topology sequence #14
 10 partitions and 1 storage nodes
-Time: 2024-12-04 12:14:44 UTC   Version: 24.3.9
+Time: 2025-03-17 09:08:59 UTC   Version: 24.4.9
 Shard Status: healthy: 1 writable-degraded: 0 read-only: 0 offline: 0 total: 1
 Admin Status: healthy
 Zone [name=KVLite id=zn1 type=PRIMARY allowArbiters=false masterAffinity=false]   RN Status: online: 1 read-only: 0 offline: 0
-Storage Node [sn1] on kvlite: 5000    Zone: [name=KVLite id=zn1 type=PRIMARY allowArbiters=false masterAffinity=false]    Status: RUNNING   Ver: 24.3.9 2024-09-26 18:01:32 UTC  Build id: 0d82533c492e Edition: Community    isMasterBalanced: true     serviceStartTime: 2024-12-04 12:06:43 UTC
-        Admin [admin1]          Status: RUNNING,MASTER  serviceStartTime: 2024-12-04 12:06:47 UTC       stateChangeTime: 2024-12-04 12:06:47 UTC        availableStorageSize: 2 GB
-        Rep Node [rg1-rn1]      Status: RUNNING,MASTER sequenceNumber: 131 haPort: 5011 availableStorageSize: 9 GB storageType: HD      serviceStartTime: 2024-12-04 12:06:49 UTC       stateChangeTime: 2024-12-04 12:06:50 UTC
+Storage Node [sn1] on kvlite: 5000    Zone: [name=KVLite id=zn1 type=PRIMARY allowArbiters=false masterAffinity=false]    Status: RUNNING   Ver: 24.4.9 2024-11-21 17:06:06 UTC  Build id: 95fa28ea4441 Edition: Community    isMasterBalanced: true     serviceStartTime: 2025-03-17 09:08:18 UTC
+        Admin [admin1]          Status: RUNNING,MASTER  serviceStartTime: 2025-03-17 09:08:22 UTC       stateChangeTime: 2025-03-17 09:08:22 UTC        availableStorageSize: 2 GB
+        Rep Node [rg1-rn1]      Status: RUNNING,MASTER sequenceNumber: 121 haPort: 5011 availableStorageSize: 9 GB storageType: HD      serviceStartTime: 2025-03-17 09:08:24 UTC       stateChangeTime: 2025-03-17 09:08:25 UTC
 
 
   kv-> put kv -key /SomeKey -value SomeValue
@@ -137,19 +137,19 @@ $ docker run --rm -ti -v secfiles:/shared_conf:ro --link kvlite:store oracle/nos
   -security /shared_conf/user.security
 
   sql-> show tables
-  tables
-    SYS$IndexStatsLease
-    SYS$MRTableAgentStat
-    SYS$MRTableInfo
-    SYS$MRTableInitCheckpoint
-    SYS$PartitionStatsLease
-    SYS$SGAttributesTable
-    SYS$StreamRequest
-    SYS$StreamResponse
-    SYS$TableMetadata
-    SYS$TableStatsIndex
-    SYS$TableStatsPartition
-    SYS$TopologyHistory
+tables
+  SYS$IndexStatsLease
+  SYS$MRTableAgentStat
+  SYS$MRTableInfo
+  SYS$MRTableInitCheckpoint
+  SYS$PartitionStatsLease
+  SYS$SGAttributesTable
+  SYS$StreamRequest
+  SYS$StreamResponse
+  SYS$TableMetadata
+  SYS$TableStatsIndex
+  SYS$TableStatsPartition
+  SYS$TopologyHistory
 
   sql-> exit
 ```
@@ -221,7 +221,7 @@ be made via the Oracle NoSQL Database Proxy on the `KV_PROXY_PORT`.
 First, install the latest version of Oracle NoSQL on your remote host:
 
 ```shell
-KV_VERSION=24.3.9
+KV_VERSION=24.4.9
 rm -rf kv-$KV_VERSION
 DOWNLOAD_ROOT=http://download.oracle.com/otn-pub/otn_software/nosql-database
 DOWNLOAD_FILE="kv-ce-${KV_VERSION}.zip"
@@ -427,9 +427,9 @@ Oracle provides no commercial support for the Oracle NoSQL Community Edition.
 
 ## Copyright
 
-Copyright (c) 2017, 2024 Oracle and/or its affiliates.
+Copyright (c) 2017, 2025 Oracle and/or its affiliates.
 
 [NOSQL]: http://www.oracle.com/technetwork/database/database-technologies/nosqldb/overview/index.html
 [DOCS]: https://docs.oracle.com/en/database/other-databases/nosql-database/index.html
-[Apache-2.0]: https://docs.oracle.com/en/database/other-databases/nosql-database/24.3/license/apache-license.html
+[Apache-2.0]: https://docs.oracle.com/en/database/other-databases/nosql-database/24.4/license/apache-license.html
 [GraalVM-License]: https://github.com/graalvm/container/blob/master/LICENSE.md

--- a/NoSQL/README.md
+++ b/NoSQL/README.md
@@ -120,19 +120,19 @@ $ docker run --rm -ti --link kvlite:store oracle/nosql:ce \
   java -jar lib/sql.jar -helper-hosts store:5000 -store kvstore
 
   sql-> show tables
-Tables in all namespaces:
-        SYS$IndexStatsLease -- 1
-        SYS$MRTableAgentStat -- 1
-        SYS$MRTableInfo -- 1
-        SYS$MRTableInitCheckpoint -- 1
-        SYS$PartitionStatsLease -- 1
-        SYS$SGAttributesTable -- 1
-        SYS$StreamRequest -- 1
-        SYS$StreamResponse -- 1
-        SYS$TableMetadata -- 1
-        SYS$TableStatsIndex -- 2
-        SYS$TableStatsPartition -- 3
-        SYS$TopologyHistory -- 1
+tables
+  SYS$IndexStatsLease
+  SYS$MRTableAgentStat
+  SYS$MRTableInfo
+  SYS$MRTableInitCheckpoint
+  SYS$PartitionStatsLease
+  SYS$SGAttributesTable
+  SYS$StreamRequest
+  SYS$StreamResponse
+  SYS$TableMetadata
+  SYS$TableStatsIndex
+  SYS$TableStatsPartition
+  SYS$TopologyHistory
 
   sql-> exit
 ```

--- a/NoSQL/README.md
+++ b/NoSQL/README.md
@@ -73,7 +73,7 @@ For example, to check the version of KVLite, use the `version` command:
 
 ```shell
 $ docker run --rm -ti --link kvlite:store oracle/nosql:ce  java -Xmx64m -Xms64m -jar lib/kvstore.jar version
-24.3.9 2024-09-26 18:01:32 UTC  Build id: 0d82533c492e Edition: Community
+24.4.9 2024-11-21 17:06:06 UTC  Build id: 95fa28ea4441 Edition: Community
 ```
 
 To check the size of the storage shard:
@@ -98,13 +98,13 @@ $ docker run --rm -ti --link kvlite:store oracle/nosql:ce \
   
 Pinging components of store kvstore based upon topology sequence #14
 10 partitions and 1 storage nodes
-Time: 2024-12-04 11:50:35 UTC   Version: 24.3.9
+Time: 2025-03-17 09:05:10 UTC   Version: 24.4.9
 Shard Status: healthy: 1 writable-degraded: 0 read-only: 0 offline: 0 total: 1
 Admin Status: healthy
 Zone [name=KVLite id=zn1 type=PRIMARY allowArbiters=false masterAffinity=false]   RN Status: online: 1 read-only: 0 offline: 0
-Storage Node [sn1] on kvlite: 5000    Zone: [name=KVLite id=zn1 type=PRIMARY allowArbiters=false masterAffinity=false]    Status: RUNNING   Ver: 24.3.9 2024-09-26 18:01:32 UTC  Build id: 0d82533c492e Edition: Community    isMasterBalanced: true     serviceStartTime: 2024-12-04 11:47:05 UTC
-        Admin [admin1]          Status: RUNNING,MASTER  serviceStartTime: 2024-12-04 11:47:08 UTC       stateChangeTime: 2024-12-04 11:47:08 UTC        availableStorageSize: 2 GB
-        Rep Node [rg1-rn1]      Status: RUNNING,MASTER sequenceNumber: 470 haPort: 5011 availableStorageSize: 9 GB storageType: HD      serviceStartTime: 2024-12-04 11:47:09 UTC       stateChangeTime: 2024-12-04 11:47:09 UTC
+Storage Node [sn1] on kvlite: 5000    Zone: [name=KVLite id=zn1 type=PRIMARY allowArbiters=false masterAffinity=false]    Status: RUNNING   Ver: 24.4.9 2024-11-21 17:06:06 UTC  Build id: 95fa28ea4441 Edition: Community    isMasterBalanced: true     serviceStartTime: 2025-03-17 09:04:40 UTC
+        Admin [admin1]          Status: RUNNING,MASTER  serviceStartTime: 2025-03-17 09:04:43 UTC       stateChangeTime: 2025-03-17 09:04:43 UTC        availableStorageSize: 2 GB
+        Rep Node [rg1-rn1]      Status: RUNNING,MASTER sequenceNumber: 86 haPort: 5011 availableStorageSize: 9 GB storageType: HD       serviceStartTime: 2025-03-17 09:04:44 UTC       stateChangeTime: 2025-03-17 09:04:45 UTC
   
   kv-> put kv -key /SomeKey -value SomeValue
   Operation successful, record inserted.
@@ -120,19 +120,19 @@ $ docker run --rm -ti --link kvlite:store oracle/nosql:ce \
   java -jar lib/sql.jar -helper-hosts store:5000 -store kvstore
 
   sql-> show tables
-  tables
-    SYS$IndexStatsLease
-    SYS$MRTableAgentStat
-    SYS$MRTableInfo
-    SYS$MRTableInitCheckpoint
-    SYS$PartitionStatsLease
-    SYS$SGAttributesTable
-    SYS$StreamRequest
-    SYS$StreamResponse
-    SYS$TableMetadata
-    SYS$TableStatsIndex
-    SYS$TableStatsPartition
-    SYS$TopologyHistory
+Tables in all namespaces:
+        SYS$IndexStatsLease -- 1
+        SYS$MRTableAgentStat -- 1
+        SYS$MRTableInfo -- 1
+        SYS$MRTableInitCheckpoint -- 1
+        SYS$PartitionStatsLease -- 1
+        SYS$SGAttributesTable -- 1
+        SYS$StreamRequest -- 1
+        SYS$StreamResponse -- 1
+        SYS$TableMetadata -- 1
+        SYS$TableStatsIndex -- 2
+        SYS$TableStatsPartition -- 3
+        SYS$TopologyHistory -- 1
 
   sql-> exit
 ```
@@ -176,7 +176,7 @@ be made via the Oracle NoSQL Database Proxy on the `KV_PROXY_PORT`.
 First, install the latest version of Oracle NoSQL on your remote host:
 
 ```shell
-KV_VERSION=24.3.9
+KV_VERSION=24.4.9
 rm -rf kv-$KV_VERSION
 DOWNLOAD_ROOT=http://download.oracle.com/otn-pub/otn_software/nosql-database
 DOWNLOAD_FILE="kv-ce-${KV_VERSION}.zip"
@@ -336,7 +336,7 @@ number used for the image tag:
 
 
 ```shell
-KV_VERSION=24.3.9 docker build --build-arg "$KV_VERSION" --tag "oracle/nosql-ce:$KV_VERSION" .
+KV_VERSION=24.4.9 docker build --build-arg "$KV_VERSION" --tag "oracle/nosql-ce:$KV_VERSION" .
 ```
 
 ## More information
@@ -359,9 +359,9 @@ Oracle provides no commercial support for the Oracle NoSQL Community Edition.
 
 ## Copyright
 
-Copyright (c) 2017, 2024 Oracle and/or its affiliates.
+Copyright (c) 2017, 2025 Oracle and/or its affiliates.
 
 [NOSQL]: http://www.oracle.com/technetwork/database/database-technologies/nosqldb/overview/index.html
 [DOCS]: https://docs.oracle.com/en/database/other-databases/nosql-database/index.html
-[Apache-2.0]: https://docs.oracle.com/en/database/other-databases/nosql-database/24.3/license/apache-license.html
+[Apache-2.0]: https://docs.oracle.com/en/database/other-databases/nosql-database/24.4/license/apache-license.html
 [GraalVM-License]: https://github.com/graalvm/container/blob/master/LICENSE.md

--- a/NoSQL/ce-sec/Dockerfile
+++ b/NoSQL/ce-sec/Dockerfile
@@ -1,11 +1,11 @@
-# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 #
-FROM ghcr.io/graalvm/jdk:ol9-java17
+FROM ghcr.io/graalvm/jdk-community:21
 
 LABEL org.opencontainers.image.source = "https://github.com/oracle/docker-images"
 
-ARG KV_VERSION=24.3.9
+ARG KV_VERSION=24.4.9
 ARG DOWNLOAD_ROOT=http://download.oracle.com/otn-pub/otn_software/nosql-database
 ARG DOWNLOAD_FILE="kv-ce-${KV_VERSION}.zip"
 ARG DOWNLOAD_LINK="${DOWNLOAD_ROOT}/${DOWNLOAD_FILE}"

--- a/NoSQL/ce/Dockerfile
+++ b/NoSQL/ce/Dockerfile
@@ -1,11 +1,11 @@
-# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 #
-FROM ghcr.io/graalvm/jdk:ol9-java17
+FROM ghcr.io/graalvm/jdk-community:21
 
 LABEL org.opencontainers.image.source = "https://github.com/oracle/docker-images"
 
-ARG KV_VERSION=24.3.9
+ARG KV_VERSION=24.4.9
 ARG DOWNLOAD_ROOT=http://download.oracle.com/otn-pub/otn_software/nosql-database
 ARG DOWNLOAD_FILE="kv-ce-${KV_VERSION}.zip"
 ARG DOWNLOAD_LINK="${DOWNLOAD_ROOT}/${DOWNLOAD_FILE}"


### PR DESCRIPTION
This PR updates the Oracle NoSQL Dockerfile to align with the latest version and bundles.

- Our last bundle for this version is `kv-ce-24.4.9`
- Using `ghcr.io/graalvm/jdk-community:21` instead of `ghcr.io/graalvm/jdk:ol9-java17`

Signed-off-by: Dario Vega [dario.vega@oracle.com](mailto:dario.vega@oracle.com)