### PR TITLE
updated OpenJDK from 25.0.1 to 25.0.2, updated dockerfile 

### DIFF
--- a/OracleJava/11/Dockerfile.ol8
+++ b/OracleJava/11/Dockerfile.ol8
@@ -26,7 +26,7 @@
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
-FROM oraclelinux:8 as builder
+FROM oraclelinux:8 AS builder
 ARG JDK11_TOKEN
 
 
@@ -37,7 +37,7 @@ LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 RUN dnf install -y tar
 
 # Default to UTF-8 file.encoding
-ENV LANG en_US.UTF-8
+ENV LANG=en_US.UTF-8
 
 # Environment variables for the builder image.
 # Required to validate that you are using the correct file
@@ -63,9 +63,9 @@ RUN set -eux; \
 FROM oraclelinux:8
 
 # Default to UTF-8 file.encoding
-ENV LANG en_US.UTF-8
+ENV LANG=en_US.UTF-8
 ENV JAVA_HOME=/usr/java/jdk-11
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Copy the uncompressed Java Runtime from the builder image
 COPY --from=builder $JAVA_HOME $JAVA_HOME

--- a/OracleJava/17/Dockerfile.ol8
+++ b/OracleJava/17/Dockerfile.ol8
@@ -26,7 +26,7 @@
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
-FROM oraclelinux:8 as builder
+FROM oraclelinux:8 AS builder
 ARG JDK17_TOKEN
 
 LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
@@ -36,7 +36,7 @@ LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 RUN dnf install -y tar
 
 # Default to UTF-8 file.encoding
-ENV LANG en_US.UTF-8
+ENV LANG=en_US.UTF-8
 
 # Environment variables for the builder image.
 # Required to validate that you are using the correct file
@@ -62,9 +62,9 @@ RUN set -eux; \
 FROM oraclelinux:8
 
 # Default to UTF-8 file.encoding
-ENV LANG en_US.UTF-8
+ENV LANG=en_US.UTF-8
 ENV JAVA_HOME=/usr/java/jdk-17
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # If you need the Java Version you can read it from the release file with
 # JAVA_VERSION=$(sed -n '/^JAVA_VERSION="/{s///;s/"//;p;}' "$JAVA_HOME"/release);

--- a/OracleJava/21/Dockerfile.ol8
+++ b/OracleJava/21/Dockerfile.ol8
@@ -23,7 +23,7 @@
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
-FROM oraclelinux:8 as builder
+FROM oraclelinux:8 AS builder
 
 LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
@@ -32,7 +32,7 @@ RUN set -eux; \
     dnf install -y tar;
 
 # Default to UTF-8 file.encoding
-ENV LANG en_US.UTF-8
+ENV LANG=en_US.UTF-8
 
 # Environment variables for the builder image.
 # Required to validate that you are using the correct file
@@ -59,9 +59,9 @@ RUN set -eux; \
 FROM oraclelinux:8
 
 # Default to UTF-8 file.encoding
-ENV LANG en_US.UTF-8
+ENV LANG=en_US.UTF-8
 ENV JAVA_HOME=/usr/java/jdk-21
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # If you need the Java Version you can read it from the release file with
 # JAVA_VERSION=$(sed -n '/^JAVA_VERSION="/{s///;s/"//;p;}' "$JAVA_HOME"/release);

--- a/OracleJava/21/Dockerfile.ol9
+++ b/OracleJava/21/Dockerfile.ol9
@@ -23,7 +23,7 @@
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
-FROM oraclelinux:9 as builder
+FROM oraclelinux:9 AS builder
 
 LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
@@ -32,7 +32,7 @@ RUN set -eux; \
     dnf install -y tar;
 
 # Default to UTF-8 file.encoding
-ENV LANG en_US.UTF-8
+ENV LANG=en_US.UTF-8
 
 # Environment variables for the builder image.
 # Required to validate that you are using the correct file
@@ -59,9 +59,9 @@ RUN set -eux; \
 FROM oraclelinux:9
 
 # Default to UTF-8 file.encoding
-ENV LANG en_US.UTF-8
+ENV LANG=en_US.UTF-8
 ENV JAVA_HOME=/usr/java/jdk-21
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # If you need the Java Version you can read it from the release file with
 # JAVA_VERSION=$(sed -n '/^JAVA_VERSION="/{s///;s/"//;p;}' "$JAVA_HOME"/release);

--- a/OracleJava/25/Dockerfile.ol9
+++ b/OracleJava/25/Dockerfile.ol9
@@ -23,7 +23,7 @@
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
-FROM oraclelinux:9 as builder
+FROM oraclelinux:9 AS builder
 
 LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
@@ -32,7 +32,7 @@ RUN set -eux; \
     dnf install -y tar;
 
 # Default to UTF-8 file.encoding
