### PR TITLE
NOSQL - Update to version  25.1.13

### DIFF
--- a/NoSQL/README-sec.md
+++ b/NoSQL/README-sec.md
@@ -14,7 +14,7 @@ This container image uses a simplified version of the Oracle NoSQL Database call
 
 This container image configures an Oracle NoSQL Database secure configuration
 1. Create a KVlite secured configuration with the
-[password complexity policy](https://docs.oracle.com/en/database/other-databases/nosql-database/24.3/security/password-complexity-policies.html)
+[password complexity policy](https://docs.oracle.com/en/database/other-databases/nosql-database/25.1/security/password-complexity-policies.html)
 enabled
 2. Create the `root` user and the file `user.security` that contain property settings for the login as admin
 3. Generate the `certificate.pem` file allowing to establish a HTTP secure communication between the proxy and the driver
@@ -86,7 +86,7 @@ For example, to check the version of KVLite, use the `version` command:
 
 ```shell
 $ docker run --rm -ti --link kvlite:store oracle/nosql:ce-sec  java -Xmx64m -Xms64m -jar lib/kvstore.jar version
-24.4.9 2024-11-21 17:06:06 UTC  Build id: 95fa28ea4441 Edition: Community
+25.1.13 2025-06-06 17:17:06 UTC  Build id: f24717f901b5 Edition: Community
 ```
 
 To check the size of the storage shard:
@@ -113,13 +113,13 @@ $ docker run --rm -ti -v secfiles:/shared_conf:ro --link kvlite:store oracle/nos
 
 Pinging components of store kvstore based upon topology sequence #14
 10 partitions and 1 storage nodes
-Time: 2025-03-17 09:08:59 UTC   Version: 24.4.9
+Time: 2025-06-10 07:56:11 UTC   Version: 25.1.13
 Shard Status: healthy: 1 writable-degraded: 0 read-only: 0 offline: 0 total: 1
 Admin Status: healthy
 Zone [name=KVLite id=zn1 type=PRIMARY allowArbiters=false masterAffinity=false]   RN Status: online: 1 read-only: 0 offline: 0
-Storage Node [sn1] on kvlite: 5000    Zone: [name=KVLite id=zn1 type=PRIMARY allowArbiters=false masterAffinity=false]    Status: RUNNING   Ver: 24.4.9 2024-11-21 17:06:06 UTC  Build id: 95fa28ea4441 Edition: Community    isMasterBalanced: true     serviceStartTime: 2025-03-17 09:08:18 UTC
-        Admin [admin1]          Status: RUNNING,MASTER  serviceStartTime: 2025-03-17 09:08:22 UTC       stateChangeTime: 2025-03-17 09:08:22 UTC        availableStorageSize: 2 GB
-        Rep Node [rg1-rn1]      Status: RUNNING,MASTER sequenceNumber: 121 haPort: 5011 availableStorageSize: 9 GB storageType: HD      serviceStartTime: 2025-03-17 09:08:24 UTC       stateChangeTime: 2025-03-17 09:08:25 UTC
+Storage Node [sn1] on proxy-nosql: 5000    Zone: [name=KVLite id=zn1 type=PRIMARY allowArbiters=false masterAffinity=false]    Status: RUNNING   Ver: 25.1.13 2025-06-06 17:17:06 UTC  Build id: f24717f901b5 Edition: Community    isMasterBalanced: true       serviceStartTime: 2025-06-10 07:54:30 UTC
+        Admin [admin1]          Status: RUNNING,MASTER  serviceStartTime: 2025-06-10 07:54:35 UTC       stateChangeTime: 2025-06-10 07:54:34 UTC        availableStorageSize: 2 GB
+        Rep Node [rg1-rn1]      Status: RUNNING,MASTER sequenceNumber: 121 haPort: 5011 availableStorageSize: 9 GB storageType: HD      serviceStartTime: 2025-06-10 07:54:36 UTC       stateChangeTime: 2025-06-10 07:54:37 UTC
 
 
   kv-> put kv -key /SomeKey -value SomeValue
@@ -191,6 +191,8 @@ set environment variable NODE_EXTRA_CA_CERTS
 ````bash
 docker cp kvlite:/kvroot/proxy/certificate.pem /mylocalpath
 export NODE_EXTRA_CA_CERTS=/mylocalpath/certificate.pem
+docker cp kvlite:/kvroot/proxy/driver.trust /mylocalpath
+docker cp kvlite:/kvroot/proxy/pwdin /mylocalpath
 ````
 
 The certificate created is using the hostname of the container as a Subject. The endpoint must be the same hostname of the container.
@@ -205,8 +207,8 @@ $ openssl x509 -text -noout -in /mylocalpath/certificate.pem | grep CN
         Subject: CN=kvlite
 
 ````
-Note: the certicate can be customized in the script setup-http-proxy-sec.sh
-(e.g adding [SAN](https://docs.oracle.com/en/database/other-databases/nosql-database/24.3/security/ssl-using-openssl.html))
+Note: the certicate can be customized using the KV_ADDITIONAL_SAN variable
+(e.g adding [SAN](https://docs.oracle.com/en/database/other-databases/nosql-database/25.1/security/ssl-using-openssl.html)
 
 ## Advanced Scenario: connecting to Oracle NoSQL CE from another host
 
@@ -221,9 +223,9 @@ be made via the Oracle NoSQL Database Proxy on the `KV_PROXY_PORT`.
 First, install the latest version of Oracle NoSQL on your remote host:
 
 ```shell
-KV_VERSION=24.4.9
+KV_VERSION=25.1.13
 rm -rf kv-$KV_VERSION
-DOWNLOAD_ROOT=http://download.oracle.com/otn-pub/otn_software/nosql-database
+DOWNLOAD_ROOT="https://github.com/oracle/nosql/releases/download/v${KV_VERSION}/"
 DOWNLOAD_FILE="kv-ce-${KV_VERSION}.zip"
 DOWNLOAD_LINK="${DOWNLOAD_ROOT}/${DOWNLOAD_FILE}"
 curl -OLs $DOWNLOAD_LINK
@@ -404,7 +406,7 @@ number used for the image tag:
 
 
 ```shell
-KV_VERSION=24.3.9 docker build --build-arg "$KV_VERSION" --tag "oracle/nosql-ce-sec:$KV_VERSION" .
+KV_VERSION=25.1.13 docker build --build-arg "$KV_VERSION" --tag "oracle/nosql-ce-sec:$KV_VERSION" .
 ```
 
 ## More information
@@ -431,5 +433,5 @@ Copyright (c) 2017, 2025 Oracle and/or its affiliates.
 
 [NOSQL]: http://www.oracle.com/technetwork/database/database-technologies/nosqldb/overview/index.html
 [DOCS]: https://docs.oracle.com/en/database/other-databases/nosql-database/index.html
-[Apache-2.0]: https://docs.oracle.com/en/database/other-databases/nosql-database/24.4/license/apache-license.html
+[Apache-2.0]: https://github.com/oracle/nosql/blob/main/LICENSE.txt
 [GraalVM-License]: https://github.com/graalvm/container/blob/master/LICENSE.md

--- a/NoSQL/README.md
+++ b/NoSQL/README.md
@@ -73,7 +73,7 @@ For example, to check the version of KVLite, use the `version` command:
 
 ```shell
 $ docker run --rm -ti --link kvlite:store oracle/nosql:ce  java -Xmx64m -Xms64m -jar lib/kvstore.jar version
-24.4.9 2024-11-21 17:06:06 UTC  Build id: 95fa28ea4441 Edition: Community
+25.1.13 2025-06-06 17:17:06 UTC  Build id: f24717f901b5 Edition: Community
 ```
 
 To check the size of the storage shard:
@@ -98,13 +98,13 @@ $ docker run --rm -ti --link kvlite:store oracle/nosql:ce \
   
 Pinging components of store kvstore based upon topology sequence #14
 10 partitions and 1 storage nodes
-Time: 2025-03-17 09:05:10 UTC   Version: 24.4.9
+Time: 2025-06-10 07:38:08 UTC   Version: 25.1.13
 Shard Status: healthy: 1 writable-degraded: 0 read-only: 0 offline: 0 total: 1
 Admin Status: healthy
 Zone [name=KVLite id=zn1 type=PRIMARY allowArbiters=false masterAffinity=false]   RN Status: online: 1 read-only: 0 offline: 0
-Storage Node [sn1] on kvlite: 5000    Zone: [name=KVLite id=zn1 type=PRIMARY allowArbiters=false masterAffinity=false]    Status: RUNNING   Ver: 24.4.9 2024-11-21 17:06:06 UTC  Build id: 95fa28ea4441 Edition: Community    isMasterBalanced: true     serviceStartTime: 2025-03-17 09:04:40 UTC
-        Admin [admin1]          Status: RUNNING,MASTER  serviceStartTime: 2025-03-17 09:04:43 UTC       stateChangeTime: 2025-03-17 09:04:43 UTC        availableStorageSize: 2 GB
-        Rep Node [rg1-rn1]      Status: RUNNING,MASTER sequenceNumber: 86 haPort: 5011 availableStorageSize: 9 GB storageType: HD       serviceStartTime: 2025-03-17 09:04:44 UTC       stateChangeTime: 2025-03-17 09:04:45 UTC
+Storage Node [sn1] on proxy-nosql: 5000    Zone: [name=KVLite id=zn1 type=PRIMARY allowArbiters=false masterAffinity=false]    Status: RUNNING   Ver: 25.1.13 2025-06-06 17:17:06 UTC  Build id: f24717f901b5 Edition: Community    isMasterBalanced: true       serviceStartTime: 2025-06-10 07:15:32 UTC
+        Admin [admin1]          Status: RUNNING,MASTER  serviceStartTime: 2025-06-10 07:15:36 UTC       stateChangeTime: 2025-06-10 07:15:35 UTC        availableStorageSize: 2 GB
+        Rep Node [rg1-rn1]      Status: RUNNING,MASTER sequenceNumber: 84 haPort: 5011 availableStorageSize: 9 GB storageType: HD       serviceStartTime: 2025-06-10 07:15:37 UTC       stateChangeTime: 2025-06-10 07:15:37 UTC
   
   kv-> put kv -key /SomeKey -value SomeValue
   Operation successful, record inserted.
@@ -176,9 +176,9 @@ be made via the Oracle NoSQL Database Proxy on the `KV_PROXY_PORT`.
 First, install the latest version of Oracle NoSQL on your remote host:
 
 ```shell
-KV_VERSION=24.4.9
+KV_VERSION=25.1.13
 rm -rf kv-$KV_VERSION
-DOWNLOAD_ROOT=http://download.oracle.com/otn-pub/otn_software/nosql-database
+DOWNLOAD_ROOT="https://github.com/oracle/nosql/releases/download/v${KV_VERSION}/"
 DOWNLOAD_FILE="kv-ce-${KV_VERSION}.zip"
 DOWNLOAD_LINK="${DOWNLOAD_ROOT}/${DOWNLOAD_FILE}"
 curl -OLs $DOWNLOAD_LINK
@@ -336,7 +336,7 @@ number used for the image tag:
 
 
 ```shell
-KV_VERSION=24.4.9 docker build --build-arg "$KV_VERSION" --tag "oracle/nosql-ce:$KV_VERSION" .
+KV_VERSION=25.1.13 docker build --build-arg "$KV_VERSION" --tag "oracle/nosql-ce:$KV_VERSION" .
 ```
 
 ## More information
@@ -363,5 +363,5 @@ Copyright (c) 2017, 2025 Oracle and/or its affiliates.
 
 [NOSQL]: http://www.oracle.com/technetwork/database/database-technologies/nosqldb/overview/index.html
 [DOCS]: https://docs.oracle.com/en/database/other-databases/nosql-database/index.html
-[Apache-2.0]: https://docs.oracle.com/en/database/other-databases/nosql-database/24.4/license/apache-license.html
+[Apache-2.0]: https://github.com/oracle/nosql/blob/main/LICENSE.txt
 [GraalVM-License]: https://github.com/graalvm/container/blob/master/LICENSE.md

--- a/NoSQL/ce-sec/Dockerfile
+++ b/NoSQL/ce-sec/Dockerfile
@@ -5,8 +5,8 @@ FROM ghcr.io/graalvm/jdk-community:21
 
 LABEL org.opencontainers.image.source = "https://github.com/oracle/docker-images"
 
-ARG KV_VERSION=24.4.9
-ARG DOWNLOAD_ROOT=http://download.oracle.com/otn-pub/otn_software/nosql-database
+ARG KV_VERSION=25.1.13
+ARG DOWNLOAD_ROOT="https://github.com/oracle/nosql/releases/download/v${KV_VERSION}/"
 ARG DOWNLOAD_FILE="kv-ce-${KV_VERSION}.zip"
 ARG DOWNLOAD_LINK="${DOWNLOAD_ROOT}/${DOWNLOAD_FILE}"
 

--- a/NoSQL/ce/Dockerfile
+++ b/NoSQL/ce/Dockerfile
@@ -5,8 +5,8 @@ FROM ghcr.io/graalvm/jdk-community:21
 
 LABEL org.opencontainers.image.source = "https://github.com/oracle/docker-images"
 
-ARG KV_VERSION=24.4.9
-ARG DOWNLOAD_ROOT=http://download.oracle.com/otn-pub/otn_software/nosql-database
+ARG KV_VERSION=25.1.13
+ARG DOWNLOAD_ROOT="https://github.com/oracle/nosql/releases/download/v${KV_VERSION}/"
 ARG DOWNLOAD_FILE="kv-ce-${KV_VERSION}.zip"
 ARG DOWNLOAD_LINK="${DOWNLOAD_ROOT}/${DOWNLOAD_FILE}"
 


### PR DESCRIPTION
This PR updates the Oracle NoSQL version

- Our last bundle for this version is `kv-ce-25.1.13` 
- Using https://github.com/oracle/nosql instead of OTN
- Using  `ghcr.io/graalvm/jdk-community:21` 

Signed-off-by: Dario Vega [dario.vega@oracle.com](mailto:dario.vega@oracle.com)