### PR TITLE
NOSQL - Update to version 24.4.9 with JDK17

### DIFF
--- a/NoSQL/ce-sec/Dockerfile
+++ b/NoSQL/ce-sec/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2022, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 #
-FROM ghcr.io/graalvm/jdk-community:21
+FROM ghcr.io/graalvm/jdk:ol9-java17
 
 LABEL org.opencontainers.image.source = "https://github.com/oracle/docker-images"
 

--- a/NoSQL/ce/Dockerfile
+++ b/NoSQL/ce/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2022, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 #
-FROM ghcr.io/graalvm/jdk-community:21
+FROM ghcr.io/graalvm/jdk:ol9-java17
 
 LABEL org.opencontainers.image.source = "https://github.com/oracle/docker-images"
 


### PR DESCRIPTION
This PR updates the Oracle NoSQL Dockerfile to use JDK 17 again. A customer using Mac M4 reported an issue.

- Our last bundle for this version is `kv-ce-24.4.9`
- Using `ghcr.io/graalvm/jdk:ol9-java17` instead of  `ghcr.io/graalvm/jdk-community:21` 

Signed-off-by: Dario Vega [dario.vega@oracle.com](mailto:dario.vega@oracle.com)