-ENV LANG en_US.UTF-8
+ENV LANG=en_US.UTF-8
 
 # Environment variables for the builder image.
 # Required to validate that you are using the correct file
@@ -59,9 +59,9 @@ RUN set -eux; \
 FROM oraclelinux:9
 
 # Default to UTF-8 file.encoding
-ENV LANG en_US.UTF-8
+ENV LANG=en_US.UTF-8
 ENV JAVA_HOME=/usr/java/jdk-25
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # If you need the Java Version you can read it from the release file with
 # JAVA_VERSION=$(sed -n '/^JAVA_VERSION="/{s///;s/"//;p;}' "$JAVA_HOME"/release);

--- a/OracleJava/8/jdk/Dockerfile.ol8
+++ b/OracleJava/8/jdk/Dockerfile.ol8
@@ -26,7 +26,7 @@
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
-FROM oraclelinux:8 as builder
+FROM oraclelinux:8 AS builder
 ARG JDK8_TOKEN
 
 LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
@@ -35,7 +35,7 @@ LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 RUN dnf install -y tar
 
 # Default to UTF-8 file.encoding
-ENV LANG en_US.UTF-8
+ENV LANG=en_US.UTF-8
 
 # Environment variables for the builder image.
 # Required to validate that you are using the correct file
@@ -63,9 +63,9 @@ RUN set -eux; \
 FROM oraclelinux:8
 
 # Default to UTF-8 file.encoding
-ENV LANG en_US.UTF-8
+ENV LANG=en_US.UTF-8
 ENV JAVA_HOME=/usr/java/jdk-8
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Copy the uncompressed Java Runtime from the builder image
 COPY --from=builder $JAVA_HOME $JAVA_HOME

--- a/OracleJava/8/serverjre/Dockerfile.ol8
+++ b/OracleJava/8/serverjre/Dockerfile.ol8
@@ -24,7 +24,7 @@
 #
 # The builder image will be used to uncompress the tar.gz file with the Java Runtime.
 
-FROM oraclelinux:8 as builder
+FROM oraclelinux:8 AS builder
 ARG JDK8_TOKEN
 
 LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
@@ -33,7 +33,7 @@ LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 RUN dnf install -y tar
 
 # Default to UTF-8 file.encoding
-ENV LANG en_US.UTF-8
+ENV LANG=en_US.UTF-8
 
 # Environment variables for the builder image.
 # Required to validate that you are using the correct file
@@ -55,9 +55,9 @@ RUN set -eux; \
 FROM oraclelinux:8
 
 # Default to UTF-8 file.encoding
-ENV LANG en_US.UTF-8
+ENV LANG=en_US.UTF-8
 ENV JAVA_HOME=/usr/java/jdk-8
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Copy the uncompressed Java Runtime from the builder image
 COPY --from=builder $JAVA_HOME $JAVA_HOME

--- a/OracleOpenJDK/25/Dockerfile.ol9
+++ b/OracleOpenJDK/25/Dockerfile.ol9
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
@@ -25,14 +25,14 @@ FROM oraclelinux:9
 
 LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
-ENV JAVA_URL=https://download.java.net/java/GA/jdk25.0.1/2fbf10d8c78e40bd87641c434705079d/8/GPL \
+ENV JAVA_URL=https://download.java.net/java/GA/jdk25.0.2/b1e0dfa218384cb9959bdcb897162d4e/10/GPL \
 	JAVA_HOME=/usr/java/jdk-25 \
 	LANG=en_US.UTF-8
 
 # If you need the Java Version you can read it from the release file with
 #JAVA_VERSION=$(sed -n '/^JAVA_VERSION="/{s///;s/"//;p;}' "$JAVA_HOME"/release);
 
-ENV	PATH $JAVA_HOME/bin:$PATH
+ENV	PATH=$JAVA_HOME/bin:$PATH
 
 # Since the files are compressed as tar.gz first dnf install tar. gzip is already in oraclelinux:9
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -49,7 +49,7 @@ RUN set -eux; \
     if [ "$ARCH" = "x86_64" ]; \
         then ARCH="x64"; \
     fi && \
-    JAVA_PKG="$JAVA_URL"/openjdk-25.0.1_linux-"${ARCH}"_bin.tar.gz ; \
+    JAVA_PKG="$JAVA_URL"/openjdk-25.0.2_linux-"${ARCH}"_bin.tar.gz ; \
 	JAVA_SHA256="$(curl "$JAVA_PKG".sha256)" ; \
 	curl --output /tmp/jdk.tgz "$JAVA_PKG" && \
 	echo "$JAVA_SHA256" */tmp/jdk.tgz | sha256sum -c -; \


### PR DESCRIPTION
Dockerfiles now use recommended format for ENV and matching case in "FOR" and "AS" statements.