### PR TITLE
Removed the need to pass the OCI region as an argument to the dockerfiles

### DIFF
--- a/OracleJava/11/Dockerfile.ol8
+++ b/OracleJava/11/Dockerfile.ol8
@@ -8,28 +8,27 @@
 #
 # ARGS
 # ----
-# This docker file requires two arguments:
-# 1) JDK11_TOKEN is a valid dowload token for JDK 11.  It can be created in cloud.oracle.com/jms under Java Download
+# This docker file requires one argument:
+# JDK11_TOKEN is a valid dowload token for JDK 11.  It can be created in cloud.oracle.com/jms under Java Download
 # Token generation is documented on https://docs.cloud.oracle.com/en-us/iaas/jms/doc/java-download.html
-# 2) OCI_REGION is the Oracle Cloud Infrastucture (OCI) region where the token is generated.
 #
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
 # This dockerfile will download a copy of latest version of JDK 11 from
-#	https://javamanagementservice-download.<OCI_REGION>.oci.oraclecloud.com/java/11/latest/
+#	https://java.oraclecloud.com/java/11/latest/
 #
 # It will use either x64 or aarch64 depending on the target platform
 #
 # HOW TO BUILD THIS IMAGE
 # -----------------------
 # Run:
-#      $ docker build --file Dockerfile.ol8 --tag oracle/jdk:11 --build-arg JDK11_TOKEN=<token> --build-arg OCI_REGION=<region> .
+#      $ docker build --file Dockerfile.ol8 --tag oracle/jdk:11 --build-arg JDK11_TOKEN=<token> .
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
 FROM oraclelinux:8 as builder
 ARG JDK11_TOKEN
-ARG OCI_REGION
+
 
 LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
@@ -43,7 +42,7 @@ ENV LANG en_US.UTF-8
 # Environment variables for the builder image.
 # Required to validate that you are using the correct file
 
-ENV JAVA_URL=https://javamanagementservice-download."${OCI_REGION}".oci.oraclecloud.com/java/11/latest/ \
+ENV JAVA_URL=https://java.oraclecloud.com/java/11/latest/ \
     JAVA_HOME=/usr/java/jdk-11
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/OracleJava/17/Dockerfile.ol8
+++ b/OracleJava/17/Dockerfile.ol8
@@ -8,28 +8,26 @@
 #
 # ARGS
 # ----
-# This docker file requires two arguments:
-# 1) JDK17_TOKEN is a valid dowload token for JDK 17.  It can be created in cloud.oracle.com/jms under Java Download
+# This docker file requires one argument:
+# JDK17_TOKEN is a valid dowload token for JDK 17.  It can be created in cloud.oracle.com/jms under Java Download
 # Token generation is documented on https://docs.cloud.oracle.com/en-us/iaas/jms/doc/java-download.html
-# 2) OCI_REGION is the Oracle Cloud Infrastucture (OCI) region where the token is generated.
 #
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
 # This dockerfile will download a copy of latest version of JDK 17 from
-#	https://javamanagementservice-download.<OCI_REGION>.oci.oraclecloud.com/java/17/latest/
+#	https://java.oraclecloud.com/java/17/latest/
 #
 # It will use either x64 or aarch64 depending on the target platform
 #
 # HOW TO BUILD THIS IMAGE
 # -----------------------
 # Run:
-#      $ docker build --file Dockerfile.ol8 --tag oracle/jdk:17 --build-arg JDK17_TOKEN=<token> --build-arg OCI_REGION=<region> .
+#      $ docker build --file Dockerfile.ol8 --tag oracle/jdk:17 --build-arg JDK17_TOKEN=<token> .
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
 FROM oraclelinux:8 as builder
 ARG JDK17_TOKEN
-ARG OCI_REGION
 
 LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
@@ -43,7 +41,7 @@ ENV LANG en_US.UTF-8
 # Environment variables for the builder image.
 # Required to validate that you are using the correct file
 
-ENV JAVA_URL=https://javamanagementservice-download."${OCI_REGION}".oci.oraclecloud.com/java/17/latest/ \
+ENV JAVA_URL=https://java.oraclecloud.com/java/17/latest/ \
     JAVA_HOME=/usr/java/jdk-17
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/OracleJava/8/jdk/Dockerfile.ol8
+++ b/OracleJava/8/jdk/Dockerfile.ol8
@@ -8,28 +8,26 @@
 #
 # ARGS
 # ----
-# This docker file requires two arguments:
-# 1) JDK8_TOKEN is a valid dowload token for JDK 8.  It can be created in cloud.oracle.com/jms under Java Download
+# This docker file requires one argument:
+# JDK8_TOKEN is a valid dowload token for JDK 8.  It can be created in cloud.oracle.com/jms under Java Download
 # Token generation is documented on https://docs.cloud.oracle.com/en-us/iaas/jms/doc/java-download.html
-# 2) OCI_REGION is the Oracle Cloud Infrastucture (OCI) region where the token is generated.
 #
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
 # This dockerfile will download a copy of latest version of JDK 8 from
-#	https://javamanagementservice-download.<OCI_REGION>.oci.oraclecloud.com/java/8/latest/
+#	https://java.oraclecloud.com/java/8/latest/
 #
 # It will use either x64 or aarch64 depending on the target platform
 #
 # HOW TO BUILD THIS IMAGE
 # -----------------------
 # Run:
