### PR TITLE
feat(oraclelinux10/nodejs): add NodeJS-24 compatibility symlinks

### DIFF
--- a/OracleLinuxDevelopers/oraclelinux10/nodejs/24/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux10/nodejs/24/Dockerfile
@@ -4,6 +4,9 @@
 FROM ghcr.io/oracle/oraclelinux:10
 
 RUN dnf -y install nodejs24 nodejs24-npm && \
+    ln -s /usr/bin/node-24 /usr/local/bin/node && \
+    ln -s /usr/bin/npm-24 /usr/local/bin/npm && \
+    ln -s /usr/bin/npx-24 /usr/local/bin/npx && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 


### PR DESCRIPTION
Adding symbolic links to the container image to make npm/npx/node commands compatible.

- Package nodejs24 do not own /usr/bin/node
    - https://yum.oracle.com/repowatch/oraclelinux10.x86_64/ol10_appstream/d492534757ac5f13b04d930d213f7cd072a57dbd?display=filelist
- Package nodejs24-npm do not own /usr/bin/npm and /usr/bin/npx
    - https://yum.oracle.com/repowatch/oraclelinux10.x86_64/ol10_appstream/b09766cd5ad496c2f606227c2be9c4b9452f5c2e?display=filelist

Closes https://github.com/oracle/docker-images/issues/3099