### PR TITLE
Make golang 1.24 just the same as latest to avoid CVEs

### DIFF
--- a/OracleLinuxDevelopers/oraclelinux10/golang/1.24/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux10/golang/1.24/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM ghcr.io/oracle/oraclelinux:10
 
-RUN dnf -y install go-toolset-1.24.6 && \
+RUN dnf -y install go-toolset && \
     rm -rf /var/cache/dnf
 
 CMD ["/bin/go", "version"]

--- a/OracleLinuxDevelopers/oraclelinux8/golang/1.24/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux8/golang/1.24/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM ghcr.io/oracle/oraclelinux:8
 
-RUN dnf -y install go-toolset-1.24.4 && \
+RUN dnf -y install go-toolset && \
     rm -rf /var/cache/dnf
 
 CMD ["/bin/go", "version"]

--- a/OracleLinuxDevelopers/oraclelinux9/golang/1.24/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux9/golang/1.24/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM ghcr.io/oracle/oraclelinux:9
 
-RUN dnf -y install go-toolset-1.24.4 && \
+RUN dnf -y install go-toolset && \
     rm -rf /var/cache/dnf
 
 CMD ["/bin/go", "version"]


### PR DESCRIPTION
Means that golang 1.24 is now 1.25 etc, but after discussions with some peeps this is probably best as we really don't want people uptaking insecure versions of golang under any circumstances.