### PR TITLE
SingleInstance 23.26.1: fix standby/clone database creation (DBT-05514, DBT-16141)

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/23.26.1/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/23.26.1/createDB.sh
@@ -226,16 +226,24 @@ if [[ "${CLONE_DB}" == "true" ]] || [[ "${STANDBY_DB}" == "true" ]] || [[ "${TRU
   PRIMARY_DB_NAME=$(echo "${PRIMARY_DB_CONN_STR}" | cut -d '/' -f 2)
 
   # Creating the database using the dbca command
+  # dbca -createDuplicateDB prompts on stdin for the remote (primary) SYS password and then for
+  # the new database's SYS password: it does not take them from the -responseFile sysPassword
+  # entry nor from a -useWalletForDBCredentials wallet. Feed both on stdin, same pattern as the
+  # TrueCache instance creation below.
   if [ "${STANDBY_DB}" = "true" ]; then
       # Creating standby database
-      dbca -silent -createDuplicateDB -gdbName "$PRIMARY_DB_NAME" -primaryDBConnectionString "$PRIMARY_DB_CONN_STR" ${DBCA_CRED_OPTIONS} -sid "$ORACLE_SID" -createAsStandby -datafileDestination $ORACLE_BASE/oradata -useOMF true -dbUniquename "$ORACLE_SID" ORACLE_HOSTNAME="$ORACLE_HOSTNAME" ||
-      cat /opt/oracle/cfgtoollogs/dbca/"$ORACLE_SID"/"$ORACLE_SID".log ||
-      cat /opt/oracle/cfgtoollogs/dbca/"$ORACLE_SID".log
-  elif [ "${CLONE_DB}" = "true" ]; then 
+      dbca -silent -createDuplicateDB -createListener LISTENER:1521 -gdbName "$PRIMARY_DB_NAME" -primaryDBConnectionString "$PRIMARY_DB_CONN_STR" ${DBCA_CRED_OPTIONS} -sid "$ORACLE_SID" -createAsStandby -datafileDestination $ORACLE_BASE/oradata -useOMF true -dbUniquename "$ORACLE_SID" ORACLE_HOSTNAME="$ORACLE_HOSTNAME" <<EOF
+${ORACLE_PWD}
+${ORACLE_PWD}
+EOF
+      [ $? -eq 0 ] || cat /opt/oracle/cfgtoollogs/dbca/"$ORACLE_SID"/"$ORACLE_SID".log || cat /opt/oracle/cfgtoollogs/dbca/"$ORACLE_SID".log
+  elif [ "${CLONE_DB}" = "true" ]; then
              # Creating clone database or Duplicate database (No -createAsStandby) after duplicating a primary database; CLONE_DB is set to true here
-            dbca -silent -createDuplicateDB -gdbName "$ORACLE_SID" -primaryDBConnectionString "$PRIMARY_DB_CONN_STR" ${DBCA_CRED_OPTIONS} -sid "$ORACLE_SID" -databaseConfigType SINGLE -datafileDestination $ORACLE_BASE/oradata -useOMF true -dbUniquename "$ORACLE_SID" ORACLE_HOSTNAME="$ORACLE_HOSTNAME" ||
-            cat /opt/oracle/cfgtoollogs/dbca/"$ORACLE_SID"/"$ORACLE_SID".log ||
-            cat /opt/oracle/cfgtoollogs/dbca/"$ORACLE_SID".log
+            dbca -silent -createDuplicateDB -createListener LISTENER:1521 -gdbName "$ORACLE_SID" -primaryDBConnectionString "$PRIMARY_DB_CONN_STR" ${DBCA_CRED_OPTIONS} -sid "$ORACLE_SID" -databaseConfigType SINGLE -datafileDestination $ORACLE_BASE/oradata -useOMF true -dbUniquename "$ORACLE_SID" ORACLE_HOSTNAME="$ORACLE_HOSTNAME" <<EOF
+${ORACLE_PWD}
+${ORACLE_PWD}
+EOF
+            [ $? -eq 0 ] || cat /opt/oracle/cfgtoollogs/dbca/"$ORACLE_SID"/"$ORACLE_SID".log || cat /opt/oracle/cfgtoollogs/dbca/"$ORACLE_SID".log
   elif  [ "$TRUE_CACHE" = "true" ]; then
       if [ -n "$TRUE_CACHE_BLOB" ]; then
           SOURCE_DB_BASED_ARGS="-trueCacheBlobFromSourceDB $TRUE_CACHE_BLOB";     


### PR DESCRIPTION
Fixes #3109.

### Problem

The standby/clone path of `OracleDatabase/SingleInstance/dockerfiles/23.26.1/createDB.sh` cannot succeed with the 23.26 `dbca`, for two stacked reasons:

1. `dbca -createDuplicateDB` prompts on **stdin** for the remote (primary) SYS password and then for the new database's SYS password. It ignores the `sysPassword=` entry in the `-responseFile` the script generates, and it ignores `-useWalletForDBCredentials` for the remote credential. Since the script feeds nothing on stdin, dbca reads EOF three times and aborts with `DBT-05514` within seconds.
2. With credentials fixed, dbca then fails with `DBT-16141`: it requires listener information, which the standby/clone invocations do not pass (unlike the `-createDatabase` path in the same script, which passes `-createListener LISTENER:1521`).

Full analysis and reproduction (plain docker, public `database/free` image) in #3109.

### Fix

Minimal and consistent with patterns already in the file:

- Feed both passwords to dbca via a heredoc — the same pattern the TrueCache path already uses (`<<EOF ${ORACLE_PWD} ... EOF`), converting the `|| cat` chain to the `[ $? -eq 0 ] || cat ... || cat ...` form used there.
- Add `-createListener LISTENER:1521` to the two `-createDuplicateDB` invocations — the same listener the `-createDatabase` path creates.

### Verification

Executed end-to-end with `container-registry.oracle.com/database/enterprise:23.26.1.0` in plain docker:

- Primary created with `ENABLE_ARCHIVELOG=true` / `ENABLE_FORCE_LOGGING=true`; remote SYSDBA over the network verified with sqlplus.
- Standby container running this patched `createDB.sh` (`STANDBY_DB=true`, `PRIMARY_DB_CONN_STR=<primary>:1521/ORCL`, `ORACLE_SID=ORCLSB`): dbca duplicated the primary and the instance came up as **`PHYSICAL STANDBY` / `READ ONLY`**, ending with `DATABASE IS READY TO USE!`.
- The same setup with the unpatched script fails within seconds with `DBT-05514`.

Note: OCA signature is in progress (evaluating individual vs. company agreement) — the OCA bot flag is expected for now.
