### PR TITLE
Update OracleGoldenGate 23 readme with new supported platforms

### DIFF
--- a/OracleGoldenGate/23/README.md
+++ b/OracleGoldenGate/23/README.md
@@ -25,6 +25,9 @@ This project was tested with:
 
 - Oracle GoldenGate 23.4 Microservices for Oracle on Linux x86-64
 - Oracle GoldenGate 23.4 Microservices for PostgreSQL on Linux x86-64
+- Oracle GoldenGate 23.4 Microservices for MSSQL on Linux x86-64
+- Oracle GoldenGate 23.4 Microservices for MYSQL on Linux x86-64
+- Oracle GoldenGate 23.8 Microservices for Distributed Applications and Analytics on Linux x86-64
 
 **IMPORTANT:** You must download the installation binaries of Oracle GoldenGate. You only need to provide the binaries for the version you plan to install. The binaries can be downloaded from the [Oracle Technology Network](https://www.oracle.com/technetwork/middleware/goldengate/downloads/index.html). Do not decompress the Oracle GoldenGate ZIP file. The container build process will handle that
 for you. You also must have Internet connectivity when building the container image for the package manager to perform additional software installations.


### PR DESCRIPTION
As part of our internal testing and validation efforts, we have successfully certified the this repo for use with the following:

- Oracle GoldenGate 23.4 Microservices for MSSQL on Linux x86-64
- Oracle GoldenGate 23.4 Microservices for MYSQL on Linux x86-64
- Oracle GoldenGate 23.8 Microservices for Distributed Applications and Analytics on Linux x86-64

These have been tested in line with the existing validations already done for PostgreSQL and Oracle.