### PR TITLE
Updated OpenJDK version to 26.0.2

### DIFF
--- a/OracleOpenJDK/26/Dockerfile.ol9
+++ b/OracleOpenJDK/26/Dockerfile.ol9
@@ -25,7 +25,7 @@ FROM oraclelinux:9
 
 LABEL maintainer="Aurelio Garcia-Ribeyro <aurelio.garciaribeyro@oracle.com>"
 
-ENV JAVA_URL=https://download.java.net/java/GA/jdk26/c3cc523845074aa0af4f5e1e1ed4151d/35/GPL \
+ENV JAVA_URL=https://download.java.net/java/GA/jdk26.0.2/818d462d89b645c7a1aad49066c454e5/10/GPL \
 	JAVA_HOME=/usr/java/jdk-26 \
 	LANG=en_US.UTF-8
 
@@ -49,7 +49,7 @@ RUN set -eux; \
     if [ "$ARCH" = "x86_64" ]; \
         then ARCH="x64"; \
     fi && \
-    JAVA_PKG="$JAVA_URL"/openjdk-26_linux-"${ARCH}"_bin.tar.gz ; \
+    JAVA_PKG="$JAVA_URL"/openjdk-26.0.2_linux-"${ARCH}"_bin.tar.gz ; \
 	JAVA_SHA256="$(curl "$JAVA_PKG".sha256)" ; \
 	curl --output /tmp/jdk.tgz "$JAVA_PKG" && \
 	echo "$JAVA_SHA256" */tmp/jdk.tgz | sha256sum -c -; \


### PR DESCRIPTION
 per the July 2026 Critical Patch Update