-#      $ docker build --file Dockerfile.ol8 --tag oracle/jdk:8 --build-arg JDK8_TOKEN=<token> --build-arg OCI_REGION=<region> .
+#      $ docker build --file Dockerfile.ol8 --tag oracle/jdk:8 --build-arg JDK8_TOKEN=<token> .
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
 FROM oraclelinux:8 as builder
 ARG JDK8_TOKEN
-ARG OCI_REGION
 
 LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
@@ -42,7 +40,7 @@ ENV LANG en_US.UTF-8
 # Environment variables for the builder image.
 # Required to validate that you are using the correct file
 
-ENV JAVA_URL=https://javamanagementservice-download."${OCI_REGION}".oci.oraclecloud.com/java/8/latest/ \
+ENV JAVA_URL=https://java.oraclecloud.com/java/8/latest/ \
     JAVA_HOME=/usr/java/jdk-8
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/OracleJava/8/serverjre/Dockerfile.ol8
+++ b/OracleJava/8/serverjre/Dockerfile.ol8
@@ -8,26 +8,24 @@
 #
 # ARGS
 # ----
-# This docker file requires two arguments:
-# 1) JDK8_TOKEN is a valid dowload token for Server JRE 8 (Create the token for JDK 8).  It can be created in cloud.oracle.com/jms under Java Download
+# This docker file requires one arguments:
+# JDK8_TOKEN is a valid dowload token for Server JRE 8 (Create the token for JDK 8).  It can be created in cloud.oracle.com/jms under Java Download
 # Token generation is documented on https://docs.cloud.oracle.com/en-us/iaas/jms/doc/java-download.html
-# 2) OCI_REGION is the Oracle Cloud Infrastucture (OCI) region where the token is generated.
 #
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
 # This dockerfile will download a copy of latest version of JDK 8 from
-#	https://javamanagementservice-download.<OCI_REGION>.oci.oraclecloud.com/java/8/latest/
+#	https://java.oraclecloud.com/java/8/latest/
 #
 # HOW TO BUILD THIS IMAGE
 # -----------------------
 # Run:
-#      $ docker build --file Dockerfile.ol8 --tag oracle/serverjre:8 --build-arg JDK8_TOKEN=<token> --build-arg OCI_REGION=<region> .
+#      $ docker build --file Dockerfile.ol8 --tag oracle/serverjre:8 --build-arg JDK8_TOKEN=<token> .
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
 FROM oraclelinux:8 as builder
 ARG JDK8_TOKEN
-ARG OCI_REGION
 
 LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
@@ -40,7 +38,7 @@ ENV LANG en_US.UTF-8
 # Environment variables for the builder image.
 # Required to validate that you are using the correct file
 
-ENV JAVA_URL=https://javamanagementservice-download."${OCI_REGION}".oci.oraclecloud.com/java/8/latest/ \
+ENV JAVA_URL=https://java.oraclecloud.com/java/8/latest/ \
     JAVA_HOME=/usr/java/jdk-8
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/OracleJava/README.md
+++ b/OracleJava/README.md
@@ -15,20 +15,20 @@ cd ../OracleJava/24
 docker build --file Dockerfile.ol9 --tag oracle/jdk:24 .
 ```
 
-Updates to prior LTS releases: JDK 17, JDK 11, JDK 8, and Server JRE 8 are offered under the [Oracle Technology Network License Agreement for Oracle Java SE](https://www.java.com/otnlicense). Users must accept the license terms, generate a download token, and provide it, as well as the OCI region for the token, as build arguments.  Token generation is documented on [https://docs.cloud.oracle.com/en-us/iaas/jms/doc/java-download.html](https://docs.cloud.oracle.com/en-us/iaas/jms/doc/java-download.html).
+Updates to prior LTS releases: JDK 17, JDK 11, JDK 8, and Server JRE 8 are offered under the [Oracle Technology Network License Agreement for Oracle Java SE](https://www.java.com/otnlicense). Users must accept the license terms, generate a download token, and provide it as a build argument.  Token generation is documented on [https://docs.cloud.oracle.com/en-us/iaas/jms/doc/java-download.html](https://docs.cloud.oracle.com/en-us/iaas/jms/doc/java-download.html).
 
 e.g., To build the JDK 17 container image generate a token for JDK 17 and run:
 
 ```bash
 cd ../OracleJava/17
-docker build --file Dockerfile.ol8 --tag oracle/jdk:17 --build-arg JDK17_TOKEN=<$token> --build-arg OCI_REGION=<$region> .
+docker build --file Dockerfile.ol8 --tag oracle/jdk:17 --build-arg JDK17_TOKEN=<$token> .
 ```
 
 e.g., To build the Server JRE 8 container image generate a token for JDK 8 and run:
 
 ```bash
 cd ../OracleJava/8/serverjre
-docker build --file Dockerfile.ol8 --tag oracle/serverjre:8 --build-arg JDK8_TOKEN=<$token> --build-arg OCI_REGION=<$region> .
+docker build --file Dockerfile.ol8 --tag oracle/serverjre:8 --build-arg JDK8_TOKEN=<$token> .
 ```
 
 For the NFTC releases (JDK 24 and 21) the right command is already scripted in `build.sh` so you can alternatively run:


### PR DESCRIPTION
Java Management Service (JMS) has been updated to no longer require users to specify OCI_REGION when downloading releases.   Simplified the dockerfiles by removing that argument